### PR TITLE
dev → main (11 commits)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -183,6 +183,9 @@ export function createCli(options: CliOptions): Cli {
                     }
                     console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
+                } else {
+                    console.error('Setup cancelled.');
+                    process.exit(2);
                 }
                 resolved = resolveAuth(cliName, configOpts);
             }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -6,20 +6,21 @@ import type {
     DispatcherHandler,
     CommandDispatcher,
 } from './types';
-import type { AuthSession } from './auth/types';
-import { resolveAuth, saveEnvironment, switchEnvironment, listEnvironments, getActiveEnvConfig, loadConfig, verifyCredentials } from './config';
+import { resolveAuth, verifyCredentials, saveEnvironment } from './config';
 import { SessionManager } from './session';
 import { formatOutput, type OutputMode } from './output';
 import { formatDryRun, formatCurl, type CapturedRequest } from './output-request';
-import { prompt, hiddenPrompt } from './prompt';
-import { fetchAndGenerate } from './codegen/index';
-import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from './routine/loader';
-import { executeRoutine } from './routine/executor';
 import { buildDispatcher } from './routine/dispatcher';
-import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { resolve, join } from 'path';
 import { registerPluginCommand } from './plugin/register';
+import { registerSetupCommand, setupAction } from './commands/setup/setup';
+import { registerConfigCommand } from './commands/config/register';
+import { registerGenerateCommand } from './commands/generate/generate';
+import { registerUpgradeCommand } from './commands/upgrade/upgrade';
+import { registerMcpCommand } from './commands/mcp/mcp';
+import { registerRoutineCommand, loadBuiltinRoutines } from './commands/routine/register';
+import { prompt, hiddenPrompt } from './prompt';
 
 export interface Cli {
     command(name: string, registrar: CommandRegistrar): void;
@@ -119,308 +120,23 @@ export function createCli(options: CliOptions): Cli {
             program.option('--dry-run', 'Preview the API request without executing');
 
             // 3. Register built-in commands
-
-            // setup / login
-            const setupAction = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
-                await interactiveSetup(cliName, {
-                    allowInsecureStorage: cmdOpts.allowInsecureStorage,
-                    allowedCidrs: options.allowedCidrs,
-                    configPath: options.configPath,
-                });
-            };
-            program
-                .command('setup')
-                .description('Interactive setup — configure URL and credentials')
-                .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
-                .action(setupAction);
-            program
-                .command('login')
-                .description('Alias for setup')
-                .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
-                .action(setupAction);
-
-            // config
-            const config = program
-                .command('config')
-                .description('Manage environment configurations');
-
-            config
-                .command('list')
-                .description('List all configured environments')
-                .action(async () => {
-                    const envs = await listEnvironments(cliName, configOpts);
-                    if (envs.length === 0) {
-                        console.log(
-                            `No environments configured. Run '${cliName} setup' to add one.`,
-                        );
-                        return;
-                    }
-                    for (const env of envs) {
-                        const marker = env.active ? '* ' : '  ';
-                        console.log(`${marker}${env.name}\t${env.url}\t${env.user}`);
-                    }
-                });
-
-            config
-                .command('switch <name>')
-                .description('Switch active environment')
-                .action(async (name: string) => {
-                    const ok = await switchEnvironment(cliName, name, configOpts);
-                    if (!ok) {
-                        const envs = await listEnvironments(cliName, configOpts);
-                        console.error(
-                            `Environment '${name}' not found. Available: ${envs.map(e => e.name).join(', ') || 'none'}`,
-                        );
-                        process.exit(1);
-                    }
-                    // Clear session cache — old session is for a different server
-                    const sessionMgr = new SessionManager(cliName);
-                    sessionMgr.invalidate();
-                    console.log(`Switched to '${name}'`);
-                });
-
-            // config import — only if knownSites provided
-            if (options.knownSites) {
-                const knownSites = options.knownSites;
-                config
-                    .command('import [alias]')
-                    .description('Import a known site — only provide credentials')
-                    .option('--user <email>', 'Email for authentication')
-                    .option('--password <password>', 'Password for authentication')
-                    .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
-                    .action(
-                        async (
-                            aliasArg: string | undefined,
-                            opts: { user?: string; password?: string; allowInsecureStorage?: boolean },
-                        ) => {
-                            let alias = aliasArg;
-
-                            // Interactive picker if no alias provided
-                            if (!alias) {
-                                const siteEntries = Object.entries(knownSites);
-                                if (siteEntries.length === 0) {
-                                    console.error('No known sites configured.');
-                                    process.exit(1);
-                                }
-
-                                console.log('\nAvailable sites:');
-                                siteEntries.forEach(([name, site], i) => {
-                                    console.log(
-                                        `  ${(i + 1).toString().padStart(2)}. ${name.padEnd(22)} ${site.description}`,
-                                    );
-                                });
-
-                                const selection = await prompt(
-                                    `\nSelect site (1-${siteEntries.length}): `,
-                                );
-                                const index = parseInt(selection);
-                                if (index < 1 || index > siteEntries.length) {
-                                    console.error('Invalid selection.');
-                                    process.exit(1);
-                                }
-                                alias = siteEntries[index - 1]![0];
-                            }
-
-                            // Validate alias is known
-                            if (!knownSites[alias]) {
-                                console.error(`Unknown site '${alias}'.`);
-                                process.exit(1);
-                            }
-
-                            const site = knownSites[alias];
-                            const user = opts.user ?? (await prompt('Email: '));
-                            const password
-                                = opts.password ?? (await hiddenPrompt('Password: '));
-                            if (!user || !password) {
-                                console.error('Email and password are required.');
-                                process.exit(1);
-                            }
-
-                            // Verify credentials
-                            const result = await verifyCredentials(site.url, user, password);
-                            if (!result.ok) {
-                                console.error(result.reason);
-                                console.error(
-                                    "Credentials saved anyway — they'll be used when the server is available.",
-                                );
-                            } else {
-                                console.log('Credentials verified.');
-                            }
-
-                            try {
-                                await saveEnvironment(cliName, alias, {
-                                    url: site.url,
-                                    user,
-                                    password,
-                                }, true, {
-                                    ...configOpts,
-                                    allowInsecureStorage: opts.allowInsecureStorage,
-                                    allowedCidrs: options.allowedCidrs,
-                                });
-                                console.log(`Saved and switched to '${alias}'.`);
-                            } catch (err) {
-                                console.error(err instanceof Error ? err.message : String(err));
-                                process.exit(1);
-                            }
-                        },
-                    );
-
-                config
-                    .command('update-password [name]')
-                    .description('Update password for an environment (defaults to active)')
-                    .option('--password <password>', 'New password')
-                    .action(
-                        async (
-                            name: string | undefined,
-                            opts: { password?: string },
-                        ) => {
-                            const cfg = await loadConfig(cliName, configOpts);
-                            if (
-                                !cfg
-                                || Object.keys(cfg.environments).length === 0
-                            ) {
-                                console.error(
-                                    `No environments configured. Run '${cliName} config import' first.`,
-                                );
-                                process.exit(1);
-                            }
-
-                            const envName = name ?? cfg.active;
-                            const env = cfg.environments[envName];
-                            if (!env) {
-                                console.error(`Environment '${envName}' not found.`);
-                                process.exit(1);
-                            }
-
-                            console.log(
-                                `Updating password for '${envName}' (${env.url})`,
-                            );
-
-                            const password
-                                = opts.password ?? (await hiddenPrompt('New password: '));
-                            if (!password) {
-                                console.error('Password is required.');
-                                process.exit(1);
-                            }
-
-                            await saveEnvironment(
-                                cliName,
-                                envName,
-                                { ...env, password },
-                                false,
-                                configOpts,
-                            );
-                            console.log('Password updated.');
-                        },
-                    );
-            }
-
-            // generate
-            program
-                .command('generate')
-                .description(
-                    "Regenerate CLI from the active environment's OpenAPI spec",
-                )
-                .action(async () => {
-                    const env = getActiveEnvConfig(cliName, configOpts);
-                    if (!env) {
-                        console.error(
-                            `No active environment. Run '${cliName} setup' first.`,
-                        );
-                        process.exit(2);
-                    }
-                    console.log(`Generating from ${env.url} ...`);
-                    try {
-                        await fetchAndGenerate({
-                            baseUrl: env.url,
-                            specPath: options.specPath,
-                            outDir: generatedDir,
-                            auth: { username: env.user, password: env.password },
-                        });
-                        console.log(`Generated files written to ${generatedDir}`);
-                    } catch (err) {
-                        console.error(
-                            'Generation failed:',
-                            err instanceof Error ? err.message : String(err),
-                        );
-                        process.exit(1);
-                    }
-                });
-
-            // upgrade
-            program
-                .command('upgrade')
-                .description('Check for and install the latest version')
-                .action(async () => {
-                    try {
-                        const res = await fetch('https://registry.npmjs.org/@apijack/core/latest');
-                        if (!res.ok) {
-                            console.error('Failed to check for updates.');
-                            process.exit(1);
-                        }
-                        const data = await res.json() as { version: string };
-                        const latest = data.version;
-
-                        if (latest === options.version) {
-                            console.log(`Already on the latest version (v${latest}).`);
-                            return;
-                        }
-
-                        console.log(`v${options.version} → v${latest}`);
-                        console.log('Upgrading...');
-                        const proc = Bun.spawn(['bun', 'install', '-g', `@apijack/core@${latest}`], {
-                            stdout: 'inherit',
-                            stderr: 'inherit',
-                        });
-                        const exitCode = await proc.exited;
-                        if (exitCode !== 0) {
-                            console.error('Upgrade failed.');
-                            process.exit(1);
-                        }
-
-                        // Update plugin registration
-                        const pluginProc = Bun.spawn([...process.argv.slice(0, 2), 'plugin', 'install'], {
-                            stdout: 'inherit',
-                            stderr: 'inherit',
-                            env: { ...process.env, APIJACK_SKIP_UPDATE: '1' },
-                        });
-                        await pluginProc.exited;
-
-                        console.log(`Upgraded to v${latest}.`);
-                    } catch {
-                        console.error('Failed to check for updates.');
-                        process.exit(1);
-                    }
-                });
-
-            // mcp
-            program
-                .command('mcp')
-                .description('Start MCP server for AI agent integration')
-                .action(async () => {
-                    try {
-                        const { startMcpServer } = await import('./mcp/server');
-                        await startMcpServer({
-                            cliName: options.name,
-                            cliInvocation: process.argv.slice(0, 2),
-                            generatedDir: resolve(options.generatedDir || 'src/generated'),
-                            routinesDir: `${homedir()}/.${options.name}/routines`,
-                        });
-                    } catch (e: any) {
-                        if (
-                            e?.code === 'MODULE_NOT_FOUND'
-                            || e?.message?.includes('Cannot find module')
-                            || e?.message?.includes('Failed to resolve')
-                        ) {
-                            console.error('MCP server requires @modelcontextprotocol/sdk');
-                            console.error('Install it: bun add @modelcontextprotocol/sdk');
-                            process.exit(1);
-                        }
-                        throw e;
-                    }
-                });
-
-            // plugin
+            registerSetupCommand(program, cliName, {
+                allowedCidrs: options.allowedCidrs,
+                configPath: options.configPath,
+            });
+            registerConfigCommand(program, cliName, {
+                configPath: options.configPath,
+                knownSites: options.knownSites,
+                allowedCidrs: options.allowedCidrs,
+            });
+            registerGenerateCommand(program, cliName, options.specPath, generatedDir, configOpts);
+            registerUpgradeCommand(program, options.version);
+            registerMcpCommand(
+                program,
+                cliName,
+                resolve(options.generatedDir || 'src/generated'),
+                join(homedir(), '.' + options.name, 'routines'),
+            );
             registerPluginCommand(program, cliName, options.version);
 
             // 4. Resolve auth
@@ -447,7 +163,27 @@ export function createCli(options: CliOptions): Cli {
                 && !skipAuthCommands.has(cmd)
                 && !isHelpOrVersion
             ) {
-                await interactiveSetup(cliName);
+                console.log(`${cliName} Setup\n`);
+                const envName = await prompt('Environment name [default]: ', 'default');
+                const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+                const user = await prompt('Username/Email: ');
+                const password = await hiddenPrompt('Password: ');
+                if (user && password) {
+                    const result = await setupAction({
+                        cliName, envName, url, user, password,
+                        verify: verifyCredentials,
+                        save: saveEnvironment,
+                        saveOpts: configOpts ?? {},
+                    });
+                    if (!result.verified) {
+                        console.error(result.verifyReason);
+                        console.error("Credentials saved anyway — they'll be used when the server is available.");
+                    } else {
+                        console.log('Credentials verified.');
+                    }
+                    console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+                    console.log(`Switched to '${envName}'\n`);
+                }
                 resolved = resolveAuth(cliName, configOpts);
             }
 
@@ -691,270 +427,4 @@ export function createCli(options: CliOptions): Cli {
     };
 
     return cli;
-}
-
-async function interactiveSetup(
-    cliName: string,
-    opts?: { allowInsecureStorage?: boolean; allowedCidrs?: string[]; configPath?: string },
-): Promise<void> {
-    console.log(`${cliName} Setup\n`);
-
-    const envName = await prompt('Environment name [default]: ', 'default');
-    const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
-    const user = await prompt('Username/Email: ');
-    const password = await hiddenPrompt('Password: ');
-
-    if (!user || !password) {
-        console.error('Setup cancelled.');
-        process.exit(2);
-    }
-
-    // Verify credentials
-    const result = await verifyCredentials(url, user, password);
-    if (!result.ok) {
-        console.error(result.reason);
-        console.error(
-            "Credentials saved anyway — they'll be used when the server is available.",
-        );
-    } else {
-        console.log('Credentials verified.');
-    }
-
-    try {
-        await saveEnvironment(cliName, envName, { url, user, password }, true, {
-            configPath: opts?.configPath,
-            allowInsecureStorage: opts?.allowInsecureStorage,
-            allowedCidrs: opts?.allowedCidrs,
-        });
-        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
-        console.log(`Switched to '${envName}'\n`);
-    } catch (err) {
-        console.error(err instanceof Error ? err.message : String(err));
-        process.exit(1);
-    }
-}
-
-function loadBuiltinRoutines(
-    builtinDir: string,
-): Record<string, string> | undefined {
-    if (!existsSync(builtinDir)) return undefined;
-    const map: Record<string, string> = {};
-
-    function collect(dir: string, prefix: string) {
-        for (const entry of readdirSync(dir, { withFileTypes: true })) {
-            const fullPath = resolve(dir, entry.name);
-            const key = prefix ? `${prefix}/${entry.name}` : entry.name;
-            if (entry.isDirectory()) {
-                collect(fullPath, key);
-            } else if (
-                entry.isFile()
-                && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml'))
-            ) {
-                map[key] = readFileSync(fullPath, 'utf-8');
-            }
-        }
-    }
-
-    collect(builtinDir, '');
-    return Object.keys(map).length > 0 ? map : undefined;
-}
-
-function registerRoutineCommand(
-    program: Command,
-    cliName: string,
-    routinesDir: string,
-    dispatch: CommandDispatcher | undefined,
-    builtinRoutinesDir?: string,
-): void {
-    const builtinsMap = builtinRoutinesDir
-        ? loadBuiltinRoutines(builtinRoutinesDir)
-        : undefined;
-
-    const routine = program
-        .command('routine')
-        .description('Manage and run routines');
-
-    routine
-        .command('list [path]')
-        .description('List available routines (optionally drill into a group)')
-        .option('--tree', 'Show full tree structure')
-        .action((path: string | undefined, opts: { tree?: boolean }) => {
-            const routines = listRoutines(routinesDir, builtinsMap);
-            if (routines.length === 0) {
-                console.log(`No routines found in ~/.${cliName}/routines/`);
-                console.log(`Run '${cliName} routine init' to install built-in routines.`);
-                return;
-            }
-
-            let filtered = routines;
-            if (path) {
-                const prefix = path.replace(/\/+$/, '');
-                filtered = routines
-                    .filter((r) => {
-                        const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
-                        return clean.startsWith(prefix + '/');
-                    })
-                    .map((r) => {
-                        const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
-                        return clean.slice(prefix.length + 1);
-                    });
-                if (filtered.length === 0) {
-                    console.log(`No routines found under '${prefix}/'`);
-                    return;
-                }
-            }
-
-            console.log(
-                opts.tree
-                    ? formatRoutineTree(filtered)
-                    : formatRoutineList(filtered, path?.replace(/\/+$/, '')),
-            );
-        });
-
-    routine
-        .command('run <name>')
-        .description('Execute a routine')
-        .option('--set <pairs...>', 'Override variables (key=value)')
-        .option('--dry-run', 'Print resolved commands without executing')
-        .action(async (name: string, opts: { set?: string[]; dryRun?: boolean }) => {
-            if (!dispatch) {
-                console.error(
-                    `No active session. Run '${cliName} setup' first.`,
-                );
-                process.exit(2);
-            }
-
-            const def = loadRoutineFile(name, routinesDir, builtinsMap);
-            const errors = validateRoutine(def);
-            if (errors.length > 0) {
-                console.error('Validation errors:');
-                for (const e of errors) console.error(`  - ${e}`);
-                process.exit(1);
-            }
-
-            // Clear stale session so routine starts fresh
-            const sessionMgr = new SessionManager(cliName);
-            sessionMgr.invalidate();
-
-            const overrides: Record<string, unknown> = {};
-            for (const s of opts.set || []) {
-                const eq = s.indexOf('=');
-                if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
-            }
-
-            console.log(
-                `Running routine: ${def.name}${def.description ? ` — ${def.description}` : ''}\n`,
-            );
-
-            const startTime = Date.now();
-            const result = await executeRoutine(def, overrides, dispatch, {
-                dryRun: opts.dryRun,
-                onStep: (step, i, total) => {
-                    console.log(`\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}`);
-                },
-                onIteration: (step, current, total, stepIndex, stepTotal) => {
-                    process.stderr.write(`\r\x1b[36m[${stepIndex + 1}/${stepTotal}]\x1b[0m ${step.name} \x1b[36m[${current}/${total}]\x1b[0m\x1b[K`);
-                },
-            });
-
-            const elapsed = Date.now() - startTime;
-            const mins = Math.floor(elapsed / 60000);
-            const secs = ((elapsed % 60000) / 1000).toFixed(1);
-            const timeStr = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
-            console.log(
-                `\nRoutine ${result.success ? '\x1b[32mcompleted\x1b[0m' : '\x1b[31mfailed\x1b[0m'}: ${result.stepsRun} run, ${result.stepsSkipped} skipped, ${result.stepsFailed} failed (${timeStr})`,
-            );
-            if (!result.success) process.exit(1);
-        });
-
-    routine
-        .command('validate <name>')
-        .description('Validate a routine YAML file')
-        .action((name: string) => {
-            const def = loadRoutineFile(name, routinesDir, builtinsMap);
-            const errors = validateRoutine(def);
-            if (errors.length > 0) {
-                console.error('Validation errors:');
-                for (const e of errors) console.error(`  - ${e}`);
-                process.exit(1);
-            }
-            console.log(`Routine "${def.name}" is valid.`);
-        });
-
-    routine
-        .command('test <name>')
-        .description("Run a routine's spec (test) file")
-        .option('--set <pairs...>', 'Override variables (key=value)')
-        .action(async (name: string, opts: { set?: string[] }) => {
-            if (!dispatch) {
-                console.error(
-                    `No active session. Run '${cliName} setup' first.`,
-                );
-                process.exit(2);
-            }
-
-            const spec = loadSpecFile(name, routinesDir, builtinsMap);
-            if (!spec) {
-                console.error(`No spec.yaml found for routine "${name}".`);
-                console.error(
-                    `Specs are optional but live at ~/.${cliName}/routines/<name>/spec.yaml`,
-                );
-                process.exit(1);
-            }
-
-            const errors = validateRoutine(spec);
-            if (errors.length > 0) {
-                console.error('Spec validation errors:');
-                for (const e of errors) console.error(`  - ${e}`);
-                process.exit(1);
-            }
-
-            const overrides: Record<string, unknown> = {};
-            for (const s of opts.set || []) {
-                const eq = s.indexOf('=');
-                if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
-            }
-
-            console.log(
-                `\x1b[36mTesting routine: ${name}\x1b[0m${spec.description ? ` — ${spec.description}` : ''}\n`,
-            );
-
-            const result = await executeRoutine(spec, overrides, dispatch, {
-                onStep: (step, i, total) => {
-                    console.log(
-                        `\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}${step.assert ? ' \x1b[33m(assert)\x1b[0m' : ''}`,
-                    );
-                },
-                onIteration: (step, current, total, stepIndex, stepTotal) => {
-                    process.stderr.write(`\r\x1b[36m[${stepIndex + 1}/${stepTotal}]\x1b[0m ${step.name} \x1b[36m[${current}/${total}]\x1b[0m\x1b[K`);
-                },
-            });
-
-            console.log('');
-            if (result.success) {
-                console.log(
-                    `\x1b[32mPASSED\x1b[0m: ${result.stepsRun} steps run, ${result.stepsSkipped} skipped`,
-                );
-            } else {
-                console.log(
-                    `\x1b[31mFAILED\x1b[0m: ${result.stepsRun} steps run, ${result.stepsFailed} failed`,
-                );
-                process.exit(1);
-            }
-        });
-
-    routine
-        .command('init')
-        .description(`Copy built-in routines to ~/.${cliName}/routines/`)
-        .action(() => {
-            mkdirSync(routinesDir, { recursive: true });
-            const builtinDir = builtinRoutinesDir;
-            if (!builtinDir || !existsSync(builtinDir)) {
-                console.error('No built-in routines directory found.');
-                return;
-            }
-            cpSync(builtinDir, routinesDir, { recursive: true });
-            const routines = readdirSync(builtinDir);
-            console.log(`Installed ${routines.length} routines to ${routinesDir}`);
-        });
 }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -33,6 +33,7 @@ const CORE_COMMANDS = new Set([
     'config',
     'generate',
     'routine',
+    'upgrade',
     'mcp',
     'plugin',
 ]);
