### PR TITLE
feat: add Windows support with CI matrix and cross-platform fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   codegen-petstore:
-    name: "Petstore (OAS 3.0)"
-    runs-on: ubuntu-latest
+    name: "Petstore (OAS 3.0) — ${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -17,26 +20,36 @@ jobs:
           bun-version: latest
       - run: bun install
       - name: Generate from petstore fixture
-        run: |
-          mkdir -p /tmp/generated
+        run: >
           bun -e "
             import { generate } from './src/codegen/index.ts';
             import spec from './tests/fixtures/petstore.json';
-            await generate({ spec, outDir: '/tmp/generated' });
+            import { mkdirSync } from 'fs';
+            import { join } from 'path';
+            const outDir = join(process.cwd(), 'codegen-out');
+            mkdirSync(outDir, { recursive: true });
+            await generate({ spec, outDir });
           "
       - name: Verify generated files exist and parse
-        run: |
-          test -f /tmp/generated/types.ts
-          test -f /tmp/generated/client.ts
-          test -f /tmp/generated/commands.ts
-          test -f /tmp/generated/command-map.ts
-          bun -e "await import('/tmp/generated/types.ts')"
-          bun -e "await import('/tmp/generated/command-map.ts')"
-          echo "All 4 files generated and valid"
+        run: >
+          bun -e "
+            import { existsSync } from 'fs';
+            import { join } from 'path';
+            const d = join(process.cwd(), 'codegen-out');
+            for (const f of ['types.ts', 'client.ts', 'commands.ts', 'command-map.ts']) {
+              if (!existsSync(join(d, f))) throw new Error(f + ' not generated');
+            }
+            await import(join(d, 'types.ts'));
+            await import(join(d, 'command-map.ts'));
+            console.log('All 4 files generated and valid');
+          "
 
   codegen-edge-cases:
-    name: "Edge Cases Stress Test"
-    runs-on: ubuntu-latest
+    name: "Edge Cases Stress Test — ${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -44,26 +57,36 @@ jobs:
           bun-version: latest
       - run: bun install
       - name: Generate from edge-cases fixture
-        run: |
-          mkdir -p /tmp/generated
+        run: >
           bun -e "
             import { generate } from './src/codegen/index.ts';
             import spec from './tests/fixtures/edge-cases.json';
-            await generate({ spec, outDir: '/tmp/generated' });
+            import { mkdirSync } from 'fs';
+            import { join } from 'path';
+            const outDir = join(process.cwd(), 'codegen-out');
+            mkdirSync(outDir, { recursive: true });
+            await generate({ spec, outDir });
           "
       - name: Verify generated files exist and parse
-        run: |
-          test -f /tmp/generated/types.ts
-          test -f /tmp/generated/client.ts
-          test -f /tmp/generated/commands.ts
-          test -f /tmp/generated/command-map.ts
-          bun -e "await import('/tmp/generated/types.ts')"
-          bun -e "await import('/tmp/generated/command-map.ts')"
-          echo "All 4 files generated and valid"
+        run: >
+          bun -e "
+            import { existsSync } from 'fs';
+            import { join } from 'path';
+            const d = join(process.cwd(), 'codegen-out');
+            for (const f of ['types.ts', 'client.ts', 'commands.ts', 'command-map.ts']) {
+              if (!existsSync(join(d, f))) throw new Error(f + ' not generated');
+            }
+            await import(join(d, 'types.ts'));
+            await import(join(d, 'command-map.ts'));
+            console.log('All 4 files generated and valid');
+          "
 
   codegen-oas31:
-    name: "OAS 3.1 Features"
-    runs-on: ubuntu-latest
+    name: "OAS 3.1 Features — ${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
@@ -71,19 +94,26 @@ jobs:
           bun-version: latest
       - run: bun install
       - name: Generate from OAS 3.1 fixture
-        run: |
-          mkdir -p /tmp/generated
+        run: >
           bun -e "
             import { generate } from './src/codegen/index.ts';
             import spec from './tests/fixtures/oas31.json';
-            await generate({ spec, outDir: '/tmp/generated' });
+            import { mkdirSync } from 'fs';
+            import { join } from 'path';
+            const outDir = join(process.cwd(), 'codegen-out');
+            mkdirSync(outDir, { recursive: true });
+            await generate({ spec, outDir });
           "
       - name: Verify generated files exist and parse
-        run: |
-          test -f /tmp/generated/types.ts
-          test -f /tmp/generated/client.ts
-          test -f /tmp/generated/commands.ts
-          test -f /tmp/generated/command-map.ts
-          bun -e "await import('/tmp/generated/types.ts')"
-          bun -e "await import('/tmp/generated/command-map.ts')"
-          echo "All 4 files generated and valid"
+        run: >
+          bun -e "
+            import { existsSync } from 'fs';
+            import { join } from 'path';
+            const d = join(process.cwd(), 'codegen-out');
+            for (const f of ['types.ts', 'client.ts', 'commands.ts', 'command-map.ts']) {
+              if (!existsSync(join(d, f))) throw new Error(f + ' not generated');
+            }
+            await import(join(d, 'types.ts'));
+            await import(join(d, 'command-map.ts'));
+            console.log('All 4 files generated and valid');
+          "

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.2.1",
+  "version": "1.3.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, parse } from 'path';
 import { homedir } from 'os';
 
 export interface ProjectConfig {
@@ -12,7 +12,7 @@ export interface ProjectConfig {
 
 export function findProjectConfig(startDir: string): string | null {
     let dir = resolve(startDir);
-    const root = resolve('/');
+    const root = parse(resolve(startDir)).root;
 
     while (dir !== root) {
         const candidate = join(dir, '.apijack.json');

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import { homedir } from 'os';
 import type { AuthStrategy, AuthSession, ResolvedAuth } from './auth/types';
 
@@ -8,7 +8,7 @@ export class SessionManager {
 
     constructor(cliName: string, sessionPathOverride?: string) {
         this.sessionPath
-            = sessionPathOverride ?? `${homedir()}/.${cliName}/session.json`;
+            = sessionPathOverride ?? join(homedir(), `.${cliName}`, 'session.json');
     }
 
     async resolve(

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -50,7 +50,7 @@ describe("installPlugin()", () => {
 
   test("returns plugin dir inside local marketplace", async () => {
     const result = await installPlugin(makeOpts());
-    expect(result.marketplaceDir).toContain("marketplaces/local/apijack");
+    expect(result.marketplaceDir).toContain(join("marketplaces", "local", "apijack"));
   });
 
   test("copies skills to plugin dir", async () => {

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, afterEach } from 'bun:test';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir, type ProjectConfig } from '../src/project';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-project-test-' + Date.now());
@@ -85,8 +85,9 @@ describe('loadProjectConfig()', () => {
 
 describe('resolveConfigDir()', () => {
     test('returns project .apijack/ dir when project config path provided', () => {
-        const result = resolveConfigDir('/home/user/myproject/.apijack.json');
-        expect(result).toBe('/home/user/myproject/.apijack');
+        const configPath = join('/home', 'user', 'myproject', '.apijack.json');
+        const result = resolveConfigDir(configPath);
+        expect(result).toBe(join(dirname(configPath), '.apijack'));
     });
 
     test('returns global dir when no project config', () => {


### PR DESCRIPTION
## Summary
- Fix cross-platform root detection in `project.ts` (`path.parse().root` instead of `resolve('/')`)
- Fix session path construction in `session.ts` (`path.join()` instead of template literal)
- Fix platform-dependent test assertions in `project.test.ts`
- Add `windows-latest` to CI unit test and E2E workflow matrices
- Rewrite E2E workflow steps as cross-platform Bun scripts (replacing `mkdir -p`, `test -f`, hardcoded `/tmp/`)

## Test plan
- [x] All 621 unit tests pass locally
- [x] Lint clean (0 errors)
- [ ] CI passes on ubuntu-latest (existing)
- [ ] CI passes on windows-latest (new)
- [ ] E2E codegen passes on both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)