@@ -346,6 +347,52 @@ export function createCli(options: CliOptions): Cli {
                     }
                 });
 
+            // upgrade
+            program
+                .command('upgrade')
+                .description('Check for and install the latest version')
+                .action(async () => {
+                    try {
+                        const res = await fetch('https://registry.npmjs.org/@apijack/core/latest');
+                        if (!res.ok) {
+                            console.error('Failed to check for updates.');
+                            process.exit(1);
+                        }
+                        const data = await res.json() as { version: string };
+                        const latest = data.version;
+
+                        if (latest === options.version) {
+                            console.log(`Already on the latest version (v${latest}).`);
+                            return;
+                        }
+
+                        console.log(`v${options.version} → v${latest}`);
+                        console.log('Upgrading...');
+                        const proc = Bun.spawn(['bun', 'install', '-g', `@apijack/core@${latest}`], {
+                            stdout: 'inherit',
+                            stderr: 'inherit',
+                        });
+                        const exitCode = await proc.exited;
+                        if (exitCode !== 0) {
+                            console.error('Upgrade failed.');
+                            process.exit(1);
+                        }
+
+                        // Update plugin registration
+                        const pluginProc = Bun.spawn([...process.argv.slice(0, 2), 'plugin', 'install'], {
+                            stdout: 'inherit',
+                            stderr: 'inherit',
+                            env: { ...process.env, APIJACK_SKIP_UPDATE: '1' },
+                        });
+                        await pluginProc.exited;
+
+                        console.log(`Upgraded to v${latest}.`);
+                    } catch {
+                        console.error('Failed to check for updates.');
+                        process.exit(1);
+                    }
+                });
+
             // mcp
             program
                 .command('mcp')
@@ -386,6 +433,7 @@ export function createCli(options: CliOptions): Cli {
                 'config',
                 'routine',
                 'generate',
+                'upgrade',
                 'mcp',
                 'plugin',
             ]);

--- a/src/commands/config/import/import.test.ts
+++ b/src/commands/config/import/import.test.ts
@@ -1,39 +1,39 @@
-import { describe, test, expect, mock } from "bun:test";
-import { configImportAction } from "./import";
+import { describe, test, expect, mock } from 'bun:test';
+import { configImportAction } from './import';
 
-describe("configImportAction", () => {
-  test("saves environment for a known site", async () => {
-    const saveFn = mock(() => Promise.resolve());
-    const verifyFn = mock(() => Promise.resolve({ ok: true }));
+describe('configImportAction', () => {
+    test('saves environment for a known site', async () => {
+        const saveFn = mock(() => Promise.resolve());
+        const verifyFn = mock(() => Promise.resolve({ ok: true }));
 
-    const result = await configImportAction({
-      alias: "staging",
-      knownSites: {
-        staging: { url: "https://staging.example.com", description: "Staging" },
-      },
-      user: "admin",
-      password: "secret",
-      cliName: "testcli",
-      verify: verifyFn,
-      save: saveFn,
-      saveOpts: {},
+        const result = await configImportAction({
+            alias: 'staging',
+            knownSites: {
+                staging: { url: 'https://staging.example.com', description: 'Staging' },
+            },
+            user: 'admin',
+            password: 'secret',
+            cliName: 'testcli',
+            verify: verifyFn,
+            save: saveFn,
+            saveOpts: {},
+        });
+
+        expect(result.saved).toBe(true);
+        expect(result.verified).toBe(true);
+        expect(saveFn).toHaveBeenCalled();
     });
 
-    expect(result.saved).toBe(true);
-    expect(result.verified).toBe(true);
-    expect(saveFn).toHaveBeenCalled();
-  });
-
-  test("throws for unknown alias", () => {
-    expect(configImportAction({
-      alias: "unknown",
-      knownSites: {},
-      user: "admin",
-      password: "secret",
-      cliName: "testcli",
-      verify: mock(() => Promise.resolve({ ok: true })),
-      save: mock(() => Promise.resolve()),
-      saveOpts: {},
-    })).rejects.toThrow("Unknown site");
-  });
+    test('throws for unknown alias', () => {
+        expect(configImportAction({
+            alias: 'unknown',
+            knownSites: {},
+            user: 'admin',
+            password: 'secret',
+            cliName: 'testcli',
+            verify: mock(() => Promise.resolve({ ok: true })),
+            save: mock(() => Promise.resolve()),
+            saveOpts: {},
+        })).rejects.toThrow('Unknown site');
+    });
 });

--- a/src/commands/config/import/import.test.ts
+++ b/src/commands/config/import/import.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, mock } from "bun:test";
+import { configImportAction } from "./import";
+
+describe("configImportAction", () => {
+  test("saves environment for a known site", async () => {
+    const saveFn = mock(() => Promise.resolve());
+    const verifyFn = mock(() => Promise.resolve({ ok: true }));
+
+    const result = await configImportAction({
+      alias: "staging",
+      knownSites: {
+        staging: { url: "https://staging.example.com", description: "Staging" },
+      },
+      user: "admin",
+      password: "secret",
+      cliName: "testcli",
+      verify: verifyFn,
+      save: saveFn,
+      saveOpts: {},
+    });
+
+    expect(result.saved).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(saveFn).toHaveBeenCalled();
+  });
+
+  test("throws for unknown alias", () => {
+    expect(configImportAction({
+      alias: "unknown",
+      knownSites: {},
+      user: "admin",
+      password: "secret",
+      cliName: "testcli",
+      verify: mock(() => Promise.resolve({ ok: true })),
+      save: mock(() => Promise.resolve()),
+      saveOpts: {},
+    })).rejects.toThrow("Unknown site");
+  });
+});

--- a/src/commands/config/import/import.ts
+++ b/src/commands/config/import/import.ts
@@ -1,0 +1,35 @@
+export interface ConfigImportDeps {
+    alias: string;
+    knownSites: Record<string, { url: string; description: string }>;
+    user: string;
+    password: string;
+    cliName: string;
+    verify: (url: string, user: string, password: string) => Promise<{ ok: boolean; reason?: string }>;
+    save: (...args: any[]) => Promise<void>;
+    saveOpts: Record<string, unknown>;
+}
+
+export interface ConfigImportResult {
+    saved: boolean;
+    verified: boolean;
+    verifyReason?: string;
+}
+
+export async function configImportAction(deps: ConfigImportDeps): Promise<ConfigImportResult> {
+    const site = deps.knownSites[deps.alias];
+    if (!site) throw new Error(`Unknown site '${deps.alias}'.`);
+
+    const verifyResult = await deps.verify(site.url, deps.user, deps.password);
+
+    await deps.save(deps.cliName, deps.alias, {
+        url: site.url,
+        user: deps.user,
+        password: deps.password,
+    }, true, deps.saveOpts);
+
+    return {
+        saved: true,
+        verified: verifyResult.ok,
+        verifyReason: verifyResult.ok ? undefined : verifyResult.reason,
+    };
+}

--- a/src/commands/config/list/list.test.ts
+++ b/src/commands/config/list/list.test.ts
@@ -1,22 +1,22 @@
-import { describe, test, expect } from "bun:test";
-import { configListAction } from "./list";
+import { describe, test, expect } from 'bun:test';
+import { configListAction } from './list';
 
-describe("configListAction", () => {
-  test("returns environment list", async () => {
-    const envs = [
-      { name: "local", url: "http://localhost:8080", user: "admin", active: true },
-      { name: "staging", url: "https://staging.example.com", user: "user", active: false },
-    ];
-    const result = await configListAction({
-      listEnvs: async () => envs,
+describe('configListAction', () => {
+    test('returns environment list', async () => {
+        const envs = [
+            { name: 'local', url: 'http://localhost:8080', user: 'admin', active: true },
+            { name: 'staging', url: 'https://staging.example.com', user: 'user', active: false },
+        ];
+        const result = await configListAction({
+            listEnvs: async () => envs,
+        });
+        expect(result).toEqual(envs);
     });
-    expect(result).toEqual(envs);
-  });
 
-  test("returns empty array when no environments", async () => {
-    const result = await configListAction({
-      listEnvs: async () => [],
+    test('returns empty array when no environments', async () => {
+        const result = await configListAction({
+            listEnvs: async () => [],
+        });
+        expect(result).toEqual([]);
     });
-    expect(result).toEqual([]);
-  });
 });

--- a/src/commands/config/list/list.test.ts
+++ b/src/commands/config/list/list.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test";
+import { configListAction } from "./list";
+
+describe("configListAction", () => {
+  test("returns environment list", async () => {
+    const envs = [
+      { name: "local", url: "http://localhost:8080", user: "admin", active: true },
+      { name: "staging", url: "https://staging.example.com", user: "user", active: false },
+    ];
+    const result = await configListAction({
+      listEnvs: async () => envs,
+    });
+    expect(result).toEqual(envs);
+  });
+
+  test("returns empty array when no environments", async () => {
+    const result = await configListAction({
+      listEnvs: async () => [],
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/commands/config/list/list.ts
+++ b/src/commands/config/list/list.ts
@@ -1,0 +1,14 @@
+interface EnvEntry {
+    name: string;
+    url: string;
+    user: string;
+    active: boolean;
+}
+
+export interface ConfigListDeps {
+    listEnvs: () => Promise<EnvEntry[]>;
+}
+
+export async function configListAction(deps: ConfigListDeps): Promise<EnvEntry[]> {
+    return deps.listEnvs();
+}

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -45,7 +45,7 @@ export function registerConfigCommand(
             const sessionMgr = new SessionManager(cliName);
             const result = await configSwitchAction({
                 name,
-                switchEnv: (n) => switchEnvironment(cliName, n, configOpts),
+                switchEnv: n => switchEnvironment(cliName, n, configOpts),
                 invalidateSession: () => sessionMgr.invalidate(),
                 listEnvs: () => listEnvironments(cliName, configOpts),
             });
@@ -139,7 +139,7 @@ export function registerConfigCommand(
                     const result = await configUpdatePasswordAction({
                         envName: name,
                         password,
-                        loadConfig: (n) => loadConfig(n, configOpts) as any,
+                        loadConfig: n => loadConfig(n, configOpts) as any,
                         save: saveEnvironment,
                         cliName,
                         saveOpts: configOpts ?? {},

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -1,0 +1,155 @@
+import { Command } from 'commander';
+import { listEnvironments, switchEnvironment, saveEnvironment, loadConfig, verifyCredentials } from '../../config';
+import { SessionManager } from '../../session';
+import { prompt, hiddenPrompt } from '../../prompt';
+import { configListAction } from './list/list';
+import { configSwitchAction } from './switch/switch';
+import { configImportAction } from './import/import';
+import { configUpdatePasswordAction } from './update-password/update-password';
+
+export function registerConfigCommand(
+    program: Command,
+    cliName: string,
+    opts?: {
+        configPath?: string;
+        knownSites?: Record<string, { url: string; description: string; group?: string }>;
+        allowedCidrs?: string[];
+    },
+): void {
+    const configOpts = opts?.configPath ? { configPath: opts.configPath } : undefined;
+    const config = program
+        .command('config')
+        .description('Manage environment configurations');
+
+    config
+        .command('list')
+        .description('List all configured environments')
+        .action(async () => {
+            const envs = await configListAction({
+                listEnvs: () => listEnvironments(cliName, configOpts),
+            });
+            if (envs.length === 0) {
+                console.log(`No environments configured. Run '${cliName} setup' to add one.`);
+                return;
+            }
+            for (const env of envs) {
+                const marker = env.active ? '* ' : '  ';
+                console.log(`${marker}${env.name}\t${env.url}\t${env.user}`);
+            }
+        });
+
+    config
+        .command('switch <name>')
+        .description('Switch active environment')
+        .action(async (name: string) => {
+            const sessionMgr = new SessionManager(cliName);
+            const result = await configSwitchAction({
+                name,
+                switchEnv: (n) => switchEnvironment(cliName, n, configOpts),
+                invalidateSession: () => sessionMgr.invalidate(),
+                listEnvs: () => listEnvironments(cliName, configOpts),
+            });
+            if (!result.ok) {
+                console.error(`Environment '${name}' not found. Available: ${result.available?.join(', ') || 'none'}`);
+                process.exit(1);
+            }
+            console.log(`Switched to '${name}'`);
+        });
+
+    if (opts?.knownSites) {
+        const knownSites = opts.knownSites;
+        config
+            .command('import [alias]')
+            .description('Import a known site — only provide credentials')
+            .option('--user <email>', 'Email for authentication')
+            .option('--password <password>', 'Password for authentication')
+            .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
+            .action(async (aliasArg: string | undefined, cmdOpts: { user?: string; password?: string; allowInsecureStorage?: boolean }) => {
+                let alias = aliasArg;
+
+                if (!alias) {
+                    const siteEntries = Object.entries(knownSites);
+                    if (siteEntries.length === 0) {
+                        console.error('No known sites configured.');
+                        process.exit(1);
+                    }
+
+                    console.log('\nAvailable sites:');
+                    siteEntries.forEach(([name, site], i) => {
+                        console.log(`  ${(i + 1).toString().padStart(2)}. ${name.padEnd(22)} ${site.description}`);
+                    });
+
+                    const selection = await prompt(`\nSelect site (1-${siteEntries.length}): `);
+                    const index = parseInt(selection);
+                    if (index < 1 || index > siteEntries.length) {
+                        console.error('Invalid selection.');
+                        process.exit(1);
+                    }
+                    alias = siteEntries[index - 1]![0];
+                }
+
+                const user = cmdOpts.user ?? (await prompt('Email: '));
+                const password = cmdOpts.password ?? (await hiddenPrompt('Password: '));
+                if (!user || !password) {
+                    console.error('Email and password are required.');
+                    process.exit(1);
+                }
+
+                try {
+                    const result = await configImportAction({
+                        alias,
+                        knownSites,
+                        user,
+                        password,
+                        cliName,
+                        verify: verifyCredentials,
+                        save: saveEnvironment,
+                        saveOpts: {
+                            ...configOpts,
+                            allowInsecureStorage: cmdOpts.allowInsecureStorage,
+                            allowedCidrs: opts?.allowedCidrs,
+                        },
+                    });
+
+                    if (!result.verified) {
+                        console.error(result.verifyReason);
+                        console.error("Credentials saved anyway — they'll be used when the server is available.");
+                    } else {
+                        console.log('Credentials verified.');
+                    }
+                    console.log(`Saved and switched to '${alias}'.`);
+                } catch (err) {
+                    console.error(err instanceof Error ? err.message : String(err));
+                    process.exit(1);
+                }
+            });
+
+        config
+            .command('update-password [name]')
+            .description('Update password for an environment (defaults to active)')
+            .option('--password <password>', 'New password')
+            .action(async (name: string | undefined, cmdOpts: { password?: string }) => {
+                const password = cmdOpts.password ?? (await hiddenPrompt('New password: '));
+                if (!password) {
+                    console.error('Password is required.');
+                    process.exit(1);
+                }
+
+                try {
+                    const result = await configUpdatePasswordAction({
+                        envName: name,
+                        password,
+                        loadConfig: (n) => loadConfig(n, configOpts) as any,
+                        save: saveEnvironment,
+                        cliName,
+                        saveOpts: configOpts ?? {},
+                    });
+                    console.log(`Updating password for '${result.envName}'`);
+                    console.log('Password updated.');
+                } catch (err) {
+                    console.error(err instanceof Error ? err.message : String(err));
+                    process.exit(1);
+                }
+            });
+    }
+}

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -129,6 +129,20 @@ export function registerConfigCommand(
             .description('Update password for an environment (defaults to active)')
             .option('--password <password>', 'New password')
             .action(async (name: string | undefined, cmdOpts: { password?: string }) => {
+                // Validate environment exists before prompting for password
+                const cfg = await loadConfig(cliName, configOpts) as any;
+                if (!cfg || Object.keys(cfg.environments).length === 0) {
+                    console.error(`No environments configured. Run '${cliName} config import' first.`);
+                    process.exit(1);
+                }
+                const envName = name ?? cfg.active;
+                if (!cfg.environments[envName]) {
+                    console.error(`Environment '${envName}' not found.`);
+                    process.exit(1);
+                }
+
+                console.log(`Updating password for '${envName}' (${cfg.environments[envName].url})`);
+
                 const password = cmdOpts.password ?? (await hiddenPrompt('New password: '));
                 if (!password) {
                     console.error('Password is required.');
@@ -136,15 +150,14 @@ export function registerConfigCommand(
                 }
 
                 try {
-                    const result = await configUpdatePasswordAction({
-                        envName: name,
+                    await configUpdatePasswordAction({
+                        envName,
                         password,
-                        loadConfig: n => loadConfig(n, configOpts) as any,
+                        loadConfig: async () => cfg,
                         save: saveEnvironment,
                         cliName,
                         saveOpts: configOpts ?? {},
                     });
-                    console.log(`Updating password for '${result.envName}'`);
                     console.log('Password updated.');
                 } catch (err) {
                     console.error(err instanceof Error ? err.message : String(err));

--- a/src/commands/config/switch/switch.test.ts
+++ b/src/commands/config/switch/switch.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect, mock } from "bun:test";
+import { configSwitchAction } from "./switch";
+
+describe("configSwitchAction", () => {
+  test("returns success when environment exists", async () => {
+    const result = await configSwitchAction({
+      name: "staging",
+      switchEnv: mock(() => Promise.resolve(true)),
+      invalidateSession: mock(() => {}),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("returns available envs when environment not found", async () => {
+    const result = await configSwitchAction({
+      name: "nonexistent",
+      switchEnv: mock(() => Promise.resolve(false)),
+      invalidateSession: mock(() => {}),
+      listEnvs: mock(() => Promise.resolve([
+        { name: "local", url: "", user: "", active: true },
+      ])),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.available).toEqual(["local"]);
+  });
+});

--- a/src/commands/config/switch/switch.test.ts
+++ b/src/commands/config/switch/switch.test.ts
@@ -1,26 +1,26 @@
-import { describe, test, expect, mock } from "bun:test";
-import { configSwitchAction } from "./switch";
+import { describe, test, expect, mock } from 'bun:test';
+import { configSwitchAction } from './switch';
 
-describe("configSwitchAction", () => {
-  test("returns success when environment exists", async () => {
-    const result = await configSwitchAction({
-      name: "staging",
-      switchEnv: mock(() => Promise.resolve(true)),
-      invalidateSession: mock(() => {}),
+describe('configSwitchAction', () => {
+    test('returns success when environment exists', async () => {
+        const result = await configSwitchAction({
+            name: 'staging',
+            switchEnv: mock(() => Promise.resolve(true)),
+            invalidateSession: mock(() => {}),
+        });
+        expect(result.ok).toBe(true);
     });
-    expect(result.ok).toBe(true);
-  });
 
-  test("returns available envs when environment not found", async () => {
-    const result = await configSwitchAction({
-      name: "nonexistent",
-      switchEnv: mock(() => Promise.resolve(false)),
-      invalidateSession: mock(() => {}),
-      listEnvs: mock(() => Promise.resolve([
-        { name: "local", url: "", user: "", active: true },
-      ])),
+    test('returns available envs when environment not found', async () => {
+        const result = await configSwitchAction({
+            name: 'nonexistent',
+            switchEnv: mock(() => Promise.resolve(false)),
+            invalidateSession: mock(() => {}),
+            listEnvs: mock(() => Promise.resolve([
+                { name: 'local', url: '', user: '', active: true },
+            ])),
+        });
+        expect(result.ok).toBe(false);
+        expect(result.available).toEqual(['local']);
     });
-    expect(result.ok).toBe(false);
-    expect(result.available).toEqual(["local"]);
-  });
 });

--- a/src/commands/config/switch/switch.ts
+++ b/src/commands/config/switch/switch.ts
@@ -1,0 +1,21 @@
+export interface ConfigSwitchDeps {
+    name: string;
+    switchEnv: (name: string) => Promise<boolean>;
+    invalidateSession: () => void;
+    listEnvs?: () => Promise<{ name: string }[]>;
+}
+
+export interface ConfigSwitchResult {
+    ok: boolean;
+    available?: string[];
+}
+
+export async function configSwitchAction(deps: ConfigSwitchDeps): Promise<ConfigSwitchResult> {
+    const ok = await deps.switchEnv(deps.name);
+    if (!ok) {
+        const envs = deps.listEnvs ? await deps.listEnvs() : [];
+        return { ok: false, available: envs.map(e => e.name) };
+    }
+    deps.invalidateSession();
+    return { ok: true };
+}

--- a/src/commands/config/update-password/update-password.test.ts
+++ b/src/commands/config/update-password/update-password.test.ts
@@ -1,67 +1,67 @@
-import { describe, test, expect, mock } from "bun:test";
-import { configUpdatePasswordAction } from "./update-password";
+import { describe, test, expect, mock } from 'bun:test';
+import { configUpdatePasswordAction } from './update-password';
 
-describe("configUpdatePasswordAction", () => {
-  test("updates password for named environment", async () => {
-    const saveFn = mock(() => Promise.resolve());
-    const result = await configUpdatePasswordAction({
-      envName: "local",
-      password: "newpass",
-      loadConfig: async () => ({
-        active: "local",
-        environments: {
-          local: { url: "http://localhost:8080", user: "admin", password: "old" },
-        },
-      }),
-      save: saveFn,
-      cliName: "testcli",
-      saveOpts: {},
+describe('configUpdatePasswordAction', () => {
+    test('updates password for named environment', async () => {
+        const saveFn = mock(() => Promise.resolve());
+        const result = await configUpdatePasswordAction({
+            envName: 'local',
+            password: 'newpass',
+            loadConfig: async () => ({
+                active: 'local',
+                environments: {
+                    local: { url: 'http://localhost:8080', user: 'admin', password: 'old' },
+                },
+            }),
+            save: saveFn,
+            cliName: 'testcli',
+            saveOpts: {},
+        });
+
+        expect(result.ok).toBe(true);
+        expect(result.envName).toBe('local');
+        expect(saveFn).toHaveBeenCalled();
     });
 
-    expect(result.ok).toBe(true);
-    expect(result.envName).toBe("local");
-    expect(saveFn).toHaveBeenCalled();
-  });
+    test('defaults to active environment when no name given', async () => {
+        const saveFn = mock(() => Promise.resolve());
+        const result = await configUpdatePasswordAction({
+            password: 'newpass',
+            loadConfig: async () => ({
+                active: 'staging',
+                environments: {
+                    staging: { url: 'https://staging.example.com', user: 'admin', password: 'old' },
+                },
+            }),
+            save: saveFn,
+            cliName: 'testcli',
+            saveOpts: {},
+        });
 
-  test("defaults to active environment when no name given", async () => {
-    const saveFn = mock(() => Promise.resolve());
-    const result = await configUpdatePasswordAction({
-      password: "newpass",
-      loadConfig: async () => ({
-        active: "staging",
-        environments: {
-          staging: { url: "https://staging.example.com", user: "admin", password: "old" },
-        },
-      }),
-      save: saveFn,
-      cliName: "testcli",
-      saveOpts: {},
+        expect(result.envName).toBe('staging');
     });
 
-    expect(result.envName).toBe("staging");
-  });
+    test('throws when no environments configured', () => {
+        expect(configUpdatePasswordAction({
+            password: 'newpass',
+            loadConfig: async () => null,
+            save: mock(() => Promise.resolve()),
+            cliName: 'testcli',
+            saveOpts: {},
+        })).rejects.toThrow('No environments configured');
+    });
 
-  test("throws when no environments configured", () => {
-    expect(configUpdatePasswordAction({
-      password: "newpass",
-      loadConfig: async () => null,
-      save: mock(() => Promise.resolve()),
-      cliName: "testcli",
-      saveOpts: {},
-    })).rejects.toThrow("No environments configured");
-  });
-
-  test("throws when named environment not found", () => {
-    expect(configUpdatePasswordAction({
-      envName: "nonexistent",
-      password: "newpass",
-      loadConfig: async () => ({
-        active: "local",
-        environments: { local: { url: "http://localhost:8080", user: "admin", password: "old" } },
-      }),
-      save: mock(() => Promise.resolve()),
-      cliName: "testcli",
-      saveOpts: {},
-    })).rejects.toThrow("not found");
-  });
+    test('throws when named environment not found', () => {
+        expect(configUpdatePasswordAction({
+            envName: 'nonexistent',
+            password: 'newpass',
+            loadConfig: async () => ({
+                active: 'local',
+                environments: { local: { url: 'http://localhost:8080', user: 'admin', password: 'old' } },
+            }),
+            save: mock(() => Promise.resolve()),
+            cliName: 'testcli',
+            saveOpts: {},
+        })).rejects.toThrow('not found');
+    });
 });

--- a/src/commands/config/update-password/update-password.test.ts
+++ b/src/commands/config/update-password/update-password.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect, mock } from "bun:test";
+import { configUpdatePasswordAction } from "./update-password";
+
+describe("configUpdatePasswordAction", () => {
+  test("updates password for named environment", async () => {
+    const saveFn = mock(() => Promise.resolve());
+    const result = await configUpdatePasswordAction({
+      envName: "local",
+      password: "newpass",
+      loadConfig: async () => ({
+        active: "local",
+        environments: {
+          local: { url: "http://localhost:8080", user: "admin", password: "old" },
+        },
+      }),
+      save: saveFn,
+      cliName: "testcli",
+      saveOpts: {},
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.envName).toBe("local");
+    expect(saveFn).toHaveBeenCalled();
+  });
+
+  test("defaults to active environment when no name given", async () => {
+    const saveFn = mock(() => Promise.resolve());
+    const result = await configUpdatePasswordAction({
+      password: "newpass",
+      loadConfig: async () => ({
+        active: "staging",
+        environments: {
+          staging: { url: "https://staging.example.com", user: "admin", password: "old" },
+        },
+      }),
+      save: saveFn,
+      cliName: "testcli",
+      saveOpts: {},
+    });
+
+    expect(result.envName).toBe("staging");
+  });
+
+  test("throws when no environments configured", () => {
+    expect(configUpdatePasswordAction({
+      password: "newpass",
+      loadConfig: async () => null,
+      save: mock(() => Promise.resolve()),
+      cliName: "testcli",
+      saveOpts: {},
+    })).rejects.toThrow("No environments configured");
+  });
+
+  test("throws when named environment not found", () => {
+    expect(configUpdatePasswordAction({
+      envName: "nonexistent",
+      password: "newpass",
+      loadConfig: async () => ({
+        active: "local",
+        environments: { local: { url: "http://localhost:8080", user: "admin", password: "old" } },
+      }),
+      save: mock(() => Promise.resolve()),
+      cliName: "testcli",
+      saveOpts: {},
+    })).rejects.toThrow("not found");
+  });
+});

--- a/src/commands/config/update-password/update-password.ts
+++ b/src/commands/config/update-password/update-password.ts
@@ -1,0 +1,30 @@
+export interface ConfigUpdatePasswordDeps {
+    envName?: string;
+    password: string;
+    loadConfig: (cliName: string) => Promise<{ active: string; environments: Record<string, { url: string; user: string; password: string }> } | null>;
+    save: (...args: any[]) => Promise<void>;
+    cliName: string;
+    saveOpts: Record<string, unknown>;
+}
+
+export interface ConfigUpdatePasswordResult {
+    ok: boolean;
+    envName: string;
+}
+
+export async function configUpdatePasswordAction(deps: ConfigUpdatePasswordDeps): Promise<ConfigUpdatePasswordResult> {
+    const cfg = await deps.loadConfig(deps.cliName);
+    if (!cfg || Object.keys(cfg.environments).length === 0) {
+        throw new Error(`No environments configured. Run '${deps.cliName} config import' first.`);
+    }
+
+    const envName = deps.envName ?? cfg.active;
+    const env = cfg.environments[envName];
+    if (!env) {
+        throw new Error(`Environment '${envName}' not found.`);
+    }
+
+    await deps.save(deps.cliName, envName, { ...env, password: deps.password }, false, deps.saveOpts);
+
+    return { ok: true, envName };
+}

--- a/src/commands/generate/generate.test.ts
+++ b/src/commands/generate/generate.test.ts
@@ -1,30 +1,30 @@
-import { describe, test, expect, mock } from "bun:test";
-import { generateAction } from "./generate";
+import { describe, test, expect, mock } from 'bun:test';
+import { generateAction } from './generate';
 
-describe("generateAction", () => {
-  test("calls fetchAndGenerate with correct params", async () => {
-    const fetchAndGen = mock(() => Promise.resolve());
-    await generateAction({
-      env: { url: "http://localhost:8080", user: "admin", password: "secret" },
-      specPath: "/v3/api-docs",
-      outDir: "/tmp/generated",
-      fetchAndGenerate: fetchAndGen,
+describe('generateAction', () => {
+    test('calls fetchAndGenerate with correct params', async () => {
+        const fetchAndGen = mock(() => Promise.resolve());
+        await generateAction({
+            env: { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
+            specPath: '/v3/api-docs',
+            outDir: '/tmp/generated',
+            fetchAndGenerate: fetchAndGen,
+        });
+
+        expect(fetchAndGen).toHaveBeenCalledWith({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            outDir: '/tmp/generated',
+            auth: { username: 'admin', password: 'secret' },
+        });
     });
 
-    expect(fetchAndGen).toHaveBeenCalledWith({
-      baseUrl: "http://localhost:8080",
-      specPath: "/v3/api-docs",
-      outDir: "/tmp/generated",
-      auth: { username: "admin", password: "secret" },
+    test('throws when no active environment', () => {
+        expect(generateAction({
+            env: null,
+            specPath: '/v3/api-docs',
+            outDir: '/tmp/generated',
+            fetchAndGenerate: mock(() => Promise.resolve()),
+        })).rejects.toThrow('No active environment');
     });
-  });
-
-  test("throws when no active environment", () => {
-    expect(generateAction({
-      env: null,
-      specPath: "/v3/api-docs",
-      outDir: "/tmp/generated",
-      fetchAndGenerate: mock(() => Promise.resolve()),
-    })).rejects.toThrow("No active environment");
-  });
 });

--- a/src/commands/generate/generate.test.ts
+++ b/src/commands/generate/generate.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect, mock } from "bun:test";
+import { generateAction } from "./generate";
+
+describe("generateAction", () => {
+  test("calls fetchAndGenerate with correct params", async () => {
+    const fetchAndGen = mock(() => Promise.resolve());
+    await generateAction({
+      env: { url: "http://localhost:8080", user: "admin", password: "secret" },
+      specPath: "/v3/api-docs",
+      outDir: "/tmp/generated",
+      fetchAndGenerate: fetchAndGen,
+    });
+
+    expect(fetchAndGen).toHaveBeenCalledWith({
+      baseUrl: "http://localhost:8080",
+      specPath: "/v3/api-docs",
+      outDir: "/tmp/generated",
+      auth: { username: "admin", password: "secret" },
+    });
+  });
+
+  test("throws when no active environment", () => {
+    expect(generateAction({
+      env: null,
+      specPath: "/v3/api-docs",
+      outDir: "/tmp/generated",
+      fetchAndGenerate: mock(() => Promise.resolve()),
+    })).rejects.toThrow("No active environment");
+  });
+});

--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -1,0 +1,50 @@
+import { Command } from 'commander';
+import { getActiveEnvConfig } from '../../config';
+import { fetchAndGenerate as defaultFetchAndGenerate } from '../../codegen/index';
+
+export interface GenerateInput {
+    env: { url: string; user: string; password: string } | null;
+    specPath: string;
+    outDir: string;
+    fetchAndGenerate: (opts: { baseUrl: string; specPath: string; outDir: string; auth: { username: string; password: string } }) => Promise<void>;
+}
+
+export async function generateAction(input: GenerateInput): Promise<void> {
+    if (!input.env) {
+        throw new Error('No active environment.');
+    }
+    await input.fetchAndGenerate({
+        baseUrl: input.env.url,
+        specPath: input.specPath,
+        outDir: input.outDir,
+        auth: { username: input.env.user, password: input.env.password },
+    });
+}
+
+export function registerGenerateCommand(
+    program: Command,
+    cliName: string,
+    specPath: string,
+    generatedDir: string,
+    configOpts?: { configPath: string },
+): void {
+    program
+        .command('generate')
+        .description("Regenerate CLI from the active environment's OpenAPI spec")
+        .action(async () => {
+            const env = getActiveEnvConfig(cliName, configOpts);
+            try {
+                console.log(`Generating from ${env?.url} ...`);
+                await generateAction({
+                    env,
+                    specPath,
+                    outDir: generatedDir,
+                    fetchAndGenerate: defaultFetchAndGenerate,
+                });
+                console.log(`Generated files written to ${generatedDir}`);
+            } catch (err) {
+                console.error('Generation failed:', err instanceof Error ? err.message : String(err));
+                process.exit(1);
+            }
+        });
+}

--- a/src/commands/mcp/mcp.test.ts
+++ b/src/commands/mcp/mcp.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect, mock } from "bun:test";
+import { mcpAction } from "./mcp";
+
+describe("mcpAction", () => {
+  test("calls startMcpServer with correct params", async () => {
+    const startFn = mock(() => Promise.resolve());
+    await mcpAction({
+      cliName: "testcli",
+      cliInvocation: ["node", "testcli"],
+      generatedDir: "/tmp/generated",
+      routinesDir: "/tmp/routines",
+      startMcpServer: startFn,
+    });
+
+    expect(startFn).toHaveBeenCalledWith({
+      cliName: "testcli",
+      cliInvocation: ["node", "testcli"],
+      generatedDir: "/tmp/generated",
+      routinesDir: "/tmp/routines",
+    });
+  });
+
+  test("throws MODULE_NOT_FOUND as user-friendly message", () => {
+    const err = new Error("Cannot find module");
+    expect(mcpAction({
+      cliName: "testcli",
+      cliInvocation: ["node", "testcli"],
+      generatedDir: "/tmp/generated",
+      routinesDir: "/tmp/routines",
+      startMcpServer: mock(() => Promise.reject(err)),
+    })).rejects.toThrow("MCP server requires @modelcontextprotocol/sdk");
+  });
+});

--- a/src/commands/mcp/mcp.test.ts
+++ b/src/commands/mcp/mcp.test.ts
@@ -1,33 +1,33 @@
-import { describe, test, expect, mock } from "bun:test";
-import { mcpAction } from "./mcp";
+import { describe, test, expect, mock } from 'bun:test';
+import { mcpAction } from './mcp';
 
-describe("mcpAction", () => {
-  test("calls startMcpServer with correct params", async () => {
-    const startFn = mock(() => Promise.resolve());
-    await mcpAction({
-      cliName: "testcli",
-      cliInvocation: ["node", "testcli"],
-      generatedDir: "/tmp/generated",
-      routinesDir: "/tmp/routines",
-      startMcpServer: startFn,
+describe('mcpAction', () => {
+    test('calls startMcpServer with correct params', async () => {
+        const startFn = mock(() => Promise.resolve());
+        await mcpAction({
+            cliName: 'testcli',
+            cliInvocation: ['node', 'testcli'],
+            generatedDir: '/tmp/generated',
+            routinesDir: '/tmp/routines',
+            startMcpServer: startFn,
+        });
+
+        expect(startFn).toHaveBeenCalledWith({
+            cliName: 'testcli',
+            cliInvocation: ['node', 'testcli'],
+            generatedDir: '/tmp/generated',
+            routinesDir: '/tmp/routines',
+        });
     });
 
-    expect(startFn).toHaveBeenCalledWith({
-      cliName: "testcli",
-      cliInvocation: ["node", "testcli"],
-      generatedDir: "/tmp/generated",
-      routinesDir: "/tmp/routines",
+    test('throws MODULE_NOT_FOUND as user-friendly message', () => {
+        const err = new Error('Cannot find module');
+        expect(mcpAction({
+            cliName: 'testcli',
+            cliInvocation: ['node', 'testcli'],
+            generatedDir: '/tmp/generated',
+            routinesDir: '/tmp/routines',
+            startMcpServer: mock(() => Promise.reject(err)),
+        })).rejects.toThrow('MCP server requires @modelcontextprotocol/sdk');
     });
-  });
-
-  test("throws MODULE_NOT_FOUND as user-friendly message", () => {
-    const err = new Error("Cannot find module");
-    expect(mcpAction({
-      cliName: "testcli",
-      cliInvocation: ["node", "testcli"],
-      generatedDir: "/tmp/generated",
-      routinesDir: "/tmp/routines",
-      startMcpServer: mock(() => Promise.reject(err)),
-    })).rejects.toThrow("MCP server requires @modelcontextprotocol/sdk");
-  });
 });

--- a/src/commands/mcp/mcp.ts
+++ b/src/commands/mcp/mcp.ts
@@ -1,6 +1,4 @@
 import { Command } from 'commander';
-import { resolve } from 'path';
-import { homedir } from 'os';
 
 export interface McpInput {
     cliName: string;

--- a/src/commands/mcp/mcp.ts
+++ b/src/commands/mcp/mcp.ts
@@ -1,0 +1,57 @@
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { homedir } from 'os';
+
+export interface McpInput {
+    cliName: string;
+    cliInvocation: string[];
+    generatedDir: string;
+    routinesDir: string;
+    startMcpServer: (opts: { cliName: string; cliInvocation: string[]; generatedDir: string; routinesDir: string }) => Promise<void>;
+}
+
+export async function mcpAction(input: McpInput): Promise<void> {
+    try {
+        await input.startMcpServer({
+            cliName: input.cliName,
+            cliInvocation: input.cliInvocation,
+            generatedDir: input.generatedDir,
+            routinesDir: input.routinesDir,
+        });
+    } catch (e: any) {
+        if (
+            e?.code === 'MODULE_NOT_FOUND'
+            || e?.message?.includes('Cannot find module')
+            || e?.message?.includes('Failed to resolve')
+        ) {
+            throw new Error('MCP server requires @modelcontextprotocol/sdk');
+        }
+        throw e;
+    }
+}
+
+export function registerMcpCommand(
+    program: Command,
+    cliName: string,
+    generatedDir: string,
+    routinesDir: string,
+): void {
+    program
+        .command('mcp')
+        .description('Start MCP server for AI agent integration')
+        .action(async () => {
+            try {
+                const { startMcpServer } = await import('../../mcp/server');
+                await mcpAction({
+                    cliName,
+                    cliInvocation: process.argv.slice(0, 2),
+                    generatedDir,
+                    routinesDir,
+                    startMcpServer,
+                });
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : String(err));
+                process.exit(1);
+            }
+        });
+}

--- a/src/commands/routine/init/init.test.ts
+++ b/src/commands/routine/init/init.test.ts
@@ -1,31 +1,31 @@
-import { describe, test, expect, mock } from "bun:test";
-import { routineInitAction } from "./init";
+import { describe, test, expect, mock } from 'bun:test';
+import { routineInitAction } from './init';
 
-describe("routineInitAction", () => {
-  test("copies builtins and returns count", () => {
-    const mkdirFn = mock(() => {});
-    const copyFn = mock(() => {});
-    const result = routineInitAction({
-      routinesDir: "/tmp/routines",
-      builtinDir: "/tmp/builtins",
-      exists: () => true,
-      mkdir: mkdirFn,
-      copy: copyFn,
-      listDir: () => ["setup.yaml", "deploy.yaml", "test.yaml"],
+describe('routineInitAction', () => {
+    test('copies builtins and returns count', () => {
+        const mkdirFn = mock(() => {});
+        const copyFn = mock(() => {});
+        const result = routineInitAction({
+            routinesDir: '/tmp/routines',
+            builtinDir: '/tmp/builtins',
+            exists: () => true,
+            mkdir: mkdirFn,
+            copy: copyFn,
+            listDir: () => ['setup.yaml', 'deploy.yaml', 'test.yaml'],
+        });
+        expect(result.installed).toBe(3);
+        expect(mkdirFn).toHaveBeenCalled();
+        expect(copyFn).toHaveBeenCalled();
     });
-    expect(result.installed).toBe(3);
-    expect(mkdirFn).toHaveBeenCalled();
-    expect(copyFn).toHaveBeenCalled();
-  });
 
-  test("throws when no builtin directory", () => {
-    expect(() => routineInitAction({
-      routinesDir: "/tmp/routines",
-      builtinDir: undefined,
-      exists: () => false,
-      mkdir: mock(() => {}),
-      copy: mock(() => {}),
-      listDir: () => [],
-    })).toThrow("No built-in routines");
-  });
+    test('throws when no builtin directory', () => {
+        expect(() => routineInitAction({
+            routinesDir: '/tmp/routines',
+            builtinDir: undefined,
+            exists: () => false,
+            mkdir: mock(() => {}),
+            copy: mock(() => {}),
+            listDir: () => [],
+        })).toThrow('No built-in routines');
+    });
 });

--- a/src/commands/routine/init/init.test.ts
+++ b/src/commands/routine/init/init.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect, mock } from "bun:test";
+import { routineInitAction } from "./init";
+
+describe("routineInitAction", () => {
+  test("copies builtins and returns count", () => {
+    const mkdirFn = mock(() => {});
+    const copyFn = mock(() => {});
+    const result = routineInitAction({
+      routinesDir: "/tmp/routines",
+      builtinDir: "/tmp/builtins",
+      exists: () => true,
+      mkdir: mkdirFn,
+      copy: copyFn,
+      listDir: () => ["setup.yaml", "deploy.yaml", "test.yaml"],
+    });
+    expect(result.installed).toBe(3);
+    expect(mkdirFn).toHaveBeenCalled();
+    expect(copyFn).toHaveBeenCalled();
+  });
+
+  test("throws when no builtin directory", () => {
+    expect(() => routineInitAction({
+      routinesDir: "/tmp/routines",
+      builtinDir: undefined,
+      exists: () => false,
+      mkdir: mock(() => {}),
+      copy: mock(() => {}),
+      listDir: () => [],
+    })).toThrow("No built-in routines");
+  });
+});

--- a/src/commands/routine/init/init.ts
+++ b/src/commands/routine/init/init.ts
@@ -1,0 +1,23 @@
+export interface RoutineInitDeps {
+    routinesDir: string;
+    builtinDir: string | undefined;
+    exists: (path: string) => boolean;
+    mkdir: (path: string, opts: { recursive: boolean }) => void;
+    copy: (src: string, dest: string, opts: { recursive: boolean }) => void;
+    listDir: (path: string) => string[];
+}
+
+export interface RoutineInitResult {
+    installed: number;
+    routinesDir: string;
+}
+
+export function routineInitAction(deps: RoutineInitDeps): RoutineInitResult {
+    if (!deps.builtinDir || !deps.exists(deps.builtinDir)) {
+        throw new Error('No built-in routines directory found.');
+    }
+    deps.mkdir(deps.routinesDir, { recursive: true });
+    deps.copy(deps.builtinDir, deps.routinesDir, { recursive: true });
+    const routines = deps.listDir(deps.builtinDir);
+    return { installed: routines.length, routinesDir: deps.routinesDir };
+}

--- a/src/commands/routine/list/list.test.ts
+++ b/src/commands/routine/list/list.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from "bun:test";
+import { routineListAction } from "./list";
+
+describe("routineListAction", () => {
+  test("returns routines", () => {
+    const result = routineListAction({
+      listRoutines: () => ["setup/create-project", "deploy/staging"],
+    });
+    expect(result).toEqual(["setup/create-project", "deploy/staging"]);
+  });
+
+  test("filters by path prefix", () => {
+    const routines = ["setup/create-project", "setup/teardown", "deploy/staging"];
+    const result = routineListAction({
+      listRoutines: () => routines,
+      path: "setup",
+    });
+    expect(result).toEqual(["create-project", "teardown"]);
+  });
+
+  test("returns empty when no match", () => {
+    const result = routineListAction({
+      listRoutines: () => ["setup/create-project"],
+      path: "deploy",
+    });
+    expect(result).toEqual([]);
+  });
+});

--- a/src/commands/routine/list/list.test.ts
+++ b/src/commands/routine/list/list.test.ts
@@ -1,28 +1,28 @@
-import { describe, test, expect } from "bun:test";
-import { routineListAction } from "./list";
+import { describe, test, expect } from 'bun:test';
+import { routineListAction } from './list';
 
-describe("routineListAction", () => {
-  test("returns routines", () => {
-    const result = routineListAction({
-      listRoutines: () => ["setup/create-project", "deploy/staging"],
+describe('routineListAction', () => {
+    test('returns routines', () => {
+        const result = routineListAction({
+            listRoutines: () => ['setup/create-project', 'deploy/staging'],
+        });
+        expect(result).toEqual(['setup/create-project', 'deploy/staging']);
     });
-    expect(result).toEqual(["setup/create-project", "deploy/staging"]);
-  });
 
-  test("filters by path prefix", () => {
-    const routines = ["setup/create-project", "setup/teardown", "deploy/staging"];
-    const result = routineListAction({
-      listRoutines: () => routines,
-      path: "setup",
+    test('filters by path prefix', () => {
+        const routines = ['setup/create-project', 'setup/teardown', 'deploy/staging'];
+        const result = routineListAction({
+            listRoutines: () => routines,
+            path: 'setup',
+        });
+        expect(result).toEqual(['create-project', 'teardown']);
     });
-    expect(result).toEqual(["create-project", "teardown"]);
-  });
 
-  test("returns empty when no match", () => {
-    const result = routineListAction({
-      listRoutines: () => ["setup/create-project"],
-      path: "deploy",
+    test('returns empty when no match', () => {
+        const result = routineListAction({
+            listRoutines: () => ['setup/create-project'],
+            path: 'deploy',
+        });
+        expect(result).toEqual([]);
     });
-    expect(result).toEqual([]);
-  });
 });

--- a/src/commands/routine/list/list.ts
+++ b/src/commands/routine/list/list.ts
@@ -1,0 +1,20 @@
+export interface RoutineListDeps {
+    listRoutines: () => string[];
+    path?: string;
+}
+
+export function routineListAction(deps: RoutineListDeps): string[] {
+    const routines = deps.listRoutines();
+    if (!deps.path) return routines;
+
+    const prefix = deps.path.replace(/\/+$/, '');
+    return routines
+        .filter((r) => {
+            const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
+            return clean.startsWith(prefix + '/');
+        })
+        .map((r) => {
+            const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
+            return clean.slice(prefix.length + 1);
+        });
+}

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -94,10 +94,13 @@ export function registerRoutineCommand(
             const sessionMgr = new SessionManager(cliName);
 
             try {
-                console.log('');
+                const def = loadRoutineFile(name, routinesDir, builtinsMap);
+                console.log(
+                    `Running routine: ${def.name}${def.description ? ` — ${def.description}` : ''}\n`,
+                );
                 const startTime = Date.now();
                 const result = await routineRunAction({
-                    loadRoutine: () => loadRoutineFile(name, routinesDir, builtinsMap),
+                    loadRoutine: () => def,
                     validateRoutine,
                     executeRoutine,
                     dispatch,
@@ -111,8 +114,6 @@ export function registerRoutineCommand(
                         process.stderr.write(`\r\x1b[36m[${stepIndex + 1}/${stepTotal}]\x1b[0m ${step.name} \x1b[36m[${current}/${total}]\x1b[0m\x1b[K`);
                     },
                 });
-
-                console.log(`Running routine: ${result.name}${result.description ? ` — ${result.description}` : ''}\n`);
 
                 const elapsed = Date.now() - startTime;
                 const mins = Math.floor(elapsed / 60000);

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -1,0 +1,214 @@
+import { Command } from 'commander';
+import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { CommandDispatcher } from '../../types';
+import { SessionManager } from '../../session';
+import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from '../../routine/loader';
+import { executeRoutine } from '../../routine/executor';
+import { routineListAction } from './list/list';
+import { routineRunAction } from './run/run';
+import { routineValidateAction } from './validate/validate';
+import { routineTestAction } from './test/test';
+import { routineInitAction } from './init/init';
+
+export function loadBuiltinRoutines(builtinDir: string): Record<string, string> | undefined {
+    if (!existsSync(builtinDir)) return undefined;
+    const map: Record<string, string> = {};
+
+    function collect(dir: string, prefix: string) {
+        for (const entry of readdirSync(dir, { withFileTypes: true })) {
+            const fullPath = resolve(dir, entry.name);
+            const key = prefix ? `${prefix}/${entry.name}` : entry.name;
+            if (entry.isDirectory()) {
+                collect(fullPath, key);
+            } else if (
+                entry.isFile()
+                && (entry.name.endsWith('.yaml') || entry.name.endsWith('.yml'))
+            ) {
+                map[key] = readFileSync(fullPath, 'utf-8');
+            }
+        }
+    }
+
+    collect(builtinDir, '');
+    return Object.keys(map).length > 0 ? map : undefined;
+}
+
+export function registerRoutineCommand(
+    program: Command,
+    cliName: string,
+    routinesDir: string,
+    dispatch: CommandDispatcher | undefined,
+    builtinRoutinesDir?: string,
+): void {
+    const builtinsMap = builtinRoutinesDir
+        ? loadBuiltinRoutines(builtinRoutinesDir)
+        : undefined;
+
+    const routine = program
+        .command('routine')
+        .description('Manage and run routines');
+
+    routine
+        .command('list [path]')
+        .description('List available routines (optionally drill into a group)')
+        .option('--tree', 'Show full tree structure')
+        .action((path: string | undefined, opts: { tree?: boolean }) => {
+            const result = routineListAction({
+                listRoutines: () => listRoutines(routinesDir, builtinsMap),
+                path,
+            });
+            if (result.length === 0) {
+                if (path) {
+                    console.log(`No routines found under '${path.replace(/\/+$/, '')}/'`);
+                } else {
+                    console.log(`No routines found in ~/.${cliName}/routines/`);
+                    console.log(`Run '${cliName} routine init' to install built-in routines.`);
+                }
+                return;
+            }
+            console.log(
+                opts.tree
+                    ? formatRoutineTree(result)
+                    : formatRoutineList(result, path?.replace(/\/+$/, '')),
+            );
+        });
+
+    routine
+        .command('run <name>')
+        .description('Execute a routine')
+        .option('--set <pairs...>', 'Override variables (key=value)')
+        .option('--dry-run', 'Print resolved commands without executing')
+        .action(async (name: string, opts: { set?: string[]; dryRun?: boolean }) => {
+            if (!dispatch) {
+                console.error(`No active session. Run '${cliName} setup' first.`);
+                process.exit(2);
+            }
+
+            const overrides: Record<string, unknown> = {};
+            for (const s of opts.set || []) {
+                const eq = s.indexOf('=');
+                if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
+            }
+
+            const sessionMgr = new SessionManager(cliName);
+
+            try {
+                console.log('');
+                const startTime = Date.now();
+                const result = await routineRunAction({
+                    loadRoutine: () => loadRoutineFile(name, routinesDir, builtinsMap),
+                    validateRoutine,
+                    executeRoutine,
+                    dispatch,
+                    overrides,
+                    dryRun: opts.dryRun,
+                    invalidateSession: () => sessionMgr.invalidate(),
+                    onStep: (step, i, total) => {
+                        console.log(`\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}`);
+                    },
+                    onIteration: (step, current, total, stepIndex, stepTotal) => {
+                        process.stderr.write(`\r\x1b[36m[${stepIndex + 1}/${stepTotal}]\x1b[0m ${step.name} \x1b[36m[${current}/${total}]\x1b[0m\x1b[K`);
+                    },
+                });
+
+                console.log(`Running routine: ${result.name}${result.description ? ` — ${result.description}` : ''}\n`);
+
+                const elapsed = Date.now() - startTime;
+                const mins = Math.floor(elapsed / 60000);
+                const secs = ((elapsed % 60000) / 1000).toFixed(1);
+                const timeStr = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+                console.log(
+                    `\nRoutine ${result.success ? '\x1b[32mcompleted\x1b[0m' : '\x1b[31mfailed\x1b[0m'}: ${result.stepsRun} run, ${result.stepsSkipped} skipped, ${result.stepsFailed} failed (${timeStr})`,
+                );
+                if (!result.success) process.exit(1);
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : String(err));
+                process.exit(1);
+            }
+        });
+
+    routine
+        .command('validate <name>')
+        .description('Validate a routine YAML file')
+        .action((name: string) => {
+            const result = routineValidateAction({
+                loadRoutine: () => loadRoutineFile(name, routinesDir, builtinsMap),
+                validateRoutine,
+            });
+            if (!result.valid) {
+                console.error('Validation errors:');
+                for (const e of result.errors) console.error(`  - ${e}`);
+                process.exit(1);
+            }
+            console.log(`Routine "${result.name}" is valid.`);
+        });
+
+    routine
+        .command('test <name>')
+        .description("Run a routine's spec (test) file")
+        .option('--set <pairs...>', 'Override variables (key=value)')
+        .action(async (name: string, opts: { set?: string[] }) => {
+            if (!dispatch) {
+                console.error(`No active session. Run '${cliName} setup' first.`);
+                process.exit(2);
+            }
+
+            const overrides: Record<string, unknown> = {};
+            for (const s of opts.set || []) {
+                const eq = s.indexOf('=');
+                if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
+            }
+
+            try {
+                console.log(`\x1b[36mTesting routine: ${name}\x1b[0m\n`);
+
+                const result = await routineTestAction({
+                    loadSpec: () => loadSpecFile(name, routinesDir, builtinsMap),
+                    validateRoutine,
+                    executeRoutine,
+                    dispatch,
+                    overrides,
+                    routineName: name,
+                    onStep: (step, i, total) => {
+                        console.log(
+                            `\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}${step.assert ? ' \x1b[33m(assert)\x1b[0m' : ''}`,
+                        );
+                    },
+                    onIteration: (step, current, total, stepIndex, stepTotal) => {
+                        process.stderr.write(`\r\x1b[36m[${stepIndex + 1}/${stepTotal}]\x1b[0m ${step.name} \x1b[36m[${current}/${total}]\x1b[0m\x1b[K`);
+                    },
+                });
+
+                console.log('');
+                if (result.success) {
+                    console.log(`\x1b[32mPASSED\x1b[0m: ${result.stepsRun} steps run, ${result.stepsSkipped} skipped`);
+                } else {
+                    console.log(`\x1b[31mFAILED\x1b[0m: ${result.stepsRun} steps run, ${result.stepsFailed} failed`);
+                    process.exit(1);
+                }
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : String(err));
+                process.exit(1);
+            }
+        });
+
+    routine
+        .command('init')
+        .description(`Copy built-in routines to ~/.${cliName}/routines/`)
+        .action(() => {
+            try {
+                const result = routineInitAction({
+                    routinesDir,
+                    builtinDir: builtinRoutinesDir,
+                    exists: existsSync,
+                    mkdir: mkdirSync,
+                    copy: cpSync,
+                    listDir: readdirSync as any,
+                });
+                console.log(`Installed ${result.installed} routines to ${result.routinesDir}`);
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : String(err));
+            }
+        });
+}

--- a/src/commands/routine/run/run.test.ts
+++ b/src/commands/routine/run/run.test.ts
@@ -1,28 +1,28 @@
-import { describe, test, expect, mock } from "bun:test";
-import { routineRunAction } from "./run";
+import { describe, test, expect, mock } from 'bun:test';
+import { routineRunAction } from './run';
 
-describe("routineRunAction", () => {
-  test("executes routine and returns result", async () => {
-    const result = await routineRunAction({
-      loadRoutine: () => ({ name: "test-routine", description: "A test", steps: [] }),
-      validateRoutine: () => [],
-      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 2, stepsSkipped: 0, stepsFailed: 0 })),
-      dispatch: mock(() => Promise.resolve({})),
-      overrides: {},
-      invalidateSession: mock(() => {}),
+describe('routineRunAction', () => {
+    test('executes routine and returns result', async () => {
+        const result = await routineRunAction({
+            loadRoutine: () => ({ name: 'test-routine', description: 'A test', steps: [] }),
+            validateRoutine: () => [],
+            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 2, stepsSkipped: 0, stepsFailed: 0 })),
+            dispatch: mock(() => Promise.resolve({})),
+            overrides: {},
+            invalidateSession: mock(() => {}),
+        });
+        expect(result.success).toBe(true);
+        expect(result.stepsRun).toBe(2);
     });
-    expect(result.success).toBe(true);
-    expect(result.stepsRun).toBe(2);
-  });
 
-  test("throws on validation errors", () => {
-    expect(routineRunAction({
-      loadRoutine: () => ({ name: "bad", steps: [] }),
-      validateRoutine: () => ["missing steps"],
-      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
-      dispatch: mock(() => Promise.resolve({})),
-      overrides: {},
-      invalidateSession: mock(() => {}),
-    })).rejects.toThrow("Validation errors");
-  });
+    test('throws on validation errors', () => {
+        expect(routineRunAction({
+            loadRoutine: () => ({ name: 'bad', steps: [] }),
+            validateRoutine: () => ['missing steps'],
+            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+            dispatch: mock(() => Promise.resolve({})),
+            overrides: {},
+            invalidateSession: mock(() => {}),
+        })).rejects.toThrow('Validation errors');
+    });
 });

--- a/src/commands/routine/run/run.test.ts
+++ b/src/commands/routine/run/run.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect, mock } from "bun:test";
+import { routineRunAction } from "./run";
+
+describe("routineRunAction", () => {
+  test("executes routine and returns result", async () => {
+    const result = await routineRunAction({
+      loadRoutine: () => ({ name: "test-routine", description: "A test", steps: [] }),
+      validateRoutine: () => [],
+      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 2, stepsSkipped: 0, stepsFailed: 0 })),
+      dispatch: mock(() => Promise.resolve({})),
+      overrides: {},
+      invalidateSession: mock(() => {}),
+    });
+    expect(result.success).toBe(true);
+    expect(result.stepsRun).toBe(2);
+  });
+
+  test("throws on validation errors", () => {
+    expect(routineRunAction({
+      loadRoutine: () => ({ name: "bad", steps: [] }),
+      validateRoutine: () => ["missing steps"],
+      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+      dispatch: mock(() => Promise.resolve({})),
+      overrides: {},
+      invalidateSession: mock(() => {}),
+    })).rejects.toThrow("Validation errors");
+  });
+});

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -1,0 +1,31 @@
+import type { CommandDispatcher } from '../../../types';
+
+export interface RoutineRunDeps {
+    loadRoutine: () => any;
+    validateRoutine: (def: any) => string[];
+    executeRoutine: (def: any, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: any) => Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }>;
+    dispatch: CommandDispatcher;
+    overrides: Record<string, unknown>;
+    dryRun?: boolean;
+    invalidateSession: () => void;
+    onStep?: (step: any, i: number, total: number) => void;
+    onIteration?: (step: any, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+}
+
+export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number; name: string; description?: string }> {
+    const def = deps.loadRoutine();
+    const errors = deps.validateRoutine(def);
+    if (errors.length > 0) {
+        throw new Error(`Validation errors:\n${errors.map(e => `  - ${e}`).join('\n')}`);
+    }
+
+    deps.invalidateSession();
+
+    const result = await deps.executeRoutine(def, deps.overrides, deps.dispatch, {
+        dryRun: deps.dryRun,
+        onStep: deps.onStep,
+        onIteration: deps.onIteration,
+    });
+
+    return { ...result, name: def.name, description: def.description };
+}

--- a/src/commands/routine/test/test.test.ts
+++ b/src/commands/routine/test/test.test.ts
@@ -1,0 +1,26 @@
+import { describe, test, expect, mock } from "bun:test";
+import { routineTestAction } from "./test";
+
+describe("routineTestAction", () => {
+  test("executes spec and returns result", async () => {
+    const result = await routineTestAction({
+      loadSpec: () => ({ name: "test-spec", description: "A test", steps: [] }),
+      validateRoutine: () => [],
+      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 3, stepsSkipped: 0, stepsFailed: 0 })),
+      dispatch: mock(() => Promise.resolve({})),
+      overrides: {},
+    });
+    expect(result.success).toBe(true);
+    expect(result.stepsRun).toBe(3);
+  });
+
+  test("throws when no spec found", () => {
+    expect(routineTestAction({
+      loadSpec: () => null,
+      validateRoutine: () => [],
+      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+      dispatch: mock(() => Promise.resolve({})),
+      overrides: {},
+    })).rejects.toThrow("No spec.yaml found");
+  });
+});

--- a/src/commands/routine/test/test.test.ts
+++ b/src/commands/routine/test/test.test.ts
@@ -1,26 +1,26 @@
-import { describe, test, expect, mock } from "bun:test";
-import { routineTestAction } from "./test";
+import { describe, test, expect, mock } from 'bun:test';
+import { routineTestAction } from './test';
 
-describe("routineTestAction", () => {
-  test("executes spec and returns result", async () => {
-    const result = await routineTestAction({
-      loadSpec: () => ({ name: "test-spec", description: "A test", steps: [] }),
-      validateRoutine: () => [],
-      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 3, stepsSkipped: 0, stepsFailed: 0 })),
-      dispatch: mock(() => Promise.resolve({})),
-      overrides: {},
+describe('routineTestAction', () => {
+    test('executes spec and returns result', async () => {
+        const result = await routineTestAction({
+            loadSpec: () => ({ name: 'test-spec', description: 'A test', steps: [] }),
+            validateRoutine: () => [],
+            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 3, stepsSkipped: 0, stepsFailed: 0 })),
+            dispatch: mock(() => Promise.resolve({})),
+            overrides: {},
+        });
+        expect(result.success).toBe(true);
+        expect(result.stepsRun).toBe(3);
     });
-    expect(result.success).toBe(true);
-    expect(result.stepsRun).toBe(3);
-  });
 
-  test("throws when no spec found", () => {
-    expect(routineTestAction({
-      loadSpec: () => null,
-      validateRoutine: () => [],
-      executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
-      dispatch: mock(() => Promise.resolve({})),
-      overrides: {},
-    })).rejects.toThrow("No spec.yaml found");
-  });
+    test('throws when no spec found', () => {
+        expect(routineTestAction({
+            loadSpec: () => null,
+            validateRoutine: () => [],
+            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+            dispatch: mock(() => Promise.resolve({})),
+            overrides: {},
+        })).rejects.toThrow('No spec.yaml found');
+    });
 });

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -1,0 +1,29 @@
+import type { CommandDispatcher } from '../../../types';
+
+export interface RoutineTestDeps {
+    loadSpec: () => any | null;
+    validateRoutine: (def: any) => string[];
+    executeRoutine: (def: any, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: any) => Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }>;
+    dispatch: CommandDispatcher;
+    overrides: Record<string, unknown>;
+    routineName?: string;
+    onStep?: (step: any, i: number, total: number) => void;
+    onIteration?: (step: any, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+}
+
+export async function routineTestAction(deps: RoutineTestDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }> {
+    const spec = deps.loadSpec();
+    if (!spec) {
+        throw new Error(`No spec.yaml found for routine "${deps.routineName}".`);
+    }
+
+    const errors = deps.validateRoutine(spec);
+    if (errors.length > 0) {
+        throw new Error(`Spec validation errors:\n${errors.map(e => `  - ${e}`).join('\n')}`);
+    }
+
+    return deps.executeRoutine(spec, deps.overrides, deps.dispatch, {
+        onStep: deps.onStep,
+        onIteration: deps.onIteration,
+    });
+}

--- a/src/commands/routine/validate/validate.test.ts
+++ b/src/commands/routine/validate/validate.test.ts
@@ -1,22 +1,22 @@
-import { describe, test, expect } from "bun:test";
-import { routineValidateAction } from "./validate";
+import { describe, test, expect } from 'bun:test';
+import { routineValidateAction } from './validate';
 
-describe("routineValidateAction", () => {
-  test("returns valid for correct routine", () => {
-    const result = routineValidateAction({
-      loadRoutine: () => ({ name: "test", steps: [] }),
-      validateRoutine: () => [],
+describe('routineValidateAction', () => {
+    test('returns valid for correct routine', () => {
+        const result = routineValidateAction({
+            loadRoutine: () => ({ name: 'test', steps: [] }),
+            validateRoutine: () => [],
+        });
+        expect(result.valid).toBe(true);
+        expect(result.name).toBe('test');
     });
-    expect(result.valid).toBe(true);
-    expect(result.name).toBe("test");
-  });
 
-  test("returns errors for invalid routine", () => {
-    const result = routineValidateAction({
-      loadRoutine: () => ({ name: "test", steps: [] }),
-      validateRoutine: () => ["missing name", "empty steps"],
+    test('returns errors for invalid routine', () => {
+        const result = routineValidateAction({
+            loadRoutine: () => ({ name: 'test', steps: [] }),
+            validateRoutine: () => ['missing name', 'empty steps'],
+        });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual(['missing name', 'empty steps']);
     });
-    expect(result.valid).toBe(false);
-    expect(result.errors).toEqual(["missing name", "empty steps"]);
-  });
 });

--- a/src/commands/routine/validate/validate.test.ts
+++ b/src/commands/routine/validate/validate.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "bun:test";
+import { routineValidateAction } from "./validate";
+
+describe("routineValidateAction", () => {
+  test("returns valid for correct routine", () => {
+    const result = routineValidateAction({
+      loadRoutine: () => ({ name: "test", steps: [] }),
+      validateRoutine: () => [],
+    });
+    expect(result.valid).toBe(true);
+    expect(result.name).toBe("test");
+  });
+
+  test("returns errors for invalid routine", () => {
+    const result = routineValidateAction({
+      loadRoutine: () => ({ name: "test", steps: [] }),
+      validateRoutine: () => ["missing name", "empty steps"],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(["missing name", "empty steps"]);
+  });
+});

--- a/src/commands/routine/validate/validate.ts
+++ b/src/commands/routine/validate/validate.ts
@@ -1,0 +1,16 @@
+export interface RoutineValidateDeps {
+    loadRoutine: () => { name: string; steps: unknown[] };
+    validateRoutine: (def: any) => string[];
+}
+
+export interface RoutineValidateResult {
+    valid: boolean;
+    name: string;
+    errors: string[];
+}
+
+export function routineValidateAction(deps: RoutineValidateDeps): RoutineValidateResult {
+    const def = deps.loadRoutine();
+    const errors = deps.validateRoutine(def);
+    return { valid: errors.length === 0, name: def.name, errors };
+}

--- a/src/commands/setup/setup.test.ts
+++ b/src/commands/setup/setup.test.ts
@@ -1,61 +1,61 @@
-import { describe, test, expect, mock } from "bun:test";
-import { setupAction } from "./setup";
+import { describe, test, expect, mock } from 'bun:test';
+import { setupAction } from './setup';
 
-describe("setupAction", () => {
-  test("calls saveEnvironment with provided credentials", async () => {
-    const saveFn = mock(() => Promise.resolve());
-    const verifyFn = mock(() => Promise.resolve({ ok: true }));
+describe('setupAction', () => {
+    test('calls saveEnvironment with provided credentials', async () => {
+        const saveFn = mock(() => Promise.resolve());
+        const verifyFn = mock(() => Promise.resolve({ ok: true }));
 
-    const result = await setupAction({
-      cliName: "testcli",
-      envName: "default",
-      url: "http://localhost:8080",
-      user: "admin",
-      password: "secret",
-      verify: verifyFn,
-      save: saveFn,
+        const result = await setupAction({
+            cliName: 'testcli',
+            envName: 'default',
+            url: 'http://localhost:8080',
+            user: 'admin',
+            password: 'secret',
+            verify: verifyFn,
+            save: saveFn,
+        });
+
+        expect(result.saved).toBe(true);
+        expect(result.verified).toBe(true);
+        expect(saveFn).toHaveBeenCalledWith(
+            'testcli', 'default',
+            { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
+            true, {},
+        );
     });
 
-    expect(result.saved).toBe(true);
-    expect(result.verified).toBe(true);
-    expect(saveFn).toHaveBeenCalledWith(
-      "testcli", "default",
-      { url: "http://localhost:8080", user: "admin", password: "secret" },
-      true, {},
-    );
-  });
+    test('returns verified=false when verification fails', async () => {
+        const saveFn = mock(() => Promise.resolve());
+        const verifyFn = mock(() => Promise.resolve({ ok: false, reason: 'Connection refused' }));
 
-  test("returns verified=false when verification fails", async () => {
-    const saveFn = mock(() => Promise.resolve());
-    const verifyFn = mock(() => Promise.resolve({ ok: false, reason: "Connection refused" }));
+        const result = await setupAction({
+            cliName: 'testcli',
+            envName: 'default',
+            url: 'http://localhost:8080',
+            user: 'admin',
+            password: 'secret',
+            verify: verifyFn,
+            save: saveFn,
+        });
 
-    const result = await setupAction({
-      cliName: "testcli",
-      envName: "default",
-      url: "http://localhost:8080",
-      user: "admin",
-      password: "secret",
-      verify: verifyFn,
-      save: saveFn,
+        expect(result.saved).toBe(true);
+        expect(result.verified).toBe(false);
+        expect(result.verifyReason).toBe('Connection refused');
     });
 
-    expect(result.saved).toBe(true);
-    expect(result.verified).toBe(false);
-    expect(result.verifyReason).toBe("Connection refused");
-  });
+    test('throws when save fails', async () => {
+        const saveFn = mock(() => Promise.reject(new Error('disk full')));
+        const verifyFn = mock(() => Promise.resolve({ ok: true }));
 
-  test("throws when save fails", async () => {
-    const saveFn = mock(() => Promise.reject(new Error("disk full")));
-    const verifyFn = mock(() => Promise.resolve({ ok: true }));
-
-    expect(setupAction({
-      cliName: "testcli",
-      envName: "default",
-      url: "http://localhost:8080",
-      user: "admin",
-      password: "secret",
-      verify: verifyFn,
-      save: saveFn,
-    })).rejects.toThrow("disk full");
-  });
+        expect(setupAction({
+            cliName: 'testcli',
+            envName: 'default',
+            url: 'http://localhost:8080',
+            user: 'admin',
+            password: 'secret',
+            verify: verifyFn,
+            save: saveFn,
+        })).rejects.toThrow('disk full');
+    });
 });

--- a/src/commands/setup/setup.test.ts
+++ b/src/commands/setup/setup.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect, mock } from "bun:test";
+import { setupAction } from "./setup";
+
+describe("setupAction", () => {
+  test("calls saveEnvironment with provided credentials", async () => {
+    const saveFn = mock(() => Promise.resolve());
+    const verifyFn = mock(() => Promise.resolve({ ok: true }));
+
+    const result = await setupAction({
+      cliName: "testcli",
+      envName: "default",
+      url: "http://localhost:8080",
+      user: "admin",
+      password: "secret",
+      verify: verifyFn,
+      save: saveFn,
+    });
+
+    expect(result.saved).toBe(true);
+    expect(result.verified).toBe(true);
+    expect(saveFn).toHaveBeenCalledWith(
+      "testcli", "default",
+      { url: "http://localhost:8080", user: "admin", password: "secret" },
+      true, {},
+    );
+  });
+
+  test("returns verified=false when verification fails", async () => {
+    const saveFn = mock(() => Promise.resolve());
+    const verifyFn = mock(() => Promise.resolve({ ok: false, reason: "Connection refused" }));
+
+    const result = await setupAction({
+      cliName: "testcli",
+      envName: "default",
+      url: "http://localhost:8080",
+      user: "admin",
+      password: "secret",
+      verify: verifyFn,
+      save: saveFn,
+    });
+
+    expect(result.saved).toBe(true);
+    expect(result.verified).toBe(false);
+    expect(result.verifyReason).toBe("Connection refused");
+  });
+
+  test("throws when save fails", async () => {
+    const saveFn = mock(() => Promise.reject(new Error("disk full")));
+    const verifyFn = mock(() => Promise.resolve({ ok: true }));
+
+    expect(setupAction({
+      cliName: "testcli",
+      envName: "default",
+      url: "http://localhost:8080",
+      user: "admin",
+      password: "secret",
+      verify: verifyFn,
+      save: saveFn,
+    })).rejects.toThrow("disk full");
+  });
+});

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -1,0 +1,97 @@
+import { Command } from 'commander';
+import { saveEnvironment, verifyCredentials } from '../../config';
+import { prompt, hiddenPrompt } from '../../prompt';
+
+export interface SetupInput {
+    cliName: string;
+    envName: string;
+    url: string;
+    user: string;
+    password: string;
+    verify: (url: string, user: string, password: string) => Promise<{ ok: boolean; reason?: string }>;
+    save: (cliName: string, envName: string, creds: { url: string; user: string; password: string }, switchTo: boolean, opts: Record<string, unknown>) => Promise<void>;
+    saveOpts?: Record<string, unknown>;
+}
+
+export interface SetupResult {
+    saved: boolean;
+    verified: boolean;
+    verifyReason?: string;
+    envName: string;
+}
+
+export async function setupAction(input: SetupInput): Promise<SetupResult> {
+    const { cliName, envName, url, user, password, verify, save, saveOpts } = input;
+
+    const verifyResult = await verify(url, user, password);
+
+    await save(cliName, envName, { url, user, password }, true, saveOpts ?? {});
+
+    return {
+        saved: true,
+        verified: verifyResult.ok,
+        verifyReason: verifyResult.ok ? undefined : verifyResult.reason,
+        envName,
+    };
+}
+
+export function registerSetupCommand(
+    program: Command,
+    cliName: string,
+    opts?: {
+        allowedCidrs?: string[];
+        configPath?: string;
+    },
+): void {
+    const action = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
+        console.log(`${cliName} Setup\n`);
+
+        const envName = await prompt('Environment name [default]: ', 'default');
+        const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+        const user = await prompt('Username/Email: ');
+        const password = await hiddenPrompt('Password: ');
+
+        if (!user || !password) {
+            console.error('Setup cancelled.');
+            process.exit(2);
+        }
+
+        const configOpts = opts?.configPath ? { configPath: opts.configPath } : undefined;
+
+        const result = await setupAction({
+            cliName,
+            envName,
+            url,
+            user,
+            password,
+            verify: verifyCredentials,
+            save: saveEnvironment,
+            saveOpts: {
+                ...configOpts,
+                allowInsecureStorage: cmdOpts.allowInsecureStorage,
+                allowedCidrs: opts?.allowedCidrs,
+            },
+        });
+
+        if (!result.verified) {
+            console.error(result.verifyReason);
+            console.error("Credentials saved anyway — they'll be used when the server is available.");
+        } else {
+            console.log('Credentials verified.');
+        }
+
+        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+        console.log(`Switched to '${envName}'\n`);
+    };
+
+    program
+        .command('setup')
+        .description('Interactive setup — configure URL and credentials')
+        .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
+        .action(action);
+    program
+        .command('login')
+        .description('Alias for setup')
+        .option('--allow-insecure-storage', 'Allow plaintext storage for production URLs')
+        .action(action);
+}

--- a/src/commands/upgrade/upgrade.test.ts
+++ b/src/commands/upgrade/upgrade.test.ts
@@ -1,40 +1,40 @@
-import { describe, test, expect, mock } from "bun:test";
-import { upgradeAction } from "./upgrade";
+import { describe, test, expect, mock } from 'bun:test';
+import { upgradeAction } from './upgrade';
 
-describe("upgradeAction", () => {
-  test("returns null when already on latest", async () => {
-    const result = await upgradeAction({
-      currentVersion: "1.2.0",
-      checkLatest: async () => "1.2.0",
-      install: mock(() => Promise.resolve(0)),
+describe('upgradeAction', () => {
+    test('returns null when already on latest', async () => {
+        const result = await upgradeAction({
+            currentVersion: '1.2.0',
+            checkLatest: async () => '1.2.0',
+            install: mock(() => Promise.resolve(0)),
+        });
+        expect(result).toBeNull();
     });
-    expect(result).toBeNull();
-  });
 
-  test("returns versions when upgrade available and install succeeds", async () => {
-    const installFn = mock(() => Promise.resolve(0));
-    const result = await upgradeAction({
-      currentVersion: "1.2.0",
-      checkLatest: async () => "1.3.0",
-      install: installFn,
+    test('returns versions when upgrade available and install succeeds', async () => {
+        const installFn = mock(() => Promise.resolve(0));
+        const result = await upgradeAction({
+            currentVersion: '1.2.0',
+            checkLatest: async () => '1.3.0',
+            install: installFn,
+        });
+        expect(result).toEqual({ previousVersion: '1.2.0', newVersion: '1.3.0' });
+        expect(installFn).toHaveBeenCalledWith('1.3.0');
     });
-    expect(result).toEqual({ previousVersion: "1.2.0", newVersion: "1.3.0" });
-    expect(installFn).toHaveBeenCalledWith("1.3.0");
-  });
 
-  test("throws when install fails", () => {
-    expect(upgradeAction({
-      currentVersion: "1.2.0",
-      checkLatest: async () => "1.3.0",
-      install: mock(() => Promise.resolve(1)),
-    })).rejects.toThrow("Upgrade failed");
-  });
+    test('throws when install fails', () => {
+        expect(upgradeAction({
+            currentVersion: '1.2.0',
+            checkLatest: async () => '1.3.0',
+            install: mock(() => Promise.resolve(1)),
+        })).rejects.toThrow('Upgrade failed');
+    });
 
-  test("throws when registry check fails", () => {
-    expect(upgradeAction({
-      currentVersion: "1.2.0",
-      checkLatest: async () => { throw new Error("network"); },
-      install: mock(() => Promise.resolve(0)),
-    })).rejects.toThrow("network");
-  });
+    test('throws when registry check fails', () => {
+        expect(upgradeAction({
+            currentVersion: '1.2.0',
+            checkLatest: async () => { throw new Error('network'); },
+            install: mock(() => Promise.resolve(0)),
+        })).rejects.toThrow('network');
+    });
 });

--- a/src/commands/upgrade/upgrade.test.ts
+++ b/src/commands/upgrade/upgrade.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, mock } from "bun:test";
+import { upgradeAction } from "./upgrade";
+
+describe("upgradeAction", () => {
+  test("returns null when already on latest", async () => {
+    const result = await upgradeAction({
+      currentVersion: "1.2.0",
+      checkLatest: async () => "1.2.0",
+      install: mock(() => Promise.resolve(0)),
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns versions when upgrade available and install succeeds", async () => {
+    const installFn = mock(() => Promise.resolve(0));
+    const result = await upgradeAction({
+      currentVersion: "1.2.0",
+      checkLatest: async () => "1.3.0",
+      install: installFn,
+    });
+    expect(result).toEqual({ previousVersion: "1.2.0", newVersion: "1.3.0" });
+    expect(installFn).toHaveBeenCalledWith("1.3.0");
+  });
+
+  test("throws when install fails", () => {
+    expect(upgradeAction({
+      currentVersion: "1.2.0",
+      checkLatest: async () => "1.3.0",
+      install: mock(() => Promise.resolve(1)),
+    })).rejects.toThrow("Upgrade failed");
+  });
+
+  test("throws when registry check fails", () => {
+    expect(upgradeAction({
+      currentVersion: "1.2.0",
+      checkLatest: async () => { throw new Error("network"); },
+      install: mock(() => Promise.resolve(0)),
+    })).rejects.toThrow("network");
+  });
+});

--- a/src/commands/upgrade/upgrade.ts
+++ b/src/commands/upgrade/upgrade.ts
@@ -1,0 +1,72 @@
+import { Command } from 'commander';
+
+export interface UpgradeInput {
+    currentVersion: string;
+    checkLatest: () => Promise<string>;
+    install: (version: string) => Promise<number>;
+}
+
+export interface UpgradeResult {
+    previousVersion: string;
+    newVersion: string;
+}
+
+export async function upgradeAction(input: UpgradeInput): Promise<UpgradeResult | null> {
+    const latest = await input.checkLatest();
+    if (latest === input.currentVersion) return null;
+
+    const exitCode = await input.install(latest);
+    if (exitCode !== 0) throw new Error('Upgrade failed.');
+
+    return { previousVersion: input.currentVersion, newVersion: latest };
+}
+
+async function checkNpmLatest(): Promise<string> {
+    const res = await fetch('https://registry.npmjs.org/@apijack/core/latest');
+    if (!res.ok) throw new Error('Failed to check for updates.');
+    const data = await res.json() as { version: string };
+    return data.version;
+}
+
+async function bunInstallGlobal(version: string): Promise<number> {
+    const proc = Bun.spawn(['bun', 'install', '-g', `@apijack/core@${version}`], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+    return proc.exited;
+}
+
+export function registerUpgradeCommand(program: Command, version: string): void {
+    program
+        .command('upgrade')
+        .description('Check for and install the latest version')
+        .action(async () => {
+            try {
+                const result = await upgradeAction({
+                    currentVersion: version,
+                    checkLatest: checkNpmLatest,
+                    install: bunInstallGlobal,
+                });
+
+                if (!result) {
+                    console.log(`Already on the latest version (v${version}).`);
+                    return;
+                }
+
+                console.log(`v${result.previousVersion} → v${result.newVersion}`);
+
+                // Update plugin registration
+                const pluginProc = Bun.spawn([...process.argv.slice(0, 2), 'plugin', 'install'], {
+                    stdout: 'inherit',
+                    stderr: 'inherit',
+                    env: { ...process.env, APIJACK_SKIP_UPDATE: '1' },
+                });
+                await pluginProc.exited;
+
+                console.log(`Upgraded to v${result.newVersion}.`);
+            } catch (err) {
+                console.error(err instanceof Error ? err.message : String(err));
+                process.exit(1);
+            }
+        });
+}


### PR DESCRIPTION
## Commits

- chore(release): v1.2.0
- fix: restore correct behavior in routine banner, auto-setup exit, and update-password prompt ordering
- style: fix lint in extracted command modules
- refactor: rewire cli-builder.ts to use extracted commands
- refactor: extract routine commands to src/commands/routine/
- refactor: extract config commands to src/commands/config/
- refactor: extract mcp command to src/commands/mcp/
- refactor: extract upgrade command to src/commands/upgrade/
- refactor: extract generate command to src/commands/generate/
- refactor: extract setup command to src/commands/setup/
- feat: add upgrade command

---
Shipped via `scripts/ship.sh`