### PR TITLE
dev → main (10 commits)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Garret"
   },
-  "repository": "https://github.com/Premo-Cloud/apijack",
+  "repository": "https://github.com/normalled/apijack",
   "license": "MIT",
   "keywords": ["openapi", "cli", "mcp", "api", "routines"]
 }

--- a/.claude/skills/test-next-release/SKILL.md
+++ b/.claude/skills/test-next-release/SKILL.md
@@ -30,7 +30,7 @@ Report the installed version before continuing.
 
 ```bash
 rm -rf /tmp/apijack-petstore-test
-git clone https://github.com/Premo-Cloud/apijack-petstore-example.git /tmp/apijack-petstore-test
+git clone https://github.com/normalled/apijack-petstore-example.git /tmp/apijack-petstore-test
 cd /tmp/apijack-petstore-test && bun run start &
 ```
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release
-    # Only publish when a version bump commit is in the push
-    if: "contains(github.event.head_commit.message, 'chore(release):') || contains(toJSON(github.event.commits.*.message), 'chore(release):')"
+    # Only publish stable releases from main when a version bump commit is in the push
+    if: "github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore(release):') || contains(toJSON(github.event.commits.*.message), 'chore(release):'))"
     permissions:
       contents: write
       id-token: write

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ bun.lockb
 
 # Superpowers docs (plans & specs)
 docs/superpowers/
+docs/icons/
 wiki/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Jack into any OpenAPI spec and rip a full-featured CLI with AI-agentic workflow automation.
 
 [![npm](https://img.shields.io/npm/v/@apijack/core)](https://www.npmjs.com/package/@apijack/core)
-[![tests](https://github.com/Premo-Cloud/apijack/actions/workflows/ci.yml/badge.svg)](https://github.com/Premo-Cloud/apijack/actions/workflows/ci.yml)
-[![e2e](https://github.com/Premo-Cloud/apijack/actions/workflows/e2e.yml/badge.svg)](https://github.com/Premo-Cloud/apijack/actions/workflows/e2e.yml)
+[![tests](https://github.com/normalled/apijack/actions/workflows/ci.yml/badge.svg)](https://github.com/normalled/apijack/actions/workflows/ci.yml)
+[![e2e](https://github.com/normalled/apijack/actions/workflows/e2e.yml/badge.svg)](https://github.com/normalled/apijack/actions/workflows/e2e.yml)
 [![buy me a coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://www.buymeacoffee.com/garreta)
 
 ## Getting Started
@@ -19,7 +19,7 @@ apijack generate            # Pull OpenAPI spec, generate types/client/commands
 apijack --help              # See all generated commands
 ```
 
-> **New to apijack?** Follow the [Quickstart](https://github.com/Premo-Cloud/apijack/wiki/Quickstart) guide with a working example API.
+> **New to apijack?** Follow the [Quickstart](https://github.com/normalled/apijack/wiki/Quickstart) guide with a working example API.
 
 ## Claude Code Plugin
 
@@ -35,7 +35,7 @@ Then in Claude Code, run `/reload-plugins`. The plugin exposes MCP tools and ski
 
 > "Use /setup-api to connect apijack to my todo list API at http://localhost:8080, then use /write-routine to automate an e2e test: create 10 todos and then delete them all."
 
-For other MCP-compatible editors (Cursor, Windsurf, etc.), see [MCP Server Integration](https://github.com/Premo-Cloud/apijack/wiki/MCP-Server-Integration).
+For other MCP-compatible editors (Cursor, Windsurf, etc.), see [MCP Server Integration](https://github.com/normalled/apijack/wiki/MCP-Server-Integration).
 
 ## As a Framework
 
@@ -59,29 +59,29 @@ const cli = createCli({
 await cli.run();
 ```
 
-See [Building a CLI](https://github.com/Premo-Cloud/apijack/wiki/Building-a-CLI) for the full configuration reference.
+See [Building a CLI](https://github.com/normalled/apijack/wiki/Building-a-CLI) for the full configuration reference.
 
 ## Features
 
-- **OpenAPI codegen** -- types, client, and Commander commands from any spec ([details](https://github.com/Premo-Cloud/apijack/wiki/Code-Generation-Internals))
+- **OpenAPI codegen** -- types, client, and Commander commands from any spec ([details](https://github.com/normalled/apijack/wiki/Code-Generation-Internals))
 - **Claude Code plugin** -- one-command setup, MCP server, AI-integrated skills
-- **Pluggable auth strategies** -- Basic, Bearer, API Key, Session/CSRF, or build your own ([details](https://github.com/Premo-Cloud/apijack/wiki/Authentication-Strategies))
-- **Secure credential handling** -- dev URLs stored locally, production APIs require env vars ([details](https://github.com/Premo-Cloud/apijack/wiki/Authentication-Configuration))
-- **Multi-environment config** -- switch between dev/staging/prod with `config switch` ([details](https://github.com/Premo-Cloud/apijack/wiki/Managing-Environments))
-- **YAML routine engine** -- variables, conditions, `forEach`, assertions, sub-routines ([details](https://github.com/Premo-Cloud/apijack/wiki/Writing-Routines))
-- **`-o routine-step` export** -- run any command with `-o routine-step` to emit YAML for workflows ([details](https://github.com/Premo-Cloud/apijack/wiki/Command-Discovery))
-- **Project mode** -- project-local config, routines, and extensions ([details](https://github.com/Premo-Cloud/apijack/wiki/Project-Mode))
-- **OpenAPI 3.0 + 3.1** -- comprehensive spec support ([compatibility matrix](https://github.com/Premo-Cloud/apijack/wiki/OpenAPI-Compatibility))
+- **Pluggable auth strategies** -- Basic, Bearer, API Key, Session/CSRF, or build your own ([details](https://github.com/normalled/apijack/wiki/Authentication-Strategies))
+- **Secure credential handling** -- dev URLs stored locally, production APIs require env vars ([details](https://github.com/normalled/apijack/wiki/Authentication-Configuration))
+- **Multi-environment config** -- switch between dev/staging/prod with `config switch` ([details](https://github.com/normalled/apijack/wiki/Managing-Environments))
+- **YAML routine engine** -- variables, conditions, `forEach`, assertions, sub-routines ([details](https://github.com/normalled/apijack/wiki/Writing-Routines))
+- **`-o routine-step` export** -- run any command with `-o routine-step` to emit YAML for workflows ([details](https://github.com/normalled/apijack/wiki/Command-Discovery))
+- **Project mode** -- project-local config, routines, and extensions ([details](https://github.com/normalled/apijack/wiki/Project-Mode))
+- **OpenAPI 3.0 + 3.1** -- comprehensive spec support ([compatibility matrix](https://github.com/normalled/apijack/wiki/OpenAPI-Compatibility))
 
 ## Documentation
 
-Full documentation is available on the [wiki](https://github.com/Premo-Cloud/apijack/wiki):
+Full documentation is available on the [wiki](https://github.com/normalled/apijack/wiki):
 
-- [Quickstart](https://github.com/Premo-Cloud/apijack/wiki/Quickstart)
-- [Writing Routines](https://github.com/Premo-Cloud/apijack/wiki/Writing-Routines)
-- [Authentication Strategies](https://github.com/Premo-Cloud/apijack/wiki/Authentication-Strategies)
-- [CLI Command Reference](https://github.com/Premo-Cloud/apijack/wiki/CLI-Command-Reference)
-- [Routine YAML Schema](https://github.com/Premo-Cloud/apijack/wiki/Routine-YAML-Schema)
+- [Quickstart](https://github.com/normalled/apijack/wiki/Quickstart)
+- [Writing Routines](https://github.com/normalled/apijack/wiki/Writing-Routines)
+- [Authentication Strategies](https://github.com/normalled/apijack/wiki/Authentication-Strategies)
+- [CLI Command Reference](https://github.com/normalled/apijack/wiki/CLI-Command-Reference)
+- [Routine YAML Schema](https://github.com/normalled/apijack/wiki/Routine-YAML-Schema)
 
 ## Requirements
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,7 @@ export default tseslint.config(
   {
     rules: {
       // Single quotes, but allow backticks for interpolation/multiline and double quotes to avoid escaping
-      '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }],
+      '@stylistic/quotes': ['error', 'single', { avoidEscape: true, allowTemplateLiterals: 'never' }],
 
       // Allow aligned trailing comments in type definitions
       '@stylistic/no-multi-spaces': ['error', { ignoreEOLComments: true }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,17 @@ export default tseslint.config(
       // Allow aligned trailing comments in type definitions
       '@stylistic/no-multi-spaces': ['error', { ignoreEOLComments: true }],
 
+      // Blank lines before/after control flow blocks
+      '@stylistic/padding-line-between-statements': ['error',
+        { blankLine: 'always', prev: '*', next: 'if' },
+        { blankLine: 'always', prev: 'if', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'for' },
+        { blankLine: 'always', prev: 'for', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'while' },
+        { blankLine: 'always', prev: 'while', next: '*' },
+        { blankLine: 'always', prev: '*', next: 'return' },
+      ],
+
       // TypeScript-specific stylistic rules
       '@stylistic/member-delimiter-style': ['error', {
         multiline: { delimiter: 'semi', requireLast: true },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.5.5",
+  "version": "1.5.6",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Premo-Cloud/apijack.git"
+    "url": "git+https://github.com/normalled/apijack.git"
   },
-  "homepage": "https://github.com/Premo-Cloud/apijack#readme",
+  "homepage": "https://github.com/normalled/apijack#readme",
   "bugs": {
-    "url": "https://github.com/Premo-Cloud/apijack/issues"
+    "url": "https://github.com/normalled/apijack/issues"
   },
   "type": "module",
   "main": "src/index.ts",

--- a/src/auth-detector.ts
+++ b/src/auth-detector.ts
@@ -59,6 +59,7 @@ export function detectAuthFromSpec(
 
     for (const prio of PRIORITY) {
         const match = detected.find(d => d.type === prio);
+
         if (match) return match;
     }
 
@@ -73,9 +74,12 @@ export async function fetchSecuritySchemes(
         const res = await fetch(specUrl, {
             headers: { Accept: 'application/json', ...headers },
         });
+
         if (!res.ok) return null;
+
         const spec = await res.json() as Record<string, unknown>;
         const components = spec.components as Record<string, unknown> | undefined;
+
         return (components?.securitySchemes as Record<string, SecurityScheme>) ?? null;
     } catch {
         return null;

--- a/src/auth/bearer.ts
+++ b/src/auth/bearer.ts
@@ -5,11 +5,13 @@ export class BearerTokenStrategy implements AuthStrategy {
 
     async authenticate(config: ResolvedAuth): Promise<AuthSession> {
         const token = await this.getToken(config);
+
         return { headers: { Authorization: `Bearer ${token}` } };
     }
 
     async restore(cached: AuthSession, _config: ResolvedAuth): Promise<AuthSession | null> {
         if (cached.expiresAt && Date.now() > cached.expiresAt) return null;
+
         return cached;
     }
 

--- a/src/auth/config-merge.ts
+++ b/src/auth/config-merge.ts
@@ -10,6 +10,7 @@ export function deepMergeSessionAuth(
     override: Partial<SessionAuthConfig> | undefined,
 ): SessionAuthConfig {
     if (!override) return structuredClone(base);
+
     return deepMerge(structuredClone(base), override) as SessionAuthConfig;
 }
 
@@ -30,5 +31,6 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
             target[key] = srcVal;
         }
     }
+
     return target;
 }

--- a/src/auth/resolve-headers.ts
+++ b/src/auth/resolve-headers.ts
@@ -15,6 +15,7 @@ export function resolveRequestHeaders(
     if (cookieApplies) {
         const cookieParts = Object.entries(session.cookies)
             .map(([name, value]) => `${name}=${value}`);
+
         if (cookieParts.length > 0) {
             headers['Cookie'] = cookieParts.join('; ');
         }
@@ -23,6 +24,7 @@ export function resolveRequestHeaders(
             const mirrorApplies = mirror.applyTo
                 ? methodMatches(upperMethod, mirror.applyTo)
                 : true;
+
             if (mirrorApplies && session.cookies[mirror.fromCookie]) {
                 headers[mirror.toHeader] = session.cookies[mirror.fromCookie];
             }
@@ -34,5 +36,6 @@ export function resolveRequestHeaders(
 
 function methodMatches(method: string, applyTo?: string[]): boolean {
     if (!applyTo) return true;
+
     return applyTo.some(m => m === '*' || m.toUpperCase() === method);
 }

--- a/src/auth/session-auth.ts
+++ b/src/auth/session-auth.ts
@@ -43,6 +43,7 @@ export class SessionAuthStrategy implements AuthStrategy {
         }
 
         const baseRestored = await this.base.restore(cached, config);
+
         if (!baseRestored) return null;
 
         return {
@@ -65,9 +66,12 @@ export class SessionAuthStrategy implements AuthStrategy {
         for (const raw of setCookies) {
             const [nameValue] = raw.split(';');
             const eqIdx = nameValue.indexOf('=');
+
             if (eqIdx < 0) continue;
+
             const name = nameValue.slice(0, eqIdx).trim();
             const value = nameValue.slice(eqIdx + 1).trim();
+
             if (extractNames.has(name)) {
                 cookies[name] = value;
             }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -48,9 +48,11 @@ function showCustomHelp(program: Command, cliName: string, showAll: boolean): vo
 
     // Options
     console.log('Options:');
+
     for (const opt of program.options) {
         console.log(`  ${opt.flags.padEnd(30)} ${opt.description}`);
     }
+
     console.log(`  ${'-h, --help'.padEnd(30)} display help for command`);
 
     // Core commands
@@ -61,6 +63,7 @@ function showCustomHelp(program: Command, cliName: string, showAll: boolean): vo
 
     if (core.length > 0) {
         console.log('\nCommands:');
+
         for (const cmd of core) {
             console.log(`  ${cmd.name().padEnd(30)} ${cmd.description()}`);
         }
@@ -68,6 +71,7 @@ function showCustomHelp(program: Command, cliName: string, showAll: boolean): vo
 
     if (showAll && api.length > 0) {
         console.log(`\nAPI Commands (${api.length}):`);
+
         for (const cmd of api) {
             console.log(`  ${cmd.name()}`);
         }
@@ -113,9 +117,11 @@ export function createCli(options: CliOptions): Cli {
             if (options.outputModes?.includes('table')) {
                 program.option('--table', 'Output as table');
             }
+
             if (options.outputModes?.includes('quiet')) {
                 program.option('--quiet', 'Suppress output');
             }
+
             program.option(
                 '-o <format>',
                 `Output format (${(options.outputModes || ['json', 'table', 'quiet']).join(', ')}, routine-step, curl, curl-with-creds)`,
@@ -159,6 +165,7 @@ export function createCli(options: CliOptions): Cli {
             const isHelpOrVersion = cmd === '--help' || cmd === '-h'
                 || cmd === '--version' || cmd === '-V'
                 || process.argv.includes('--help') || process.argv.includes('-h');
+
             if (
                 !resolved
                 && process.stdin.isTTY
@@ -171,6 +178,7 @@ export function createCli(options: CliOptions): Cli {
                 const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
                 const user = await prompt('Username/Email: ');
                 const password = await hiddenPrompt('Password: ');
+
                 if (user && password) {
                     const result = await setupAction({
                         cliName, envName, url, user, password,
@@ -178,18 +186,21 @@ export function createCli(options: CliOptions): Cli {
                         save: saveEnvironment,
                         saveOpts: configOpts ?? {},
                     });
+
                     if (!result.verified) {
                         console.error(result.verifyReason);
                         console.error("Credentials saved anyway — they'll be used when the server is available.");
                     } else {
                         console.log('Credentials verified.');
                     }
+
                     console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
                 } else {
                     console.error('Setup cancelled.');
                     process.exit(2);
                 }
+
                 resolved = resolveAuth(cliName, configOpts);
             }
 
@@ -235,6 +246,7 @@ export function createCli(options: CliOptions): Cli {
                         const commandsModule = await import(
                             resolve(generatedDir, 'commands'),
                         );
+
                         if (commandsModule.registerGeneratedCommands) {
                             const { ApiClient } = await import(
                                 resolve(generatedDir, 'client'),
@@ -265,6 +277,7 @@ export function createCli(options: CliOptions): Cli {
                                 // Handle request preview modes
                                 if (isRequestPreview && result && typeof result === 'object' && 'method' in result && 'url' in result) {
                                     const captured = result as CapturedRequest;
+
                                     if (isCurl) {
                                         console.log(formatCurl(captured, { includeCreds: false }));
                                     } else if (isCurlWithCreds) {
@@ -272,6 +285,7 @@ export function createCli(options: CliOptions): Cli {
                                     } else {
                                         console.log(formatDryRun(captured));
                                     }
+
                                     return;
                                 }
 
@@ -281,6 +295,7 @@ export function createCli(options: CliOptions): Cli {
                                         ? 'quiet'
                                         : 'json';
                                 const output = formatOutput(result, mode);
+
                                 if (output) console.log(output);
                             };
 
@@ -333,6 +348,7 @@ export function createCli(options: CliOptions): Cli {
 
             // Only build dispatcher if we have a context
             let dispatch: CommandDispatcher | undefined;
+
             if (ctx) {
                 dispatch = buildDispatcher({
                     commandMap,
@@ -354,20 +370,24 @@ export function createCli(options: CliOptions): Cli {
             const isRoutineStep
                 = process.argv.includes('-o')
                     && process.argv[process.argv.indexOf('-o') + 1] === 'routine-step';
+
             if (isRoutineStep) {
                 program.hook('preAction', (_thisCommand, actionCommand) => {
                     const cmdParts: string[] = [];
                     let cmd: Command = actionCommand;
+
                     while (cmd.parent && cmd.parent !== program) {
                         cmdParts.unshift(cmd.name());
                         cmd = cmd.parent;
                     }
+
                     cmdParts.unshift(cmd.name());
                     const commandPath = cmdParts.join(' ');
 
                     // Get provided values
                     const opts = actionCommand.opts();
                     const providedArgs: Record<string, unknown> = {};
+
                     for (const [key, val] of Object.entries(opts)) {
                         if (val !== undefined && key !== 'output') {
                             providedArgs[`--${key}`] = val;
@@ -398,6 +418,7 @@ export function createCli(options: CliOptions): Cli {
                         // Provided args first (uncommented)
                         for (const [flag, val] of Object.entries(providedArgs)) {
                             if (skipFlags.has(flag)) continue;
+
                             lines.push(`    ${flag}: ${JSON.stringify(val)}`);
                             emitted.add(flag);
                         }
@@ -405,10 +426,13 @@ export function createCli(options: CliOptions): Cli {
                         // Remaining options as commented-out
                         for (const opt of allOptions) {
                             const flag = opt.long || opt.short;
+
                             if (!flag || skipFlags.has(flag) || emitted.has(flag))
                                 continue;
+
                             // Skip hidden (variant-specific) options unless -V
                             if (opt.hidden && !isVerbose) continue;
+
                             const desc = opt.description || '';
                             lines.push(
                                 `    # ${flag}: "" # optional — ${desc}`,
@@ -418,6 +442,7 @@ export function createCli(options: CliOptions): Cli {
 
                     if (positional.length > 0) {
                         lines.push('  args-positional:');
+
                         for (const p of positional)
                             lines.push(`    - ${JSON.stringify(p)}`);
                     }
@@ -429,6 +454,7 @@ export function createCli(options: CliOptions): Cli {
 
             // 12. Custom help — intercept no-args and --help
             const userArgs = process.argv.slice(2);
+
             if (
                 userArgs.length === 0
                 || (userArgs.length === 1

--- a/src/codegen/client.ts
+++ b/src/codegen/client.ts
@@ -18,9 +18,11 @@ export function generateClient(
     function collectImportableTypes(typeStr: string) {
     // Strip array suffix and parens from discriminated union wrappers
         const bare = typeStr.replace(/\[\]$/g, '').replace(/^\(|\)$/g, '');
+
         // Split on union/intersection operators
         for (const part of bare.split(/\s*[|&]\s*/)) {
             const trimmed = part.trim().replace(/\[\]$/g, '');
+
             if (trimmed && !PRIMITIVE_TYPES.has(trimmed) && /^[A-Za-z_]\w*$/.test(trimmed)) {
                 referencedTypes.add(trimmed);
             }
@@ -34,13 +36,16 @@ export function generateClient(
 
         for (const method of HTTP_METHODS) {
             const op = methods[method] as OpenApiOperation | undefined;
+
             if (!op || !op.operationId) continue;
 
             // Merge path-level params with operation params (op overrides by name+in)
             const opParams = op.parameters || [];
             const mergedParams: typeof opParams = [...pathLevelParams];
+
             for (const opParam of opParams) {
                 const idx = mergedParams.findIndex(p => p.name === opParam.name && p.in === opParam.in);
+
                 if (idx >= 0) mergedParams[idx] = opParam;
                 else mergedParams.push(opParam);
             }
@@ -49,11 +54,13 @@ export function generateClient(
             const queryParams = mergedParams.filter(p => p.in === 'query');
 
             const args: string[] = [];
+
             for (const p of pathParams) {
                 args.push(`${p.name}: ${schemaToTsType(p.schema)}`);
             }
 
             const bodySchema = op.requestBody?.content?.['application/json']?.schema;
+
             if (bodySchema) {
                 const bodyType = bodySchema.$ref
                     ? refToName(bodySchema.$ref)
@@ -78,8 +85,11 @@ export function generateClient(
                 : `"${path}"`;
 
             const reqOpts: string[] = [];
+
             if (queryParams.length > 0) reqOpts.push('params');
+
             if (bodySchema) reqOpts.push('body');
+
             const optsArg = reqOpts.length > 0 ? `, { ${reqOpts.join(', ')} }` : '';
 
             // Build operation JSDoc
@@ -110,12 +120,17 @@ export function generateClient(
             // @param tags for path parameters (always) and query parameters (when described)
             for (const p of pathParams) {
                 let paramDesc = p.description ? `${p.description}` : p.name;
+
                 if (p.style) paramDesc += ` (style: ${p.style}${p.explode !== undefined ? `, explode: ${p.explode}` : ''})`;
+
                 docLines.push(`@param ${p.name} ${paramDesc}`);
             }
+
             for (const p of queryParams) {
                 let paramDesc = p.description || p.name;
+
                 if (p.style) paramDesc += ` (style: ${p.style}${p.explode !== undefined ? `, explode: ${p.explode}` : ''})`;
+
                 if (paramDesc !== p.name || p.style) {
                     docLines.push(`@param ${p.name} ${paramDesc}`);
                 }
@@ -124,6 +139,7 @@ export function generateClient(
             // @param for body
             if (bodySchema) {
                 const bodyDesc = op.requestBody?.description;
+
                 if (bodyDesc) {
                     docLines.push(`@param body ${bodyDesc}`);
                 } else {
@@ -136,6 +152,7 @@ export function generateClient(
                 methodLines.push(`  /** ${docLines[0]} */`);
             } else {
                 methodLines.push(`  /** ${docLines[0]}`);
+
                 for (let i = 1; i < docLines.length; i++) {
                     if (i === docLines.length - 1) {
                         methodLines.push(`   * ${docLines[i]} */`);

--- a/src/codegen/command-map.ts
+++ b/src/codegen/command-map.ts
@@ -33,6 +33,7 @@ export function generateCommandMap(
 
         for (const method of HTTP_METHODS) {
             const op = methods[method] as OpenApiOperation | undefined;
+
             if (!op || !op.operationId) continue;
 
             const tag = op.tags?.[0] || 'default';
@@ -44,8 +45,10 @@ export function generateCommandMap(
             // Merge path-level params with operation params (op overrides by name+in)
             const opParams = op.parameters || [];
             const mergedParams: typeof opParams = [...pathLevelParams];
+
             for (const opParam of opParams) {
                 const idx = mergedParams.findIndex(p => p.name === opParam.name && p.in === opParam.in);
+
                 if (idx >= 0) mergedParams[idx] = opParam;
                 else mergedParams.push(opParam);
             }
@@ -84,9 +87,13 @@ export function generateCommandMap(
             }
 
             const rKey = resourceKey || '__root__';
+
             if (!groups.has(groupKey)) groups.set(groupKey, new Map());
+
             const group = groups.get(groupKey)!;
+
             if (!group.has(rKey)) group.set(rKey, []);
+
             group.get(rKey)!.push({
                 verb,
                 operationId: op.operationId,
@@ -110,6 +117,7 @@ export function generateCommandMap(
         for (const [resourceName, cmds] of resources) {
             // Same dedup logic as generateCommands
             const verbCounts = new Map<string, number>();
+
             for (const cmd of cmds) {
                 verbCounts.set(cmd.verb, (verbCounts.get(cmd.verb) || 0) + 1);
             }
@@ -117,6 +125,7 @@ export function generateCommandMap(
             for (const cmd of cmds) {
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
+
                 if (count > 1) {
                     cmdName = cmd.operationId
                         .replace(/([A-Z])/g, '-$1')

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -27,6 +27,7 @@ export function generateCommands(
 
         for (const method of HTTP_METHODS) {
             const op = methods[method] as OpenApiOperation | undefined;
+
             if (!op || !op.operationId) continue;
 
             const tag = op.tags?.[0] || 'default';
@@ -38,8 +39,10 @@ export function generateCommands(
             // Merge path-level params with operation params (op overrides by name+in)
             const opParams = op.parameters || [];
             const mergedParams: typeof opParams = [...pathLevelParams];
+
             for (const opParam of opParams) {
                 const idx = mergedParams.findIndex(p => p.name === opParam.name && p.in === opParam.in);
+
                 if (idx >= 0) mergedParams[idx] = opParam;
                 else mergedParams.push(opParam);
             }
@@ -58,10 +61,12 @@ export function generateCommands(
 
             // Detect primitive body types that can't be decomposed into properties
             let bodyPrimitiveType: CommandDef['bodyPrimitiveType'];
+
             if (hasBody && bodyProps.length === 0 && bodySchema) {
                 const resolved = bodySchema.$ref
                     ? schemas[bodySchema.$ref.split('/').pop()!]
                     : bodySchema;
+
                 if (resolved) {
                     if (resolved.type === 'string') bodyPrimitiveType = 'string';
                     else if (
@@ -75,6 +80,7 @@ export function generateCommands(
                         const itemType = resolved.items.$ref
                             ? schemas[resolved.items.$ref.split('/').pop()!]?.type
                             : resolved.items.type;
+
                         if (itemType === 'string') bodyPrimitiveType = 'string[]';
                         else if (itemType === 'integer' || itemType === 'number')
                             bodyPrimitiveType = 'number[]';
@@ -132,9 +138,12 @@ export function generateCommands(
             };
 
             if (!groups.has(groupKey)) groups.set(groupKey, new Map());
+
             const group = groups.get(groupKey)!;
             const rKey = resourceKey || '__root__';
+
             if (!group.has(rKey)) group.set(rKey, []);
+
             group.get(rKey)!.push(cmd);
         }
     }
@@ -156,6 +165,7 @@ export function generateCommands(
 
         for (const [resourceName, cmds] of resources) {
             let parent: string;
+
             if (resourceName === '__root__') {
                 parent = sanitizeVar(groupName);
             } else {
@@ -169,14 +179,17 @@ export function generateCommands(
 
             // Deduplicate verb names within the same parent
             const verbCounts = new Map<string, number>();
+
             for (const cmd of cmds) {
                 verbCounts.set(cmd.verb, (verbCounts.get(cmd.verb) || 0) + 1);
             }
+
             const verbSeen = new Map<string, number>();
 
             for (const cmd of cmds) {
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
+
                 if (count > 1) {
                     // Use operationId as the command name when verbs collide
                     cmdName = cmd.operationId
@@ -184,6 +197,7 @@ export function generateCommands(
                         .toLowerCase()
                         .replace(/^-/, '');
                 }
+
                 verbSeen.set(
                     cmd.verb,
                     (verbSeen.get(cmd.verb) || 0) + 1,
@@ -206,9 +220,11 @@ export function generateCommands(
                 } else {
                     lines.push(`  ${parent}`);
                 }
+
                 lines.push(`    .command("${cmdName}${argStr}")`);
 
                 let cmdDesc: string;
+
                 if (cmd.deprecated) {
                     cmdDesc = `[DEPRECATED] ${cmd.summary || cmd.description}`;
                 } else if (cmd.summary) {
@@ -216,6 +232,7 @@ export function generateCommands(
                 } else {
                     cmdDesc = cmd.description;
                 }
+
                 lines.push(
                     `    .description("${cmdDesc.replace(/"/g, '\\"')}${arrayNote} (use -o routine-step to export as YAML)")`,
                 );
@@ -251,8 +268,11 @@ export function generateCommands(
                     } else {
                         for (const bp of cmd.bodyProps) {
                             let desc: string = bp.description || bp.name;
+
                             if (bp.enumValues) desc += ` [${bp.enumValues.join(', ')}]`;
+
                             if (bp.format) desc += ` (${bp.format})`;
+
                             if (bp.default !== undefined) desc += ` (default: ${bp.default})`;
 
                             const variantTag = bp.variant
@@ -276,6 +296,7 @@ export function generateCommands(
                             }
                         }
                     }
+
                     if (hasVariantProps) {
                         lines.push(
                             '    .option("-V", "Show all variant-specific flags in help")',
@@ -288,19 +309,24 @@ export function generateCommands(
                 );
 
                 const totalPositional = cmd.pathParams.length;
+
                 for (let i = 0; i < cmd.pathParams.length; i++) {
                     lines.push(
                         `      const ${cmd.pathParams[i].name} = actionArgs[${i}] as ${cmd.pathParams[i].type};`,
                     );
                 }
+
                 lines.push(
                     `      const opts = actionArgs[${totalPositional}] as Record<string, unknown>;`,
                 );
 
                 const callArgs: string[] = [];
+
                 for (const pp of cmd.pathParams) callArgs.push(pp.name);
+
                 if (cmd.hasBody) {
                     lines.push('      let body: any;');
+
                     if (cmd.bodyPrimitiveType) {
                         // Primitive body — convert from CLI flag
                         if (cmd.bodyPrimitiveType === 'string[]') {
@@ -327,11 +353,13 @@ export function generateCommands(
                         }
                     } else if (cmd.bodyProps.length > 0) {
                         lines.push('      const obj: Record<string, unknown> = {};');
+
                         for (const bp of cmd.bodyProps) {
                             lines.push(
                                 `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName};`,
                             );
                         }
+
                         if (cmd.bodyIsArray) {
                             lines.push(
                                 '      body = [obj]; // API expects an array',
@@ -340,8 +368,10 @@ export function generateCommands(
                             lines.push('      body = obj;');
                         }
                     }
+
                     callArgs.push('body');
                 }
+
                 if (cmd.queryParams.length > 0) {
                     const qpObj = cmd.queryParams
                         .map(p => `${p.name}: opts.${p.name}`)
@@ -377,5 +407,6 @@ export function generateCommands(
     }
 
     lines.push('}');
+
     return lines.join('\n');
 }

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -41,6 +41,7 @@ export async function fetchAndGenerate(
     opts: FetchAndGenerateOptions,
 ): Promise<void> {
     const headers: Record<string, string> = { Accept: 'application/json' };
+
     if (opts.auth) {
         headers.Authorization
             = 'Basic ' + btoa(`${opts.auth.username}:${opts.auth.password}`);
@@ -48,6 +49,7 @@ export async function fetchAndGenerate(
 
     const url = `${opts.baseUrl}${opts.specPath}`;
     const res = await fetch(url, { headers });
+
     if (!res.ok) {
         throw new Error(
             `Failed to fetch spec from ${url}: ${res.status} ${res.statusText}`,

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -14,6 +14,7 @@ export function generateTypes(
 ): string {
     // Flatten $defs from all schemas into the main schemas map
     const allSchemas = { ...schemas };
+
     for (const [, schema] of Object.entries(schemas)) {
         if (schema.$defs) {
             for (const [defName, defSchema] of Object.entries(schema.$defs)) {
@@ -28,6 +29,7 @@ export function generateTypes(
 
     for (const [rawName, schema] of Object.entries(allSchemas)) {
         const name = sanitizeTypeName(rawName);
+
         if (schema.const !== undefined) {
             // OAS 3.1: const — literal type alias
             const schemaDoc = buildJsDoc(schema);
@@ -68,6 +70,7 @@ export function generateTypes(
             lines.push(...schemaDoc);
             lines.push(`export interface ${name} {`);
             const requiredSet = new Set(schema.required || []);
+
             if (schema.properties) {
                 for (const [propName, propSchema] of Object.entries(schema.properties)) {
                     const tsType = resolveType(propSchema, allSchemas, 0);
@@ -77,19 +80,23 @@ export function generateTypes(
                     lines.push(`  ${propName}${optional}: ${tsType};`);
                 }
             }
+
             // patternProperties — emit index signatures with JSDoc per pattern
             if (schema.patternProperties) {
                 const patternTypes: string[] = [];
+
                 for (const [pattern, patternSchema] of Object.entries(schema.patternProperties)) {
                     const patType = resolveType(patternSchema, allSchemas);
                     lines.push(`  /** Properties matching pattern: ${pattern} */`);
                     patternTypes.push(patType);
                 }
+
                 if (patternTypes.length > 0 && !schema.additionalProperties) {
                     const unionType = [...new Set(patternTypes)].join(' | ');
                     lines.push(`  [key: string]: ${unionType} | undefined;`);
                 }
             }
+
             // additionalProperties
             if (schema.additionalProperties && schema.additionalProperties !== true) {
                 const addType = resolveType(schema.additionalProperties, allSchemas, 0);
@@ -97,6 +104,7 @@ export function generateTypes(
             } else if (schema.additionalProperties === true) {
                 lines.push('  [key: string]: unknown;');
             }
+
             lines.push('}');
         } else if (schema.allOf) {
             // Emit schema-level JSDoc
@@ -104,19 +112,23 @@ export function generateTypes(
             lines.push(...schemaDoc);
             // Merge required arrays from all parts
             const mergedRequired = new Set<string>();
+
             for (const part of schema.allOf) {
                 if (part.required) {
                     for (const r of part.required) mergedRequired.add(r);
                 }
             }
+
             const parts = schema.allOf.map((s) => {
                 if (s.$ref) {
                     return refToName(s.$ref);
                 }
+
                 if (s.properties) {
                     // Inline intersection member with properties and JSDoc
                     const innerLines: string[] = ['{'];
                     const partRequired = new Set([...mergedRequired, ...(s.required || [])]);
+
                     for (const [propName, propSchema] of Object.entries(s.properties)) {
                         const propDoc = buildJsDoc(propSchema, '  ');
                         innerLines.push(...propDoc);
@@ -124,9 +136,12 @@ export function generateTypes(
                         const optional = partRequired.has(propName) ? '' : '?';
                         innerLines.push(`  ${propName}${optional}: ${tsType};`);
                     }
+
                     innerLines.push('}');
+
                     return innerLines.join('\n');
                 }
+
                 return 'unknown';
             });
             lines.push(`export type ${name} = ${parts.join(' & ')};`);
@@ -135,6 +150,7 @@ export function generateTypes(
             const schemaDoc = buildJsDoc({ description: schema.description, deprecated: schema.deprecated });
             lines.push(...schemaDoc);
             const variants = (schema.oneOf || schema.anyOf)!;
+
             if (schema.discriminator) {
                 // Discriminated union
                 const discProp = schema.discriminator.propertyName;
@@ -142,6 +158,7 @@ export function generateTypes(
                 const parts = variants.map((s) => {
                     const typeName = s.$ref ? refToName(s.$ref) : 'unknown';
                     let discValue: string | undefined;
+
                     if (mapping) {
                         // Find the key in mapping whose value matches this $ref
                         for (const [key, ref] of Object.entries(mapping)) {
@@ -151,10 +168,12 @@ export function generateTypes(
                             }
                         }
                     }
+
                     if (!discValue) {
                         // Fallback to schema name
                         discValue = typeName;
                     }
+
                     return `${typeName} & { ${discProp}: "${discValue}" }`;
                 });
                 lines.push(`export type ${name} = ${parts.join(' | ')};`);
@@ -163,6 +182,7 @@ export function generateTypes(
                 lines.push(`export type ${name} = ${parts.join(' | ')};`);
             }
         }
+
         lines.push('');
     }
 

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -17,7 +17,9 @@ export function resolveType(
     // OAS 3.1: const — literal value
     if (schema.const !== undefined) {
         if (typeof schema.const === 'string') return `"${schema.const}"`;
+
         if (schema.const === null) return 'null';
+
         return String(schema.const);
     }
 
@@ -25,10 +27,14 @@ export function resolveType(
     if (schema.enum && schema.type !== 'string') {
         base = schema.enum.map((v) => {
             if (v === null) return 'null';
+
             if (typeof v === 'string') return `"${v}"`;
+
             return String(v);
         }).join(' | ');
+
         if (schema.nullable) base += ' | null';
+
         return base;
     }
 
@@ -37,6 +43,7 @@ export function resolveType(
         const nonNull = schema.type.filter((t: string) => t !== 'null');
         const isNullable = schema.type.includes('null');
         let resolved: string;
+
         if (nonNull.length === 0) {
             resolved = 'null';
         } else if (nonNull.length === 1) {
@@ -46,29 +53,36 @@ export function resolveType(
                 resolveType({ ...schema, type: t, nullable: undefined, enum: undefined }, schemas, depth, visited),
             ).join(' | ');
         }
+
         if (isNullable && !resolved.includes('null')) {
             resolved += ' | null';
         }
+
         return resolved;
     }
 
     // OAS 3.1: prefixItems — tuple types
     if (schema.prefixItems) {
         const tupleTypes = schema.prefixItems.map(s => resolveType(s, schemas, depth, visited));
+
         if (schema.items && typeof schema.items === 'object') {
             const restType = resolveType(schema.items as OpenApiSchema, schemas, depth, visited);
             base = `[${tupleTypes.join(', ')}, ...${restType}[]]`;
         } else {
             base = `[${tupleTypes.join(', ')}]`;
         }
+
         if (schema.nullable) base += ' | null';
+
         return base;
     }
 
     // OAS 3.1: not — negation (no other type info)
     if (schema.not && !schema.type && !schema.properties && !schema.$ref && !schema.allOf && !schema.oneOf && !schema.anyOf && !schema.enum && schema.const === undefined) {
         base = 'unknown';
+
         if (schema.nullable) base += ' | null';
+
         return base;
     }
 
@@ -77,7 +91,9 @@ export function resolveType(
     } else if (schema.allOf) {
         const parts = schema.allOf.map((s) => {
             if (s.$ref) return refToName(s.$ref);
+
             if (s.properties) return resolveType(s, schemas, depth, visited);
+
             return 'unknown';
         });
         base = parts.join(' & ');
@@ -87,6 +103,7 @@ export function resolveType(
         base = parts.join(' | ');
     } else if (schema.type === 'array' && schema.items) {
         const itemType = typeof schema.items === 'boolean' ? 'unknown' : resolveType(schema.items, schemas, depth, visited);
+
         // Wrap union/intersection types in parens for array
         if (itemType.includes(' | ') || itemType.includes(' & ')) {
             base = `(${itemType})[]`;
@@ -101,7 +118,9 @@ export function resolveType(
         if (schema.enum) {
             base = schema.enum.map((v) => {
                 if (v === null) return 'null';
+
                 if (typeof v === 'string') return `"${v}"`;
+
                 return String(v);
             }).join(' | ');
         } else {
@@ -112,6 +131,7 @@ export function resolveType(
             // Emit inline object literal type
             const innerLines: string[] = ['{'];
             const requiredSet = new Set(schema.required || []);
+
             for (const [propName, propSchema] of Object.entries(schema.properties)) {
                 const propDoc = buildJsDoc(propSchema, '  ');
                 innerLines.push(...propDoc);
@@ -119,19 +139,23 @@ export function resolveType(
                 const optional = requiredSet.has(propName) ? '' : '?';
                 innerLines.push(`  ${propName}${optional}: ${tsType};`);
             }
+
             // patternProperties inside inline objects
             if (schema.patternProperties) {
                 const patternTypes: string[] = [];
+
                 for (const [pattern, patternSchema] of Object.entries(schema.patternProperties)) {
                     const patType = resolveType(patternSchema, schemas, depth + 1, visited);
                     innerLines.push(`  /** Properties matching pattern: ${pattern} */`);
                     patternTypes.push(patType);
                 }
+
                 if (patternTypes.length > 0 && !schema.additionalProperties) {
                     const unionType = [...new Set(patternTypes)].join(' | ');
                     innerLines.push(`  [key: string]: ${unionType} | undefined;`);
                 }
             }
+
             // additionalProperties inside inline objects
             if (schema.additionalProperties && schema.additionalProperties !== true) {
                 const addType = resolveType(schema.additionalProperties, schemas, depth + 1, visited);
@@ -139,6 +163,7 @@ export function resolveType(
             } else if (schema.additionalProperties === true) {
                 innerLines.push('  [key: string]: unknown;');
             }
+
             innerLines.push('}');
             base = innerLines.join('\n');
         } else {
@@ -182,9 +207,13 @@ export function refToName(ref: string): string {
  */
 export function schemaToTsType(schema: OpenApiSchema): string {
     if (schema.type === 'integer' || schema.type === 'number') return 'number';
+
     if (schema.type === 'boolean') return 'boolean';
+
     if (schema.type === 'string') return 'string';
+
     if (schema.$ref) return refToName(schema.$ref);
+
     return 'unknown';
 }
 
@@ -212,23 +241,37 @@ export function buildJsDoc(
 
     // Collect tags in specified order
     if (schema.format !== undefined) tags.push(`@format ${schema.format}`);
+
     if (schema.minimum !== undefined) tags.push(`@minimum ${schema.minimum}`);
+
     if (schema.maximum !== undefined) tags.push(`@maximum ${schema.maximum}`);
+
     if (schema.exclusiveMinimum !== undefined && schema.exclusiveMinimum !== false) {
         tags.push(`@exclusiveMinimum ${schema.exclusiveMinimum}`);
     }
+
     if (schema.exclusiveMaximum !== undefined && schema.exclusiveMaximum !== false) {
         tags.push(`@exclusiveMaximum ${schema.exclusiveMaximum}`);
     }
+
     if (schema.minLength !== undefined) tags.push(`@minLength ${schema.minLength}`);
+
     if (schema.maxLength !== undefined) tags.push(`@maxLength ${schema.maxLength}`);
+
     if (schema.pattern !== undefined) tags.push(`@pattern ${schema.pattern}`);
+
     if (schema.minItems !== undefined) tags.push(`@minItems ${schema.minItems}`);
+
     if (schema.maxItems !== undefined) tags.push(`@maxItems ${schema.maxItems}`);
+
     if (schema.uniqueItems === true) tags.push('@uniqueItems');
+
     if (schema.multipleOf !== undefined) tags.push(`@multipleOf ${schema.multipleOf}`);
+
     if (schema.minProperties !== undefined) tags.push(`@minProperties ${schema.minProperties}`);
+
     if (schema.maxProperties !== undefined) tags.push(`@maxProperties ${schema.maxProperties}`);
+
     if (schema.default !== undefined) {
         if (typeof schema.default === 'object' && schema.default !== null) {
             tags.push(`@default ${JSON.stringify(schema.default)}`);
@@ -236,6 +279,7 @@ export function buildJsDoc(
             tags.push(`@default ${schema.default}`);
         }
     }
+
     if (schema.example !== undefined) {
         if (typeof schema.example === 'string') {
             tags.push(`@example "${schema.example}"`);
@@ -245,8 +289,11 @@ export function buildJsDoc(
             tags.push(`@example ${schema.example}`);
         }
     }
+
     if (schema.readOnly === true) tags.push('@readonly');
+
     if (schema.writeOnly === true) tags.push('@writeonly');
+
     // OAS 3.1: not — negation annotation
     if (schema.not) {
         const notSchema = schema.not as OpenApiSchema;
@@ -256,6 +303,7 @@ export function buildJsDoc(
 
     // Handle description, escaping */ sequences (but not the final closing */)
     let desc = schema.description;
+
     if (desc) {
         desc = desc.replace(/\*\//g, '*\\/');
     }
@@ -298,6 +346,7 @@ export function buildJsDoc(
     // Multi-line JSDoc
     const result: string[] = [];
     result.push(`${indent}/** ${contentLines[0]}`);
+
     for (let i = 1; i < contentLines.length; i++) {
         if (i === contentLines.length - 1) {
             result.push(`${indent} * ${contentLines[i]} */`);
@@ -319,11 +368,16 @@ export function resolveResponseType(
 ): string {
     for (const status of ['200', '201', '202', '204']) {
         const response = responses[status];
+
         if (!response) continue;
+
         const jsonSchema = response.content?.['application/json']?.schema;
+
         if (!jsonSchema) continue;
+
         return resolveType(jsonSchema, schemas);
     }
+
     return 'void';
 }
 
@@ -343,6 +397,7 @@ export function resolveSchemaProps(
     if (schema.$ref) {
         const name = schema.$ref.split('/').pop()!;
         const refSchema = schemas[name];
+
         return resolveSchemaProps(refSchema, schemas, parentRequired);
     }
 
@@ -351,14 +406,18 @@ export function resolveSchemaProps(
         const merged: BodyProp[] = [];
         const seen = new Set<string>();
         const mergedRequired = new Set<string>(parentRequired || []);
+
         for (const part of schema.allOf) {
             if (part.required) part.required.forEach(r => mergedRequired.add(r));
+
             if (part.$ref) {
                 const refName = part.$ref.split('/').pop()!;
                 const refSchema = schemas[refName];
+
                 if (refSchema?.required) refSchema.required.forEach(r => mergedRequired.add(r));
             }
         }
+
         for (const part of schema.allOf) {
             for (const prop of resolveSchemaProps(part, schemas, mergedRequired)) {
                 if (!seen.has(prop.name) && !seen.has(prop.cliFlag)) {
@@ -368,12 +427,14 @@ export function resolveSchemaProps(
                 }
             }
         }
+
         return merged;
     }
 
     // Resolve oneOf/anyOf — collect all variant properties tagged with variant name
     if (schema.oneOf || schema.anyOf) {
         const variants = (schema.oneOf || schema.anyOf)!;
+
         if (variants.length === 1) {
             return resolveSchemaProps(variants[0], schemas, parentRequired);
         }
@@ -384,6 +445,7 @@ export function resolveSchemaProps(
         for (const v of variants) {
             const variantName = v.$ref ? v.$ref.split('/').pop()! : undefined;
             const props = resolveSchemaProps(v, schemas, parentRequired);
+
             for (const prop of props) {
                 if (!seen.has(prop.cliFlag)) {
                     seen.add(prop.cliFlag);
@@ -391,6 +453,7 @@ export function resolveSchemaProps(
                 }
             }
         }
+
         return all;
     }
 
@@ -408,28 +471,35 @@ export function resolveSchemaProps(
 
     const results: BodyProp[] = [];
     const seenFlags = new Set<string>();
+
     for (const [name, prop] of Object.entries(schema.properties)) {
     // Skip readOnly properties — server-generated, shouldn't be CLI flags
         if (prop.readOnly) continue;
 
         const flag = name;
+
         if (seenFlags.has(flag)) continue; // Skip duplicate CLI flags
+
         seenFlags.add(flag);
 
         // Resolve enum values — direct or via $ref
         let enumValues: (string | number | boolean | null)[] | undefined;
+
         if (prop.enum) {
             enumValues = prop.enum;
         } else if (prop.$ref) {
             const refName = prop.$ref.split('/').pop()!;
             const refSchema = schemas[refName];
+
             if (refSchema?.enum) enumValues = refSchema.enum;
         }
 
         let description = prop.description;
+
         if (!description && prop.$ref) {
             const refName = prop.$ref.split('/').pop()!;
             const refSchema = schemas[refName];
+
             if (refSchema?.description) description = refSchema.description;
         }
 
@@ -447,6 +517,7 @@ export function resolveSchemaProps(
             readOnly: prop.readOnly,
         });
     }
+
     return results;
 }
 

--- a/src/commands/config/import/import.ts
+++ b/src/commands/config/import/import.ts
@@ -17,6 +17,7 @@ export interface ConfigImportResult {
 
 export async function configImportAction(deps: ConfigImportDeps): Promise<ConfigImportResult> {
     const site = deps.knownSites[deps.alias];
+
     if (!site) throw new Error(`Unknown site '${deps.alias}'.`);
 
     const verifyResult = await deps.verify(site.url, deps.user, deps.password);

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -28,10 +28,13 @@ export function registerConfigCommand(
             const envs = await configListAction({
                 listEnvs: () => listEnvironments(cliName, configOpts),
             });
+
             if (envs.length === 0) {
                 console.log(`No environments configured. Run '${cliName} setup' to add one.`);
+
                 return;
             }
+
             for (const env of envs) {
                 const marker = env.active ? '* ' : '  ';
                 console.log(`${marker}${env.name}\t${env.url}\t${env.user}`);
@@ -49,10 +52,12 @@ export function registerConfigCommand(
                 invalidateSession: () => sessionMgr.invalidate(),
                 listEnvs: () => listEnvironments(cliName, configOpts),
             });
+
             if (!result.ok) {
                 console.error(`Environment '${name}' not found. Available: ${result.available?.join(', ') || 'none'}`);
                 process.exit(1);
             }
+
             console.log(`Switched to '${name}'`);
         });
 
@@ -69,6 +74,7 @@ export function registerConfigCommand(
 
                 if (!alias) {
                     const siteEntries = Object.entries(knownSites);
+
                     if (siteEntries.length === 0) {
                         console.error('No known sites configured.');
                         process.exit(1);
@@ -81,15 +87,18 @@ export function registerConfigCommand(
 
                     const selection = await prompt(`\nSelect site (1-${siteEntries.length}): `);
                     const index = parseInt(selection);
+
                     if (index < 1 || index > siteEntries.length) {
                         console.error('Invalid selection.');
                         process.exit(1);
                     }
+
                     alias = siteEntries[index - 1]![0];
                 }
 
                 const user = cmdOpts.user ?? (await prompt('Email: '));
                 const password = cmdOpts.password ?? (await hiddenPrompt('Password: '));
+
                 if (!user || !password) {
                     console.error('Email and password are required.');
                     process.exit(1);
@@ -117,6 +126,7 @@ export function registerConfigCommand(
                     } else {
                         console.log('Credentials verified.');
                     }
+
                     console.log(`Saved and switched to '${alias}'.`);
                 } catch (err) {
                     console.error(err instanceof Error ? err.message : String(err));
@@ -131,11 +141,14 @@ export function registerConfigCommand(
             .action(async (name: string | undefined, cmdOpts: { password?: string }) => {
                 // Validate environment exists before prompting for password
                 const cfg = await loadConfig(cliName, configOpts) as any;
+
                 if (!cfg || Object.keys(cfg.environments).length === 0) {
                     console.error(`No environments configured. Run '${cliName} config import' first.`);
                     process.exit(1);
                 }
+
                 const envName = name ?? cfg.active;
+
                 if (!cfg.environments[envName]) {
                     console.error(`Environment '${envName}' not found.`);
                     process.exit(1);
@@ -144,6 +157,7 @@ export function registerConfigCommand(
                 console.log(`Updating password for '${envName}' (${cfg.environments[envName].url})`);
 
                 const password = cmdOpts.password ?? (await hiddenPrompt('New password: '));
+
                 if (!password) {
                     console.error('Password is required.');
                     process.exit(1);

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -140,7 +140,7 @@ export function registerConfigCommand(
             .option('--password <password>', 'New password')
             .action(async (name: string | undefined, cmdOpts: { password?: string }) => {
                 // Validate environment exists before prompting for password
-                const cfg = await loadConfig(cliName, configOpts) as any;
+                const cfg = await loadConfig(cliName, configOpts);
 
                 if (!cfg || Object.keys(cfg.environments).length === 0) {
                     console.error(`No environments configured. Run '${cliName} config import' first.`);

--- a/src/commands/config/switch/switch.ts
+++ b/src/commands/config/switch/switch.ts
@@ -12,10 +12,14 @@ export interface ConfigSwitchResult {
 
 export async function configSwitchAction(deps: ConfigSwitchDeps): Promise<ConfigSwitchResult> {
     const ok = await deps.switchEnv(deps.name);
+
     if (!ok) {
         const envs = deps.listEnvs ? await deps.listEnvs() : [];
+
         return { ok: false, available: envs.map(e => e.name) };
     }
+
     deps.invalidateSession();
+
     return { ok: true };
 }

--- a/src/commands/config/update-password/update-password.ts
+++ b/src/commands/config/update-password/update-password.ts
@@ -14,12 +14,14 @@ export interface ConfigUpdatePasswordResult {
 
 export async function configUpdatePasswordAction(deps: ConfigUpdatePasswordDeps): Promise<ConfigUpdatePasswordResult> {
     const cfg = await deps.loadConfig(deps.cliName);
+
     if (!cfg || Object.keys(cfg.environments).length === 0) {
         throw new Error(`No environments configured. Run '${deps.cliName} config import' first.`);
     }
 
     const envName = deps.envName ?? cfg.active;
     const env = cfg.environments[envName];
+
     if (!env) {
         throw new Error(`Environment '${envName}' not found.`);
     }

--- a/src/commands/config/update-password/update-password.ts
+++ b/src/commands/config/update-password/update-password.ts
@@ -1,8 +1,10 @@
+import type { CliConfig, EnvironmentConfig } from '../../../config';
+
 export interface ConfigUpdatePasswordDeps {
     envName?: string;
     password: string;
-    loadConfig: (cliName: string) => Promise<{ active: string; environments: Record<string, { url: string; user: string; password: string }> } | null>;
-    save: (...args: any[]) => Promise<void>;
+    loadConfig: (cliName: string) => Promise<CliConfig | null>;
+    save: (cliName: string, name: string, env: EnvironmentConfig, setActive?: boolean, opts?: Record<string, unknown>) => Promise<void>;
     cliName: string;
     saveOpts: Record<string, unknown>;
 }

--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -13,6 +13,7 @@ export async function generateAction(input: GenerateInput): Promise<void> {
     if (!input.env) {
         throw new Error('No active environment.');
     }
+
     await input.fetchAndGenerate({
         baseUrl: input.env.url,
         specPath: input.specPath,

--- a/src/commands/mcp/mcp.ts
+++ b/src/commands/mcp/mcp.ts
@@ -16,11 +16,13 @@ export async function mcpAction(input: McpInput): Promise<void> {
             generatedDir: input.generatedDir,
             routinesDir: input.routinesDir,
         });
-    } catch (e: any) {
+    } catch (e: unknown) {
         if (
-            e?.code === 'MODULE_NOT_FOUND'
-            || e?.message?.includes('Cannot find module')
-            || e?.message?.includes('Failed to resolve')
+            e instanceof Error && (
+                (e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND'
+                || e.message.includes('Cannot find module')
+                || e.message.includes('Failed to resolve')
+            )
         ) {
             throw new Error('MCP server requires @modelcontextprotocol/sdk');
         }

--- a/src/commands/mcp/mcp.ts
+++ b/src/commands/mcp/mcp.ts
@@ -26,6 +26,7 @@ export async function mcpAction(input: McpInput): Promise<void> {
         ) {
             throw new Error('MCP server requires @modelcontextprotocol/sdk');
         }
+
         throw e;
     }
 }

--- a/src/commands/routine/init/init.ts
+++ b/src/commands/routine/init/init.ts
@@ -16,8 +16,10 @@ export function routineInitAction(deps: RoutineInitDeps): RoutineInitResult {
     if (!deps.builtinDir || !deps.exists(deps.builtinDir)) {
         throw new Error('No built-in routines directory found.');
     }
+
     deps.mkdir(deps.routinesDir, { recursive: true });
     deps.copy(deps.builtinDir, deps.routinesDir, { recursive: true });
     const routines = deps.listDir(deps.builtinDir);
+
     return { installed: routines.length, routinesDir: deps.routinesDir };
 }

--- a/src/commands/routine/list/list.ts
+++ b/src/commands/routine/list/list.ts
@@ -5,16 +5,20 @@ export interface RoutineListDeps {
 
 export function routineListAction(deps: RoutineListDeps): string[] {
     const routines = deps.listRoutines();
+
     if (!deps.path) return routines;
 
     const prefix = deps.path.replace(/\/+$/, '');
+
     return routines
         .filter((r) => {
             const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
+
             return clean.startsWith(prefix + '/');
         })
         .map((r) => {
             const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
+
             return clean.slice(prefix.length + 1);
         });
 }

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -13,12 +13,14 @@ import { routineInitAction } from './init/init';
 
 export function loadBuiltinRoutines(builtinDir: string): Record<string, string> | undefined {
     if (!existsSync(builtinDir)) return undefined;
+
     const map: Record<string, string> = {};
 
     function collect(dir: string, prefix: string) {
         for (const entry of readdirSync(dir, { withFileTypes: true })) {
             const fullPath = resolve(dir, entry.name);
             const key = prefix ? `${prefix}/${entry.name}` : entry.name;
+
             if (entry.isDirectory()) {
                 collect(fullPath, key);
             } else if (
@@ -31,6 +33,7 @@ export function loadBuiltinRoutines(builtinDir: string): Record<string, string> 
     }
 
     collect(builtinDir, '');
+
     return Object.keys(map).length > 0 ? map : undefined;
 }
 
@@ -58,6 +61,7 @@ export function registerRoutineCommand(
                 listRoutines: () => listRoutines(routinesDir, builtinsMap),
                 path,
             });
+
             if (result.length === 0) {
                 if (path) {
                     console.log(`No routines found under '${path.replace(/\/+$/, '')}/'`);
@@ -65,8 +69,10 @@ export function registerRoutineCommand(
                     console.log(`No routines found in ~/.${cliName}/routines/`);
                     console.log(`Run '${cliName} routine init' to install built-in routines.`);
                 }
+
                 return;
             }
+
             console.log(
                 opts.tree
                     ? formatRoutineTree(result)
@@ -86,8 +92,10 @@ export function registerRoutineCommand(
             }
 
             const overrides: Record<string, unknown> = {};
+
             for (const s of opts.set || []) {
                 const eq = s.indexOf('=');
+
                 if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
             }
 
@@ -122,6 +130,7 @@ export function registerRoutineCommand(
                 console.log(
                     `\nRoutine ${result.success ? '\x1b[32mcompleted\x1b[0m' : '\x1b[31mfailed\x1b[0m'}: ${result.stepsRun} run, ${result.stepsSkipped} skipped, ${result.stepsFailed} failed (${timeStr})`,
                 );
+
                 if (!result.success) process.exit(1);
             } catch (err) {
                 console.error(err instanceof Error ? err.message : String(err));
@@ -137,11 +146,15 @@ export function registerRoutineCommand(
                 loadRoutine: () => loadRoutineFile(name, routinesDir, builtinsMap),
                 validateRoutine,
             });
+
             if (!result.valid) {
                 console.error('Validation errors:');
+
                 for (const e of result.errors) console.error(`  - ${e}`);
+
                 process.exit(1);
             }
+
             console.log(`Routine "${result.name}" is valid.`);
         });
 
@@ -156,8 +169,10 @@ export function registerRoutineCommand(
             }
 
             const overrides: Record<string, unknown> = {};
+
             for (const s of opts.set || []) {
                 const eq = s.indexOf('=');
+
                 if (eq > 0) overrides[s.slice(0, eq)] = s.slice(eq + 1);
             }
 
@@ -182,6 +197,7 @@ export function registerRoutineCommand(
                 });
 
                 console.log('');
+
                 if (result.success) {
                     console.log(`\x1b[32mPASSED\x1b[0m: ${result.stepsRun} steps run, ${result.stepsSkipped} skipped`);
                 } else {

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -221,7 +221,7 @@ export function registerRoutineCommand(
                     exists: existsSync,
                     mkdir: mkdirSync,
                     copy: cpSync,
-                    listDir: readdirSync as any,
+                    listDir: (path: string) => readdirSync(path) as string[],
                 });
                 console.log(`Installed ${result.installed} routines to ${result.routinesDir}`);
             } catch (err) {

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -1,15 +1,17 @@
 import type { CommandDispatcher } from '../../../types';
+import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
+import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineRunDeps {
-    loadRoutine: () => any;
-    validateRoutine: (def: any) => string[];
-    executeRoutine: (def: any, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: any) => Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }>;
+    loadRoutine: () => RoutineDefinition;
+    validateRoutine: (def: RoutineDefinition) => string[];
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     dryRun?: boolean;
     invalidateSession: () => void;
-    onStep?: (step: any, i: number, total: number) => void;
-    onIteration?: (step: any, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+    onStep?: (step: RoutineStep, i: number, total: number) => void;
+    onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
 }
 
 export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number; name: string; description?: string }> {

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -15,6 +15,7 @@ export interface RoutineRunDeps {
 export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number; name: string; description?: string }> {
     const def = deps.loadRoutine();
     const errors = deps.validateRoutine(def);
+
     if (errors.length > 0) {
         throw new Error(`Validation errors:\n${errors.map(e => `  - ${e}`).join('\n')}`);
     }

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -13,11 +13,13 @@ export interface RoutineTestDeps {
 
 export async function routineTestAction(deps: RoutineTestDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }> {
     const spec = deps.loadSpec();
+
     if (!spec) {
         throw new Error(`No spec.yaml found for routine "${deps.routineName}".`);
     }
 
     const errors = deps.validateRoutine(spec);
+
     if (errors.length > 0) {
         throw new Error(`Spec validation errors:\n${errors.map(e => `  - ${e}`).join('\n')}`);
     }

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -1,14 +1,16 @@
 import type { CommandDispatcher } from '../../../types';
+import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
+import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineTestDeps {
-    loadSpec: () => any | null;
-    validateRoutine: (def: any) => string[];
-    executeRoutine: (def: any, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: any) => Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }>;
+    loadSpec: () => RoutineDefinition | null;
+    validateRoutine: (def: RoutineDefinition) => string[];
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     routineName?: string;
-    onStep?: (step: any, i: number, total: number) => void;
-    onIteration?: (step: any, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+    onStep?: (step: RoutineStep, i: number, total: number) => void;
+    onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
 }
 
 export async function routineTestAction(deps: RoutineTestDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number }> {

--- a/src/commands/routine/validate/validate.ts
+++ b/src/commands/routine/validate/validate.ts
@@ -1,6 +1,8 @@
+import type { RoutineDefinition } from '../../../routine/types';
+
 export interface RoutineValidateDeps {
-    loadRoutine: () => { name: string; steps: unknown[] };
-    validateRoutine: (def: any) => string[];
+    loadRoutine: () => RoutineDefinition;
+    validateRoutine: (def: RoutineDefinition) => string[];
 }
 
 export interface RoutineValidateResult {

--- a/src/commands/routine/validate/validate.ts
+++ b/src/commands/routine/validate/validate.ts
@@ -12,5 +12,6 @@ export interface RoutineValidateResult {
 export function routineValidateAction(deps: RoutineValidateDeps): RoutineValidateResult {
     const def = deps.loadRoutine();
     const errors = deps.validateRoutine(def);
+
     return { valid: errors.length === 0, name: def.name, errors };
 }

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { saveEnvironment, verifyCredentials } from '../../config';
+import type { EnvironmentConfig } from '../../config';
 import { prompt, hiddenPrompt } from '../../prompt';
 
 export interface SetupInput {
@@ -9,7 +10,7 @@ export interface SetupInput {
     user: string;
     password: string;
     verify: (url: string, user: string, password: string) => Promise<{ ok: boolean; reason?: string }>;
-    save: (cliName: string, envName: string, creds: { url: string; user: string; password: string }, switchTo: boolean, opts: Record<string, unknown>) => Promise<void>;
+    save: (cliName: string, envName: string, creds: EnvironmentConfig, switchTo: boolean, opts: Record<string, unknown>) => Promise<void>;
     saveOpts?: Record<string, unknown>;
 }
 

--- a/src/commands/upgrade/upgrade.ts
+++ b/src/commands/upgrade/upgrade.ts
@@ -13,9 +13,11 @@ export interface UpgradeResult {
 
 export async function upgradeAction(input: UpgradeInput): Promise<UpgradeResult | null> {
     const latest = await input.checkLatest();
+
     if (latest === input.currentVersion) return null;
 
     const exitCode = await input.install(latest);
+
     if (exitCode !== 0) throw new Error('Upgrade failed.');
 
     return { previousVersion: input.currentVersion, newVersion: latest };
@@ -23,8 +25,11 @@ export async function upgradeAction(input: UpgradeInput): Promise<UpgradeResult 
 
 async function checkNpmLatest(): Promise<string> {
     const res = await fetch('https://registry.npmjs.org/@apijack/core/latest');
+
     if (!res.ok) throw new Error('Failed to check for updates.');
+
     const data = await res.json() as { version: string };
+
     return data.version;
 }
 
@@ -33,6 +38,7 @@ async function bunInstallGlobal(version: string): Promise<number> {
         stdout: 'inherit',
         stderr: 'inherit',
     });
+
     return proc.exited;
 }
 
@@ -50,6 +56,7 @@ export function registerUpgradeCommand(program: Command, version: string): void 
 
                 if (!result) {
                     console.log(`Already on the latest version (v${version}).`);
+
                     return;
                 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,6 +71,7 @@ export function resolveAuth(
 
     const configPath = resolveConfigPath(cliName, opts);
     const env = loadActiveEnvSync(configPath);
+
     if (env) {
         return {
             baseUrl: env.url,
@@ -89,9 +90,12 @@ export function resolveAuth(
 function loadActiveEnvSync(path: string): EnvironmentConfig | null {
     try {
         if (!existsSync(path)) return null;
+
         const text = readFileSync(path, 'utf-8');
         const config = JSON.parse(text) as CliConfig;
+
         if (!config.active || !config.environments?.[config.active]) return null;
+
         return config.environments[config.active];
     } catch {
         return null;
@@ -107,6 +111,7 @@ export function getActiveEnvConfig(
     opts?: ConfigOpts,
 ): EnvironmentConfig | null {
     const configPath = resolveConfigPath(cliName, opts);
+
     return loadActiveEnvSync(configPath);
 }
 
@@ -120,8 +125,11 @@ export async function loadConfig(
     const configPath = resolveConfigPath(cliName, opts);
     try {
         const file = Bun.file(configPath);
+
         if (!(await file.exists())) return null;
+
         const raw = await file.json();
+
         return raw as CliConfig;
     } catch {
         return null;
@@ -148,6 +156,7 @@ export async function saveEnvironment(
 
     // Check URL safety before storing credentials
     const classification = classifyUrl(env.url, opts?.allowedCidrs);
+
     if (!classification.safe && !opts?.allowInsecureStorage) {
         let hostname: string;
         try {
@@ -171,6 +180,7 @@ export async function saveEnvironment(
     };
 
     config.environments[name] = env as EnvironmentConfig;
+
     if (setActive) config.active = name;
 
     const dir = dirname(configPath);
@@ -189,10 +199,12 @@ export async function switchEnvironment(
 ): Promise<boolean> {
     const configPath = resolveConfigPath(cliName, opts);
     const config = await loadConfig(cliName, opts);
+
     if (!config || !config.environments[name]) return false;
 
     config.active = name;
     await Bun.write(configPath, JSON.stringify(config, null, 2) + '\n');
+
     return true;
 }
 
@@ -204,6 +216,7 @@ export async function listEnvironments(
     opts?: ConfigOpts,
 ): Promise<{ name: string; url: string; user: string; active: boolean }[]> {
     const config = await loadConfig(cliName, opts);
+
     if (!config) return [];
 
     return Object.entries(config.environments).map(([name, env]) => ({
@@ -226,9 +239,11 @@ export async function updateEnvironmentField(
 ): Promise<void> {
     const configPath = resolveConfigPath(cliName, opts);
     const config = await loadConfig(cliName, opts);
+
     if (!config || !config.active) return;
 
     const env = config.environments[config.active];
+
     if (!env) return;
 
     (env as Record<string, unknown>)[fieldName] = value;
@@ -248,9 +263,11 @@ export async function verifyCredentials(
     };
     try {
         const res = await fetch(`${url}/v3/api-docs`, { headers, method: 'HEAD' });
+
         if (!res.ok) {
             return { ok: false, reason: `Authentication failed: ${res.status}` };
         }
+
         return { ok: true };
     } catch {
         return { ok: false, reason: `Could not reach ${url} — server may be down.` };

--- a/src/mcp-server-entry.ts
+++ b/src/mcp-server-entry.ts
@@ -15,7 +15,9 @@ export function loadPluginConfig(dataDir?: string): PluginConfig | null {
     const configPath = join(dir, 'plugin.json');
     try {
         if (!existsSync(configPath)) return null;
+
         const raw = readFileSync(configPath, 'utf-8');
+
         return JSON.parse(raw) as PluginConfig;
     } catch {
         return null;
@@ -25,6 +27,7 @@ export function loadPluginConfig(dataDir?: string): PluginConfig | null {
 // Entry point — only runs when executed directly
 if (import.meta.main) {
     const config = loadPluginConfig();
+
     if (!config) {
         console.error("apijack plugin not configured. Run your CLI's 'plugin install' command first.");
         console.error('Expected config at: ~/.apijack/plugin.json');
@@ -41,6 +44,7 @@ if (import.meta.main) {
 
     // Resolve generatedDir using same logic as CLI entry point
     let generatedDir: string;
+
     if (projectConfig?.generatedDir && projectConfigPath) {
         generatedDir = resolve(projectRoot, projectConfig.generatedDir);
     } else if (projectConfigPath) {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,4 +1,4 @@
-import type { McpContext } from './types';
+import type { McpContext, ToolResult } from './types';
 
 import { listCommandsTool } from './tools/commands/list-commands/list-commands';
 import { describeCommandTool } from './tools/commands/describe-command/describe-command';
@@ -46,7 +46,7 @@ export async function startMcpServer(opts: McpContext): Promise<void> {
         server.registerTool(tool.name, {
             description: tool.description,
             inputSchema: tool.schema,
-        }, (params: Record<string, unknown>) => tool.handler(params as any, opts));
+        }, (params: Record<string, unknown>) => (tool.handler as (p: Record<string, unknown>, ctx: McpContext) => Promise<ToolResult>)(params, opts));
     }
 
     const transport = new StdioServerTransport();

--- a/src/mcp/tools/codegen/generate/generate.spec.ts
+++ b/src/mcp/tools/codegen/generate/generate.spec.ts
@@ -20,6 +20,7 @@ describe('generate tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/codegen/generate/generate.spec.ts
+++ b/src/mcp/tools/codegen/generate/generate.spec.ts
@@ -18,7 +18,7 @@ describe('generate tool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (cmd: string[], _opts: any) => {
+        Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
             return {
                 stdout: new ReadableStream({
@@ -50,7 +50,7 @@ describe('generate tool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (_cmd: string[], _opts: any) => {
+        Bun.spawn = (_cmd: string[], _opts: unknown) => {
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/codegen/generate/generate.ts
+++ b/src/mcp/tools/codegen/generate/generate.ts
@@ -12,12 +12,14 @@ export const generateTool = defineTool({
             ['generate'],
             ctx.projectRoot ?? undefined,
         );
+
         if (exitCode !== 0) {
             return textResult(
                 `Generate failed (exit ${exitCode}):\n${stderr || stdout}`,
                 true,
             );
         }
+
         return textResult(stdout);
     },
 });

--- a/src/mcp/tools/codegen/get-spec/get-spec.ts
+++ b/src/mcp/tools/codegen/get-spec/get-spec.ts
@@ -24,6 +24,7 @@ export const getSpecTool = defineTool({
             const blocks: string[] = [];
             const typeRegex = /^export (?:interface|type) (\w+)/gm;
             let match;
+
             while ((match = typeRegex.exec(content)) !== null) {
                 blocks.push(match[1]);
             }

--- a/src/mcp/tools/commands/describe-command/describe-command.ts
+++ b/src/mcp/tools/commands/describe-command/describe-command.ts
@@ -16,13 +16,16 @@ export const describeCommandTool = defineTool({
             const mapModule = await import(mapPath);
             const commandMap = mapModule.commandMap as Record<string, Record<string, unknown>>;
             const info = commandMap[params.command];
+
             if (!info) {
                 const available = Object.keys(commandMap).join(', ');
+
                 return textResult(
                     `Command "${params.command}" not found. Available commands: ${available}`,
                     true,
                 );
             }
+
             return textResult(JSON.stringify(info, null, 2));
         } catch {
             return textResult(

--- a/src/mcp/tools/commands/list-commands/list-commands.ts
+++ b/src/mcp/tools/commands/list-commands/list-commands.ts
@@ -26,6 +26,7 @@ export const listCommandsTool = defineTool({
             > = mapModule.commandMap;
 
             let entries = Object.entries(commandMap);
+
             if (params.filter) {
                 const prefix = params.filter.toLowerCase();
                 entries = entries.filter(([path]) =>
@@ -43,12 +44,17 @@ export const listCommandsTool = defineTool({
 
             const lines = entries.map(([path, info]) => {
                 const parts = [path];
+
                 if (info.description) parts.push(`- ${info.description}`);
+
                 if (info.pathParams.length > 0)
                     parts.push(`[path: ${info.pathParams.join(', ')}]`);
+
                 if (info.queryParams.length > 0)
                     parts.push(`[query: ${info.queryParams.join(', ')}]`);
+
                 if (info.hasBody) parts.push('[has body]');
+
                 return parts.join('  ');
             });
 

--- a/src/mcp/tools/commands/run-commands/run-commands.spec.ts
+++ b/src/mcp/tools/commands/run-commands/run-commands.spec.ts
@@ -20,6 +20,7 @@ describe('runCommandsTool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c) {
@@ -66,6 +67,7 @@ describe('runCommandsTool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/commands/run-commands/run-commands.spec.ts
+++ b/src/mcp/tools/commands/run-commands/run-commands.spec.ts
@@ -18,7 +18,7 @@ describe('runCommandsTool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (cmd: string[], _opts: any) => {
+        Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
             return {
                 stdout: new ReadableStream({
@@ -64,7 +64,7 @@ describe('runCommandsTool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (cmd: string[], _opts: any) => {
+        Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
             return {
                 stdout: new ReadableStream({

--- a/src/mcp/tools/commands/run-commands/run-commands.ts
+++ b/src/mcp/tools/commands/run-commands/run-commands.ts
@@ -19,6 +19,7 @@ export const runCommandsTool = defineTool({
         const results: string[] = [];
         let failures = 0;
         let ran = 0;
+
         for (let i = 0; i < params.commands.length; i++) {
             ran++;
             const cmd = params.commands[i];
@@ -31,9 +32,11 @@ export const runCommandsTool = defineTool({
                 ...cmdParts,
                 ...flagArgs,
             ], ctx.projectRoot ?? undefined);
+
             if (exitCode !== 0) {
                 failures++;
                 results.push(`[${i + 1}/${params.commands.length}] FAIL: ${cmd.command}\n${stderr || stdout}`);
+
                 if (params.stop_on_error) {
                     results.push(`Stopped after ${ran}/${params.commands.length} commands.`);
                     break;
@@ -42,7 +45,9 @@ export const runCommandsTool = defineTool({
                 results.push(`[${i + 1}/${params.commands.length}] OK: ${cmd.command}${stdout ? '\n' + stdout.trim() : ''}`);
             }
         }
+
         const summary = `Ran ${ran}/${params.commands.length} commands (${failures} failed)`;
+
         return textResult(
             summary + '\n\n' + results.join('\n\n'),
             failures > 0,

--- a/src/mcp/tools/config/config-list/config-list.spec.ts
+++ b/src/mcp/tools/config/config-list/config-list.spec.ts
@@ -18,7 +18,7 @@ describe('config_list tool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (cmd: string[], _opts: any) => {
+        Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
             return {
                 stdout: new ReadableStream({

--- a/src/mcp/tools/config/config-list/config-list.spec.ts
+++ b/src/mcp/tools/config/config-list/config-list.spec.ts
@@ -20,6 +20,7 @@ describe('config_list tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/config/config-list/config-list.ts
+++ b/src/mcp/tools/config/config-list/config-list.ts
@@ -12,12 +12,14 @@ export const configListTool = defineTool({
             ['config', 'list'],
             ctx.projectRoot ?? undefined,
         );
+
         if (exitCode !== 0) {
             return textResult(
                 `Config list failed (exit ${exitCode}):\n${stderr || stdout}`,
                 true,
             );
         }
+
         return textResult(stdout);
     },
 });

--- a/src/mcp/tools/config/config-switch/config-switch.spec.ts
+++ b/src/mcp/tools/config/config-switch/config-switch.spec.ts
@@ -18,7 +18,7 @@ describe('config_switch tool', () => {
         const origSpawn = Bun.spawn;
 
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (cmd: string[], _opts: any) => {
+        Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
             return {
                 stdout: new ReadableStream({

--- a/src/mcp/tools/config/config-switch/config-switch.spec.ts
+++ b/src/mcp/tools/config/config-switch/config-switch.spec.ts
@@ -20,6 +20,7 @@ describe('config_switch tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/config/config-switch/config-switch.ts
+++ b/src/mcp/tools/config/config-switch/config-switch.ts
@@ -15,12 +15,14 @@ export const configSwitchTool = defineTool({
             ['config', 'switch', params.name],
             ctx.projectRoot ?? undefined,
         );
+
         if (exitCode !== 0) {
             return textResult(
                 `Config switch failed (exit ${exitCode}):\n${stderr || stdout}`,
                 true,
             );
         }
+
         return textResult(stdout);
     },
 });

--- a/src/mcp/tools/config/get-config/get-config.ts
+++ b/src/mcp/tools/config/get-config/get-config.ts
@@ -11,11 +11,14 @@ export const getConfigTool = defineTool({
             ctx.cliName,
             ctx.configPath ? { configPath: ctx.configPath } : undefined,
         );
+
         if (!env) {
             return textResult('No active environment configured.', true);
         }
+
         // Strip password from output
         const { password: _password, ...safe } = env;
+
         return textResult(JSON.stringify(safe, null, 2));
     },
 });

--- a/src/mcp/tools/config/setup/setup.spec.ts
+++ b/src/mcp/tools/config/setup/setup.spec.ts
@@ -21,7 +21,7 @@ describe('setup tool', () => {
 
         const origSpawn = Bun.spawn;
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (_cmd: string[], _opts: any) => {
+        Bun.spawn = (_cmd: string[], _opts: unknown) => {
             return {
                 stdout: new ReadableStream({
                     start(c) {
@@ -83,7 +83,7 @@ describe('setup tool', () => {
 
         const origSpawn = Bun.spawn;
         // @ts-expect-error - mocking Bun.spawn
-        Bun.spawn = (_cmd: string[], _opts: any) => {
+        Bun.spawn = (_cmd: string[], _opts: unknown) => {
             return {
                 stdout: new ReadableStream({
                     start(c) {

--- a/src/mcp/tools/config/setup/setup.ts
+++ b/src/mcp/tools/config/setup/setup.ts
@@ -21,6 +21,7 @@ export const setupTool = defineTool({
     },
     handler: async (params, ctx) => {
         const classification = classifyUrl(params.url, ctx.allowedCidrs);
+
         if (!classification.safe) {
             let hostname: string;
             try {
@@ -28,6 +29,7 @@ export const setupTool = defineTool({
             } catch {
                 hostname = params.url;
             }
+
             return textResult(
                 `Production API detected (${hostname}).\n`
                 + 'The MCP setup tool cannot store credentials for production APIs.\n\n'
@@ -43,13 +45,16 @@ export const setupTool = defineTool({
         // Bootstrap project config if in a project directory without .apijack.json
         if (ctx.projectRoot) {
             const apijackJsonPath = join(ctx.projectRoot, '.apijack.json');
+
             if (!existsSync(apijackJsonPath)) {
                 const hasPackageJson = existsSync(join(ctx.projectRoot, 'package.json'));
                 const hasGit = existsSync(join(ctx.projectRoot, '.git'));
+
                 if (hasPackageJson || hasGit) {
                     let specUrl = '/v3/api-docs';
                     try {
                         specUrl = new URL(params.url).pathname || '/v3/api-docs';
+
                         if (specUrl === '/') specUrl = '/v3/api-docs';
                     } catch {}
                     writeFileSync(apijackJsonPath, JSON.stringify({
@@ -75,7 +80,9 @@ export const setupTool = defineTool({
             const configOpts: { configPath?: string; allowedCidrs?: string[] } = {
                 allowedCidrs: ctx.allowedCidrs,
             };
+
             if (ctx.configPath) configOpts.configPath = ctx.configPath;
+
             await saveEnvironment(ctx.cliName, params.name, {
                 url: params.url,
                 user: params.user,
@@ -93,6 +100,7 @@ export const setupTool = defineTool({
             const { stdout: genOut, stderr: genErr, exitCode: genCode } = await runCli(
                 ctx.cliInvocation, ['generate'], ctx.projectRoot ?? undefined,
             );
+
             if (genCode !== 0) {
                 return textResult(
                     `Environment "${params.name}" configured (${params.url})\n`
@@ -100,6 +108,7 @@ export const setupTool = defineTool({
                     true,
                 );
             }
+
             return textResult(
                 `Environment "${params.name}" configured (${params.url})\n${genOut.trim()}`,
             );

--- a/src/mcp/tools/routines/create-routine/create-routine.ts
+++ b/src/mcp/tools/routines/create-routine/create-routine.ts
@@ -17,6 +17,7 @@ export const createRoutineTool = defineTool({
             const filename = params.name.endsWith('.yaml') ? params.name : `${params.name}.yaml`;
             const filePath = join(ctx.routinesDir, filename);
             writeFileSync(filePath, params.content);
+
             return textResult(`Routine saved to ${filePath}`);
         } catch (err) {
             return textResult(

--- a/src/mcp/tools/routines/get-routine-templates/get-routine-templates.spec.ts
+++ b/src/mcp/tools/routines/get-routine-templates/get-routine-templates.spec.ts
@@ -20,6 +20,7 @@ describe('get_routine_templates tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], _opts: unknown) => {
             spawnCalls.push(cmd);
+
             return {
                 stdout: new ReadableStream({
                     start(c: ReadableStreamDefaultController) {
@@ -109,6 +110,7 @@ describe('get_routine_templates tool', () => {
         Bun.spawn = (_cmd: string[], _opts: unknown) => {
             callCount++;
             const output = callCount === 1 ? '- name: first' : '- name: second';
+
             return {
                 stdout: new ReadableStream({
                     start(c: ReadableStreamDefaultController) {

--- a/src/mcp/tools/routines/get-routine-templates/get-routine-templates.ts
+++ b/src/mcp/tools/routines/get-routine-templates/get-routine-templates.ts
@@ -16,6 +16,7 @@ export const getRoutineTemplatesTool = defineTool({
     },
     handler: async (params, ctx) => {
         const templates: string[] = [];
+
         for (const cmd of params.commands) {
             const cmdParts = cmd.command.split(/\s+/);
             const flagArgs = Object.entries(cmd.args || {}).flatMap(([k, v]) => [
@@ -27,12 +28,14 @@ export const getRoutineTemplatesTool = defineTool({
                 ...flagArgs,
                 '-o', 'routine-step',
             ], ctx.projectRoot ?? undefined);
+
             if (exitCode !== 0) {
                 templates.push(`# Error getting template for: ${cmd.command}\n# ${(stderr || stdout).trim()}`);
             } else {
                 templates.push(stdout.trim());
             }
         }
+
         return textResult(templates.join('\n\n'));
     },
 });

--- a/src/mcp/tools/routines/list-routines/list-routines.ts
+++ b/src/mcp/tools/routines/list-routines/list-routines.ts
@@ -8,13 +8,16 @@ export const listRoutinesTool = defineTool({
     schema: {},
     handler: async (_params, ctx) => {
         const routines = listRoutinesStructured(ctx.routinesDir);
+
         if (routines.length === 0) {
             return textResult(
                 `No routines found in ${ctx.routinesDir}/.\n`
                 + 'Create a routine with the create_routine tool or place a YAML file in that directory.',
             );
         }
+
         const lines = routines.map(r => r.name);
+
         return textResult(lines.join('\n'));
     },
 });

--- a/src/mcp/tools/routines/run-routine/run-routine.spec.ts
+++ b/src/mcp/tools/routines/run-routine/run-routine.spec.ts
@@ -37,6 +37,7 @@ describe('run_routine tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], opts: unknown) => {
             spawnCalls.push(cmd);
+
             return mockSpawn('done')(cmd, opts);
         };
 
@@ -69,6 +70,7 @@ describe('run_routine tool', () => {
         // @ts-expect-error - mocking Bun.spawn
         Bun.spawn = (cmd: string[], opts: unknown) => {
             spawnCalls.push(cmd);
+
             return mockSpawn('')(cmd, opts);
         };
 

--- a/src/mcp/tools/routines/run-routine/run-routine.ts
+++ b/src/mcp/tools/routines/run-routine/run-routine.ts
@@ -21,12 +21,14 @@ export const runRoutineTool = defineTool({
             params.name,
             ...setArgs,
         ], ctx.projectRoot ?? undefined);
+
         if (exitCode !== 0) {
             return textResult(
                 `Routine failed (exit ${exitCode}):\n${stderr || stdout}`,
                 true,
             );
         }
+
         return textResult(stdout);
     },
 });

--- a/src/mcp/utils/get-generated-dir.ts
+++ b/src/mcp/utils/get-generated-dir.ts
@@ -5,14 +5,18 @@ import type { McpContext } from '../types';
 export function getGeneratedDir(ctx: McpContext): string {
     if (ctx.projectRoot) {
         const projectConfigPath = findProjectConfig(ctx.projectRoot);
+
         if (projectConfigPath) {
             const projectConfig = loadProjectConfig(projectConfigPath);
             const projectRoot = dirname(projectConfigPath);
+
             if (projectConfig?.generatedDir) {
                 return resolve(projectRoot, projectConfig.generatedDir);
             }
+
             return resolve(projectRoot, '.apijack', 'generated');
         }
     }
+
     return ctx.generatedDir;
 }

--- a/src/mcp/utils/run-cli.ts
+++ b/src/mcp/utils/run-cli.ts
@@ -11,5 +11,6 @@ export async function runCli(
     const stdout = await new Response(proc.stdout).text();
     const stderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
+
     return { stdout, stderr, exitCode };
 }

--- a/src/output-request.ts
+++ b/src/output-request.ts
@@ -11,9 +11,11 @@ function shellQuote(s: string): string {
 
 function maskHeaders(headers: Record<string, string>): Record<string, string> {
     const masked: Record<string, string> = {};
+
     for (const [key, value] of Object.entries(headers)) {
         masked[key] = key.toLowerCase() === 'authorization' ? '****' : value;
     }
+
     return masked;
 }
 
@@ -23,6 +25,7 @@ export function formatDryRun(req: CapturedRequest): string {
 
     const masked = maskHeaders(req.headers);
     lines.push('Headers:');
+
     for (const [key, value] of Object.entries(masked)) {
         lines.push(`  ${key}: ${value}`);
     }
@@ -30,6 +33,7 @@ export function formatDryRun(req: CapturedRequest): string {
     if (req.body !== undefined) {
         lines.push('Body:');
         const json = JSON.stringify(req.body, null, 2);
+
         for (const line of json.split('\n')) {
             lines.push(`  ${line}`);
         }
@@ -52,6 +56,7 @@ export function formatCurl(
 
     for (const [key, value] of Object.entries(req.headers)) {
         if (key.toLowerCase() === 'authorization' && !opts.includeCreds) continue;
+
         parts.push(`  -H ${shellQuote(`${key}: ${value}`)}`);
     }
 

--- a/src/output.ts
+++ b/src/output.ts
@@ -4,13 +4,16 @@ export type OutputMode = 'json' | 'table' | 'quiet' | 'dry-run' | 'curl' | 'curl
 
 export function formatOutput(data: unknown, mode: OutputMode): string {
     if (mode === 'quiet') return '';
+
     if (mode === 'table') return formatTable(data);
+
     return JSON.stringify(data, null, 2);
 }
 
 function formatTable(data: unknown): string {
     if (!Array.isArray(data) || data.length === 0 || typeof data[0] !== 'object' || data[0] === null) {
         process.stderr.write('Warning: response is not a flat array of objects, falling back to JSON\n');
+
         return JSON.stringify(data, null, 2);
     }
 

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -40,11 +40,13 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         owner: { name: 'Local Plugins' },
         plugins: [],
     };
+
     if (existsSync(localMarketplacePath)) {
         try {
             localMarketplace = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
         } catch {}
     }
+
     const plugins = (localMarketplace.plugins as Array<{ name: string; [k: string]: unknown }>) || [];
     const idx = plugins.findIndex(p => p.name === 'apijack');
     const marketplaceEntry = {
@@ -53,8 +55,10 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         category: 'development',
         source: './apijack',
     };
+
     if (idx >= 0) plugins[idx] = marketplaceEntry;
     else plugins.push(marketplaceEntry);
+
     localMarketplace.plugins = plugins;
     writeFileSync(localMarketplacePath, JSON.stringify(localMarketplace, null, 2) + '\n');
 
@@ -90,16 +94,20 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     const distDir = join(pluginDir, 'dist');
     mkdirSync(distDir, { recursive: true });
     const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
+
     if (existsSync(bundleSrc)) {
         cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
     }
 
     // Copy skills (clear first to remove stale entries from previous versions)
     const skillsDst = join(pluginDir, 'skills');
+
     if (existsSync(skillsDst)) {
         rmSync(skillsDst, { recursive: true, force: true });
     }
+
     const skillsSrc = join(sourceDir, 'skills');
+
     if (existsSync(skillsSrc)) {
         cpSync(skillsSrc, skillsDst, { recursive: true });
     }
@@ -109,11 +117,13 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     const settingsPath = join(claudeDir, 'settings.json');
 
     const oldCacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
+
     if (existsSync(oldCacheDir)) {
         rmSync(oldCacheDir, { recursive: true, force: true });
     }
 
     const oldMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
+
     if (existsSync(oldMarketplaceDir)) {
         rmSync(oldMarketplaceDir, { recursive: true, force: true });
     }
@@ -122,7 +132,9 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     const installedPlugins = existsSync(installedPath)
         ? JSON.parse(readFileSync(installedPath, 'utf-8'))
         : { version: 2, plugins: {} };
+
     if (!installedPlugins.plugins) installedPlugins.plugins = {};
+
     delete installedPlugins.plugins['apijack@apijack'];
     installedPlugins.plugins['apijack@local'] = [{
         scope: 'user',
@@ -137,7 +149,9 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     const settings = existsSync(settingsPath)
         ? JSON.parse(readFileSync(settingsPath, 'utf-8'))
         : {};
+
     if (!settings.enabledPlugins) settings.enabledPlugins = {};
+
     delete settings.enabledPlugins['apijack@apijack'];
     settings.enabledPlugins['apijack@local'] = true;
     writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -66,7 +66,7 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
             description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
             version,
             author: { name: 'apijack' },
-            repository: 'https://github.com/Premo-Cloud/apijack',
+            repository: 'https://github.com/normalled/apijack',
             license: 'MIT',
             keywords: ['openapi', 'cli', 'mcp', 'api', 'routines'],
         }, null, 2) + '\n',

--- a/src/plugin/register.ts
+++ b/src/plugin/register.ts
@@ -26,6 +26,7 @@ export function registerPluginCommand(
 
             // Build the bundle if it doesn't exist
             const bundlePath = resolve(paths.sourceDir, 'dist', 'mcp-server.bundle.js');
+
             if (!existsSync(bundlePath)) {
                 console.log('Building MCP server bundle...');
                 const buildScript = resolve(paths.sourceDir, 'scripts', 'build-plugin.ts');
@@ -34,6 +35,7 @@ export function registerPluginCommand(
                     stderr: 'inherit',
                 });
                 const exitCode = await proc.exited;
+
                 if (exitCode !== 0) {
                     console.error('Bundle build failed.');
                     process.exit(1);
@@ -87,6 +89,7 @@ export function registerPluginCommand(
             const configPath = join(paths.userDataDir, 'plugin.json');
 
             let config: Record<string, unknown> = {};
+
             if (existsSync(configPath)) {
                 try {
                     config = JSON.parse(readFileSync(configPath, 'utf-8'));
@@ -94,10 +97,13 @@ export function registerPluginCommand(
             }
 
             const cidrs: string[] = (config.allowedCidrs as string[]) || [];
+
             if (cidrs.includes(cidr)) {
                 console.log(`CIDR ${cidr} is already in the allowlist.`);
+
                 return;
             }
+
             cidrs.push(cidr);
             config.allowedCidrs = cidrs;
             writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
@@ -113,6 +119,7 @@ export function registerPluginCommand(
 
             if (!existsSync(configPath)) {
                 console.error('No plugin config found.');
+
                 return;
             }
 
@@ -123,10 +130,13 @@ export function registerPluginCommand(
 
             const cidrs: string[] = (config.allowedCidrs as string[]) || [];
             const idx = cidrs.indexOf(cidr);
+
             if (idx === -1) {
                 console.log(`CIDR ${cidr} is not in the allowlist.`);
+
                 return;
             }
+
             cidrs.splice(idx, 1);
             config.allowedCidrs = cidrs;
             writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
@@ -142,6 +152,7 @@ export function registerPluginCommand(
 
             if (!existsSync(configPath)) {
                 console.log('No plugin config found.');
+
                 return;
             }
 

--- a/src/plugin/uninstall.ts
+++ b/src/plugin/uninstall.ts
@@ -15,18 +15,21 @@ export async function uninstallPlugin(opts: UninstallOptions): Promise<Uninstall
 
     // 1. Remove plugin directory from local marketplace
     const pluginDir = join(claudeDir, 'plugins', 'marketplaces', 'local', 'apijack');
+
     if (existsSync(pluginDir)) {
         rmSync(pluginDir, { recursive: true, force: true });
     }
 
     // Remove legacy separate marketplace directory
     const legacyMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
+
     if (existsSync(legacyMarketplaceDir)) {
         rmSync(legacyMarketplaceDir, { recursive: true, force: true });
     }
 
     // 2. Remove apijack entry from local marketplace.json
     const localMarketplacePath = join(claudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json');
+
     if (existsSync(localMarketplacePath)) {
         try {
             const local = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
@@ -37,6 +40,7 @@ export async function uninstallPlugin(opts: UninstallOptions): Promise<Uninstall
 
     // 3. Clean up registrations (current + legacy)
     const installedPath = join(claudeDir, 'plugins', 'installed_plugins.json');
+
     if (existsSync(installedPath)) {
         try {
             const installed = JSON.parse(readFileSync(installedPath, 'utf-8'));
@@ -47,19 +51,23 @@ export async function uninstallPlugin(opts: UninstallOptions): Promise<Uninstall
     }
 
     const settingsPath = join(claudeDir, 'settings.json');
+
     if (existsSync(settingsPath)) {
         try {
             const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+
             if (settings.enabledPlugins) {
                 delete settings.enabledPlugins['apijack@apijack'];
                 delete settings.enabledPlugins['apijack@local'];
             }
+
             writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
         } catch {}
     }
 
     // 4. Remove old plugin cache
     const cacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
+
     if (existsSync(cacheDir)) {
         rmSync(cacheDir, { recursive: true, force: true });
     }

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -7,10 +7,12 @@ export async function loadProjectAuth(
     apijackDir: string,
 ): Promise<AuthStrategy | null> {
     const authPath = join(apijackDir, 'auth.ts');
+
     if (!existsSync(authPath)) return null;
 
     try {
         const mod = await import(authPath);
+
         return (mod.default ?? mod) as AuthStrategy;
     } catch {
         return null;
@@ -26,6 +28,7 @@ export async function loadProjectCommands(
     apijackDir: string,
 ): Promise<LoadedCommand[]> {
     const cmdDir = join(apijackDir, 'commands');
+
     if (!existsSync(cmdDir)) return [];
 
     const commands: LoadedCommand[] = [];
@@ -36,6 +39,7 @@ export async function loadProjectCommands(
             const mod = await import(join(cmdDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const registrar = mod.default as CommandRegistrar;
+
             if (typeof registrar === 'function') {
                 commands.push({ name, registrar });
             }
@@ -51,6 +55,7 @@ export async function loadProjectDispatchers(
     apijackDir: string,
 ): Promise<Map<string, DispatcherHandler>> {
     const dispDir = join(apijackDir, 'dispatchers');
+
     if (!existsSync(dispDir)) return new Map();
 
     const dispatchers = new Map<string, DispatcherHandler>();
@@ -61,6 +66,7 @@ export async function loadProjectDispatchers(
             const mod = await import(join(dispDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const handler = mod.default as DispatcherHandler;
+
             if (typeof handler === 'function') {
                 dispatchers.set(name, handler);
             }

--- a/src/project.ts
+++ b/src/project.ts
@@ -16,11 +16,15 @@ export function findProjectConfig(startDir: string): string | null {
 
     while (dir !== root) {
         const candidate = join(dir, '.apijack.json');
+
         if (existsSync(candidate)) {
             return candidate;
         }
+
         const parent = dirname(dir);
+
         if (parent === dir) break;
+
         dir = parent;
     }
 
@@ -30,6 +34,7 @@ export function findProjectConfig(startDir: string): string | null {
 export function loadProjectConfig(configPath: string): ProjectConfig | null {
     try {
         const raw = readFileSync(configPath, 'utf-8');
+
         return JSON.parse(raw) as ProjectConfig;
     } catch {
         return null;
@@ -40,5 +45,6 @@ export function resolveConfigDir(projectConfigPath: string | null): string {
     if (projectConfigPath) {
         return join(dirname(projectConfigPath), '.apijack');
     }
+
     return join(homedir(), '.apijack');
 }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -44,13 +44,16 @@ export function hiddenPrompt(message: string, defaultValue?: string): Promise<st
                 // Accumulate escape sequences
                 if (escBuf.length > 0 || c === '\x1b') {
                     escBuf += c;
+
                     // Check for bracketed paste start: \x1b[200~
                     if (escBuf === '\x1b[200~' || escBuf === '\x1b[201~') {
                         escBuf = '';
                         continue;
                     }
+
                     // Still accumulating — wait for more chars (max 6 for bracketed paste)
                     if (escBuf.length < 6 && escBuf.startsWith('\x1b')) continue;
+
                     // Not a recognized sequence — discard
                     escBuf = '';
                     continue;
@@ -60,6 +63,7 @@ export function hiddenPrompt(message: string, defaultValue?: string): Promise<st
                     cleanup();
                     process.stdout.write('\n');
                     resolve(input || defaultValue || '');
+
                     return;
                 } else if (c === '\x7f' || c === '\b') {
                     input = input.slice(0, -1);

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -26,7 +26,6 @@ export function hiddenPrompt(message: string, defaultValue?: string): Promise<st
         process.stdout.write('\x1b[?2004h');
 
         let input = '';
-        let pasting = false;
         let escBuf = '';
 
         const cleanup = () => {
@@ -46,14 +45,7 @@ export function hiddenPrompt(message: string, defaultValue?: string): Promise<st
                 if (escBuf.length > 0 || c === '\x1b') {
                     escBuf += c;
                     // Check for bracketed paste start: \x1b[200~
-                    if (escBuf === '\x1b[200~') {
-                        pasting = true;
-                        escBuf = '';
-                        continue;
-                    }
-                    // Check for bracketed paste end: \x1b[201~
-                    if (escBuf === '\x1b[201~') {
-                        pasting = false;
+                    if (escBuf === '\x1b[200~' || escBuf === '\x1b[201~') {
                         escBuf = '';
                         continue;
                     }

--- a/src/routine/condition.ts
+++ b/src/routine/condition.ts
@@ -3,31 +3,39 @@ import { resolveRef } from './resolver';
 
 export function evaluateCondition(expr: string | undefined, ctx: RoutineContext): boolean {
     if (expr === undefined || expr === null) return true;
+
     if (expr === 'true') return true;
+
     if (expr === 'false') return false;
 
     // Equality: $ref == value (RHS can also be a $ref)
     const eqMatch = expr.match(/^(\$[a-zA-Z_][a-zA-Z0-9_.\-]*)\s*==\s*(.+)$/);
+
     if (eqMatch) {
         const resolved = resolveRef(eqMatch[1]!.slice(1), ctx);
         const rhs = eqMatch[2]!.trim();
         const rhsValue = rhs.startsWith('$') ? String(resolveRef(rhs.slice(1), ctx)) : rhs;
+
         return String(resolved) === rhsValue;
     }
 
     // Inequality: $ref != value (RHS can also be a $ref)
     const neqMatch = expr.match(/^(\$[a-zA-Z_][a-zA-Z0-9_.\-]*)\s*!=\s*(.+)$/);
+
     if (neqMatch) {
         const resolved = resolveRef(neqMatch[1]!.slice(1), ctx);
         const rhs = neqMatch[2]!.trim();
         const rhsValue = rhs.startsWith('$') ? String(resolveRef(rhs.slice(1), ctx)) : rhs;
+
         return String(resolved) !== rhsValue;
     }
 
     // Truthy check: $ref
     const refMatch = expr.match(/^\$([a-zA-Z_][a-zA-Z0-9_.\-]*)$/);
+
     if (refMatch) {
         const resolved = resolveRef(refMatch[1]!, ctx);
+
         return !!resolved;
     }
 

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -4,7 +4,7 @@ import { executeRoutine } from './executor';
 
 export interface DispatcherConfig {
     commandMap?: Record<string, { operationId: string; pathParams: string[]; queryParams: string[]; hasBody: boolean }>;
-    client?: any;
+    client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     ctx: CliContext;
@@ -37,7 +37,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
         if (config.commandMap && config.commandMap[command]) {
             const mapping = config.commandMap[command]!;
             const methodName = mapping.operationId;
-            const method = config.client?.[methodName];
+            const method = config.client?.[methodName] as ((...args: unknown[]) => Promise<unknown>) | undefined;
 
             if (!method) throw new Error(`Client method "${methodName}" not found`);
 
@@ -86,7 +86,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                 if (Object.keys(queryObj).length > 0) callArgs.push(queryObj);
             }
 
-            return await method.call(config.client, ...callArgs);
+            return await method.call(config.client as Record<string, unknown>, ...callArgs);
         }
 
         // 3. Consumer-registered dispatchers

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -38,6 +38,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
             const mapping = config.commandMap[command]!;
             const methodName = mapping.operationId;
             const method = config.client?.[methodName];
+
             if (!method) throw new Error(`Client method "${methodName}" not found`);
 
             const callArgs: unknown[] = [];
@@ -51,6 +52,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
             // Body from args
             if (mapping.hasBody) {
                 const body: Record<string, unknown> = {};
+
                 for (const [key, val] of Object.entries(args)) {
                     if (key.startsWith('--')) {
                         // Skip path params and query params — they're handled separately
@@ -60,22 +62,27 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                         const isQueryParam = mapping.queryParams.some(
                             (p: string) => `--${p}` === key,
                         );
+
                         if (!isPathParam && !isQueryParam) {
                             const propName = key.slice(2);
                             body[propName] = val;
                         }
                     }
                 }
+
                 if (Object.keys(body).length > 0) callArgs.push(body);
             }
 
             // Query params
             if (mapping.queryParams.length > 0) {
                 const queryObj: Record<string, unknown> = {};
+
                 for (const param of mapping.queryParams) {
                     const val = args[`--${param}`];
+
                     if (val !== undefined) queryObj[param] = val;
                 }
+
                 if (Object.keys(queryObj).length > 0) callArgs.push(queryObj);
             }
 
@@ -85,6 +92,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
         // 3. Consumer-registered dispatchers
         if (config.consumerHandlers?.has(command)) {
             const handler = config.consumerHandlers.get(command)!;
+
             return await handler(args, positionalArgs ?? [], config.ctx);
         }
 
@@ -93,20 +101,25 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
         // wait-until — poll with --interval (default 3s) and --timeout (default 120s) until truthy result
         if (command === 'wait-until') {
             const pollCmd = String(positionalArgs?.[0] || '');
+
             if (!pollCmd) throw new Error('wait-until requires a command to poll');
+
             const interval = Number(args['--interval'] || 3) * 1000;
             const timeout = Number(args['--timeout'] || 120) * 1000;
 
             const pollArgs: Record<string, unknown> = {};
+
             for (const [k, v] of Object.entries(args)) {
                 if (!['--interval', '--timeout'].includes(k)) pollArgs[k] = v;
             }
 
             const startTime = Date.now();
             let polls = 0;
+
             while (Date.now() - startTime < timeout) {
                 try {
                     const result = await dispatch(pollCmd, pollArgs, positionalArgs?.slice(1));
+
                     // Truthy check: non-zero number, non-empty string/array/object
                     if (
                         result !== 0
@@ -116,6 +129,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                         && !(Array.isArray(result) && result.length === 0)
                     ) {
                         if (polls > 0) process.stderr.write('\n');
+
                         return result;
                     }
                 } catch {
@@ -125,32 +139,41 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                 await new Promise(r => setTimeout(r, interval));
                 process.stderr.write('.');
             }
+
             if (polls > 0) process.stderr.write('\n');
+
             throw new Error(`wait-until timed out after ${timeout / 1000}s waiting for truthy result from: ${pollCmd}`);
         }
 
         // session refresh — call ctx.refreshSession()
         if (command === 'session refresh') {
             await config.ctx.refreshSession();
+
             return { refreshed: true };
         }
 
         // routine run — load and execute sub-routine
         if (command === 'routine run') {
             const routineName = String(positionalArgs?.[0] || '');
+
             if (!routineName) throw new Error('routine run requires a routine name');
+
             const subDef = _load(routineName, config.routinesDir, config.builtinsMap);
             const subErrors = _validate(subDef);
+
             if (subErrors.length > 0) throw new Error(`Sub-routine validation failed: ${subErrors.join(', ')}`);
 
             // Pass through any --set- overrides from args
             const subOverrides: Record<string, unknown> = {};
+
             for (const [k, v] of Object.entries(args)) {
                 if (k.startsWith('--set-')) subOverrides[k.slice(6)] = v;
             }
 
             const result = await _execute(subDef, subOverrides, dispatch);
+
             if (!result.success) throw new Error(`Sub-routine "${routineName}" failed`);
+
             return result;
         }
 

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -152,7 +152,15 @@ export async function executeRoutine(
                     }
                 }
             } catch (err) {
-                const errMsg = err instanceof Error ? err.message : (typeof err === 'object' && err !== null && 'status' in err) ? `HTTP ${(err as any).status}: ${(err as any).body}` : String(err);
+                let errMsg: string;
+                if (err instanceof Error) {
+                    errMsg = err.message;
+                } else if (typeof err === 'object' && err !== null && 'status' in err) {
+                    const { status, body } = err as Record<string, unknown>;
+                    errMsg = `HTTP ${status}: ${body}`;
+                } else {
+                    errMsg = String(err);
+                }
                 const stepResult: StepResult = { name: step.name, success: false, output: null, error: errMsg };
                 parentCtx.stepOutputs.set(step.name, stepResult);
                 if (step.output) parentCtx.stepOutputs.set(step.output, stepResult);

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -11,175 +11,187 @@ export interface RoutineResult {
     error?: string;
 }
 
-export async function executeRoutine(
-    routine: RoutineDefinition,
-    overrides: Record<string, unknown>,
-    dispatch: CommandDispatcher,
-    options?: {
-        dryRun?: boolean;
-        onStep?: (step: RoutineStep, index: number, total: number) => void;
-        onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
-    },
-): Promise<RoutineResult> {
-    const builtins: Record<string, unknown> = {
-        _timestamp: Math.floor(Date.now() / 1000),
-        _date: new Date().toISOString().slice(0, 10),
-    };
-    // Merge variables: builtins < routine defaults < overrides
-    const rawVars = { ...builtins, ...routine.variables, ...overrides };
-    // Resolve $references in default variable values (e.g. "run-$_timestamp")
-    const REF = /\$([a-zA-Z_][a-zA-Z0-9_\-]*)/g;
-    for (const [key, val] of Object.entries(rawVars)) {
-        if (typeof val === 'string' && val.includes('$')) {
-            rawVars[key] = val.replace(REF, (_, ref: string) => {
-                const resolved = rawVars[ref];
-                return resolved !== undefined ? String(resolved) : `$${ref}`;
-            });
+interface ExecutorOptions {
+    dryRun?: boolean;
+    onStep?: (step: RoutineStep, index: number, total: number) => void;
+    onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+}
+
+class RoutineExecutor {
+    private stepsRun = 0;
+    private stepsSkipped = 0;
+    private stepsFailed = 0;
+    private inIteration = false;
+
+    constructor(
+        private dispatch: CommandDispatcher,
+        private options?: ExecutorOptions,
+    ) {}
+
+    async execute(routine: RoutineDefinition, overrides: Record<string, unknown>): Promise<RoutineResult> {
+        const builtins: Record<string, unknown> = {
+            _timestamp: Math.floor(Date.now() / 1000),
+            _date: new Date().toISOString().slice(0, 10),
+        };
+        // Merge variables: builtins < routine defaults < overrides
+        const rawVars = { ...builtins, ...routine.variables, ...overrides };
+        // Resolve $references in default variable values (e.g. "run-$_timestamp")
+        const REF = /\$([a-zA-Z_][a-zA-Z0-9_\-]*)/g;
+        for (const [key, val] of Object.entries(rawVars)) {
+            if (typeof val === 'string' && val.includes('$')) {
+                rawVars[key] = val.replace(REF, (_, ref: string) => {
+                    const resolved = rawVars[ref];
+                    return resolved !== undefined ? String(resolved) : `$${ref}`;
+                });
+            }
         }
+
+        const ctx: RoutineContext = {
+            variables: rawVars,
+            stepOutputs: new Map(),
+        };
+
+        const ok = await this.runSteps(routine.steps, ctx);
+
+        return {
+            success: ok && this.stepsFailed === 0,
+            stepsRun: this.stepsRun,
+            stepsSkipped: this.stepsSkipped,
+            stepsFailed: this.stepsFailed,
+        };
     }
-    const ctx: RoutineContext = {
-        variables: rawVars,
-        stepOutputs: new Map(),
-    };
 
-    let stepsRun = 0;
-    let stepsSkipped = 0;
-    let stepsFailed = 0;
-    let inIteration = false;
-
-    async function runSteps(steps: RoutineStep[], parentCtx: RoutineContext): Promise<boolean> {
+    private async runSteps(steps: RoutineStep[], ctx: RoutineContext): Promise<boolean> {
         for (let i = 0; i < steps.length; i++) {
             const step = steps[i]!;
 
-            if (!evaluateCondition(step.condition, parentCtx)) {
-                stepsSkipped++;
-                if (options?.onStep && !inIteration) options.onStep(step, i, steps.length);
+            if (!evaluateCondition(step.condition, ctx)) {
+                this.stepsSkipped++;
+                if (this.options?.onStep && !this.inIteration) this.options.onStep(step, i, steps.length);
                 continue;
             }
 
-            // range — generates an array for iteration
             if (step.range && step.steps) {
-                const [start, end] = step.range;
-                let items = Array.from({ length: end - start + 1 }, (_, i) => i + start);
-                if (step.shuffle) items = shuffle(items);
-                if (step.reverse) items = items.reverse();
-                resetDistinctPools();
-                const asName = step.as || 'item';
-                inIteration = true;
-                for (let j = 0; j < items.length; j++) {
-                    if (options?.onIteration) options.onIteration(step, j + 1, items.length, i, steps.length);
-                    const iterCtx: RoutineContext = {
-                        ...parentCtx,
-                        forEachItem: { name: asName, value: items[j] },
-                    };
-                    const ok = await runSteps(step.steps, iterCtx);
-                    if (!ok && !step.continueOnError) {
-                        inIteration = false;
-                        return false;
-                    }
-                }
-                inIteration = false;
-                if (options?.onIteration) process.stderr.write('\n');
+                const ok = await this.runRange(step, ctx, i, steps.length);
+                if (!ok) return false;
                 continue;
             }
 
-            // forEach
             if (step.forEach && step.steps) {
-                const rawItems = resolveValue(step.forEach, parentCtx);
-                if (!Array.isArray(rawItems)) {
-                    process.stderr.write(`Warning: forEach on "${step.name}" did not resolve to an array\n`);
-                    stepsSkipped++;
-                    continue;
-                }
-
-                let items = [...rawItems];
-                if (step.shuffle) items = shuffle(items);
-                if (step.reverse) items = items.reverse();
-
-                // Reset distinct pools for each forEach block
-                resetDistinctPools();
-
-                const asName = step.as || 'item';
-                inIteration = true;
-                for (let j = 0; j < items.length; j++) {
-                    if (options?.onIteration) options.onIteration(step, j + 1, items.length, i, steps.length);
-                    const iterCtx: RoutineContext = {
-                        ...parentCtx,
-                        forEachItem: { name: asName, value: items[j] },
-                    };
-                    const ok = await runSteps(step.steps, iterCtx);
-                    if (!ok && !step.continueOnError) {
-                        inIteration = false;
-                        return false;
-                    }
-                }
-                inIteration = false;
-                if (options?.onIteration) process.stderr.write('\n');
+                const ok = await this.runForEach(step, ctx, i, steps.length);
+                if (!ok) return false;
                 continue;
             }
 
             if (!step.command) continue;
 
-            if (options?.onStep && !inIteration) options.onStep(step, i, steps.length);
-
-            const resolvedArgs = resolveArgs(step.args, parentCtx);
-            const resolvedPositional = resolvePositionalArgs(step['args-positional'], parentCtx);
-
-            if (options?.dryRun) {
-                const argStr = Object.entries(resolvedArgs).map(([k, v]) => `${k} ${v}`).join(' ');
-                const posStr = resolvedPositional.join(' ');
-                console.log(`[${stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim());
-                stepsRun++;
-                continue;
-            }
-
-            try {
-                const result = await dispatch(step.command, resolvedArgs, resolvedPositional);
-                const stepResult: StepResult = { name: step.name, success: true, output: result };
-                parentCtx.stepOutputs.set(step.name, stepResult);
-                if (step.output) parentCtx.stepOutputs.set(step.output, stepResult);
-                stepsRun++;
-
-                // Evaluate assert after successful execution
-                if (step.assert) {
-                    const passed = evaluateCondition(step.assert, parentCtx);
-                    if (!passed) {
-                        console.error(`Assert failed on "${step.name}": ${step.assert}`);
-                        stepResult.success = false;
-                        stepResult.error = `Assertion failed: ${step.assert}`;
-                        stepsFailed++;
-                        if (!step.continueOnError) return false;
-                    }
-                }
-            } catch (err) {
-                let errMsg: string;
-                if (err instanceof Error) {
-                    errMsg = err.message;
-                } else if (typeof err === 'object' && err !== null && 'status' in err) {
-                    const { status, body } = err as Record<string, unknown>;
-                    errMsg = `HTTP ${status}: ${body}`;
-                } else {
-                    errMsg = String(err);
-                }
-                const stepResult: StepResult = { name: step.name, success: false, output: null, error: errMsg };
-                parentCtx.stepOutputs.set(step.name, stepResult);
-                if (step.output) parentCtx.stepOutputs.set(step.output, stepResult);
-                stepsFailed++;
-                stepsRun++;
-                console.error(`Step "${step.name}" failed: ${errMsg}`);
-
-                if (!step.continueOnError) return false;
-            }
+            const ok = await this.executeCommand(step, ctx, i, steps.length);
+            if (!ok) return false;
         }
         return true;
     }
 
-    const ok = await runSteps(routine.steps, ctx);
+    private async runRange(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+        const [start, end] = step.range!;
+        const items = Array.from({ length: end - start + 1 }, (_, i) => i + start);
+        return this.runIteration(step, items, ctx, stepIndex, totalSteps);
+    }
 
-    return {
-        success: ok && stepsFailed === 0,
-        stepsRun,
-        stepsSkipped,
-        stepsFailed,
-    };
+    private async runForEach(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+        const rawItems = resolveValue(step.forEach!, ctx);
+        if (!Array.isArray(rawItems)) {
+            process.stderr.write(`Warning: forEach on "${step.name}" did not resolve to an array\n`);
+            this.stepsSkipped++;
+            return true;
+        }
+        return this.runIteration(step, [...rawItems], ctx, stepIndex, totalSteps);
+    }
+
+    private async runIteration(step: RoutineStep, items: unknown[], ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+        if (step.shuffle) items = shuffle(items);
+        if (step.reverse) items = items.reverse();
+        resetDistinctPools();
+
+        const asName = step.as || 'item';
+        this.inIteration = true;
+
+        for (let i = 0; i < items.length; i++) {
+            if (this.options?.onIteration) this.options.onIteration(step, i + 1, items.length, stepIndex, totalSteps);
+            const iterCtx: RoutineContext = {
+                ...ctx,
+                forEachItem: { name: asName, value: items[i] },
+            };
+            const ok = await this.runSteps(step.steps!, iterCtx);
+            if (!ok && !step.continueOnError) {
+                this.inIteration = false;
+                return false;
+            }
+        }
+
+        this.inIteration = false;
+        if (this.options?.onIteration) process.stderr.write('\n');
+        return true;
+    }
+
+    private async executeCommand(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+        if (this.options?.onStep && !this.inIteration) this.options.onStep(step, stepIndex, totalSteps);
+
+        const resolvedArgs = resolveArgs(step.args, ctx);
+        const resolvedPositional = resolvePositionalArgs(step['args-positional'], ctx);
+
+        if (this.options?.dryRun) {
+            const argStr = Object.entries(resolvedArgs).map(([k, v]) => `${k} ${v}`).join(' ');
+            const posStr = resolvedPositional.join(' ');
+            console.log(`[${this.stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim());
+            this.stepsRun++;
+            return true;
+        }
+
+        try {
+            const result = await this.dispatch(step.command!, resolvedArgs, resolvedPositional);
+            const stepResult: StepResult = { name: step.name, success: true, output: result };
+            ctx.stepOutputs.set(step.name, stepResult);
+            if (step.output) ctx.stepOutputs.set(step.output, stepResult);
+            this.stepsRun++;
+
+            if (step.assert) {
+                const passed = evaluateCondition(step.assert, ctx);
+                if (!passed) {
+                    console.error(`Assert failed on "${step.name}": ${step.assert}`);
+                    stepResult.success = false;
+                    stepResult.error = `Assertion failed: ${step.assert}`;
+                    this.stepsFailed++;
+                    if (!step.continueOnError) return false;
+                }
+            }
+        } catch (err) {
+            let errMsg: string;
+            if (err instanceof Error) {
+                errMsg = err.message;
+            } else if (typeof err === 'object' && err !== null && 'status' in err) {
+                const { status, body } = err as Record<string, unknown>;
+                errMsg = `HTTP ${status}: ${body}`;
+            } else {
+                errMsg = String(err);
+            }
+            const stepResult: StepResult = { name: step.name, success: false, output: null, error: errMsg };
+            ctx.stepOutputs.set(step.name, stepResult);
+            if (step.output) ctx.stepOutputs.set(step.output, stepResult);
+            this.stepsFailed++;
+            this.stepsRun++;
+            console.error(`Step "${step.name}" failed: ${errMsg}`);
+
+            if (!step.continueOnError) return false;
+        }
+        return true;
+    }
+}
+
+export async function executeRoutine(
+    routine: RoutineDefinition,
+    overrides: Record<string, unknown>,
+    dispatch: CommandDispatcher,
+    options?: ExecutorOptions,
+): Promise<RoutineResult> {
+    return new RoutineExecutor(dispatch, options).execute(routine, overrides);
 }

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -1,5 +1,16 @@
-import type { RoutineDefinition, RoutineStep, RoutineContext, StepResult } from './types';
-import { resolveValue, resolveArgs, resolvePositionalArgs, resetDistinctPools, shuffle } from './resolver';
+import type {
+    RoutineDefinition,
+    RoutineStep,
+    RoutineContext,
+    StepResult,
+} from './types';
+import {
+    resolveValue,
+    resolveArgs,
+    resolvePositionalArgs,
+    resetDistinctPools,
+    shuffle,
+} from './resolver';
 import { evaluateCondition } from './condition';
 import type { CommandDispatcher } from '../types';
 
@@ -14,7 +25,13 @@ export interface RoutineResult {
 interface ExecutorOptions {
     dryRun?: boolean;
     onStep?: (step: RoutineStep, index: number, total: number) => void;
-    onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
+    onIteration?: (
+        step: RoutineStep,
+        current: number,
+        total: number,
+        stepIndex: number,
+        stepTotal: number,
+    ) => void;
 }
 
 class RoutineExecutor {
@@ -28,7 +45,10 @@ class RoutineExecutor {
         private options?: ExecutorOptions,
     ) {}
 
-    async execute(routine: RoutineDefinition, overrides: Record<string, unknown>): Promise<RoutineResult> {
+    async execute(
+        routine: RoutineDefinition,
+        overrides: Record<string, unknown>,
+    ): Promise<RoutineResult> {
         const builtins: Record<string, unknown> = {
             _timestamp: Math.floor(Date.now() / 1000),
             _date: new Date().toISOString().slice(0, 10),
@@ -37,10 +57,12 @@ class RoutineExecutor {
         const rawVars = { ...builtins, ...routine.variables, ...overrides };
         // Resolve $references in default variable values (e.g. "run-$_timestamp")
         const REF = /\$([a-zA-Z_][a-zA-Z0-9_\-]*)/g;
+
         for (const [key, val] of Object.entries(rawVars)) {
             if (typeof val === 'string' && val.includes('$')) {
                 rawVars[key] = val.replace(REF, (_, ref: string) => {
                     const resolved = rawVars[ref];
+
                     return resolved !== undefined ? String(resolved) : `$${ref}`;
                 });
             }
@@ -61,111 +83,186 @@ class RoutineExecutor {
         };
     }
 
-    private async runSteps(steps: RoutineStep[], ctx: RoutineContext): Promise<boolean> {
+    private async runSteps(
+        steps: RoutineStep[],
+        ctx: RoutineContext,
+    ): Promise<boolean> {
         for (let i = 0; i < steps.length; i++) {
             const step = steps[i]!;
 
             if (!evaluateCondition(step.condition, ctx)) {
                 this.stepsSkipped++;
-                if (this.options?.onStep && !this.inIteration) this.options.onStep(step, i, steps.length);
+
+                if (this.options?.onStep && !this.inIteration)
+                    this.options.onStep(step, i, steps.length);
+
                 continue;
             }
 
             if (step.range && step.steps) {
                 const ok = await this.runRange(step, ctx, i, steps.length);
+
                 if (!ok) return false;
+
                 continue;
             }
 
             if (step.forEach && step.steps) {
                 const ok = await this.runForEach(step, ctx, i, steps.length);
+
                 if (!ok) return false;
+
                 continue;
             }
 
             if (!step.command) continue;
 
             const ok = await this.executeCommand(step, ctx, i, steps.length);
+
             if (!ok) return false;
         }
+
         return true;
     }
 
-    private async runRange(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+    private async runRange(
+        step: RoutineStep,
+        ctx: RoutineContext,
+        stepIndex: number,
+        totalSteps: number,
+    ): Promise<boolean> {
         const [start, end] = step.range!;
         const items = Array.from({ length: end - start + 1 }, (_, i) => i + start);
+
         return this.runIteration(step, items, ctx, stepIndex, totalSteps);
     }
 
-    private async runForEach(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+    private async runForEach(
+        step: RoutineStep,
+        ctx: RoutineContext,
+        stepIndex: number,
+        totalSteps: number,
+    ): Promise<boolean> {
         const rawItems = resolveValue(step.forEach!, ctx);
+
         if (!Array.isArray(rawItems)) {
-            process.stderr.write(`Warning: forEach on "${step.name}" did not resolve to an array\n`);
+            process.stderr.write(
+                `Warning: forEach on "${step.name}" did not resolve to an array\n`,
+            );
             this.stepsSkipped++;
+
             return true;
         }
+
         return this.runIteration(step, [...rawItems], ctx, stepIndex, totalSteps);
     }
 
-    private async runIteration(step: RoutineStep, items: unknown[], ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
+    private async runIteration(
+        step: RoutineStep,
+        items: unknown[],
+        ctx: RoutineContext,
+        stepIndex: number,
+        totalSteps: number,
+    ): Promise<boolean> {
         if (step.shuffle) items = shuffle(items);
+
         if (step.reverse) items = items.reverse();
+
         resetDistinctPools();
 
         const asName = step.as || 'item';
         this.inIteration = true;
 
         for (let i = 0; i < items.length; i++) {
-            if (this.options?.onIteration) this.options.onIteration(step, i + 1, items.length, stepIndex, totalSteps);
+            if (this.options?.onIteration)
+                this.options.onIteration(
+                    step,
+                    i + 1,
+                    items.length,
+                    stepIndex,
+                    totalSteps,
+                );
+
             const iterCtx: RoutineContext = {
                 ...ctx,
                 forEachItem: { name: asName, value: items[i] },
             };
             const ok = await this.runSteps(step.steps!, iterCtx);
+
             if (!ok && !step.continueOnError) {
                 this.inIteration = false;
+
                 return false;
             }
         }
 
         this.inIteration = false;
+
         if (this.options?.onIteration) process.stderr.write('\n');
+
         return true;
     }
 
-    private async executeCommand(step: RoutineStep, ctx: RoutineContext, stepIndex: number, totalSteps: number): Promise<boolean> {
-        if (this.options?.onStep && !this.inIteration) this.options.onStep(step, stepIndex, totalSteps);
+    private async executeCommand(
+        step: RoutineStep,
+        ctx: RoutineContext,
+        stepIndex: number,
+        totalSteps: number,
+    ): Promise<boolean> {
+        if (this.options?.onStep && !this.inIteration)
+            this.options.onStep(step, stepIndex, totalSteps);
 
         const resolvedArgs = resolveArgs(step.args, ctx);
-        const resolvedPositional = resolvePositionalArgs(step['args-positional'], ctx);
+        const resolvedPositional = resolvePositionalArgs(
+            step['args-positional'],
+            ctx,
+        );
 
         if (this.options?.dryRun) {
-            const argStr = Object.entries(resolvedArgs).map(([k, v]) => `${k} ${v}`).join(' ');
+            const argStr = Object.entries(resolvedArgs)
+                .map(([k, v]) => `${k} ${v}`)
+                .join(' ');
             const posStr = resolvedPositional.join(' ');
-            console.log(`[${this.stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim());
+            console.log(
+                `[${this.stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim(),
+            );
             this.stepsRun++;
+
             return true;
         }
 
         try {
-            const result = await this.dispatch(step.command!, resolvedArgs, resolvedPositional);
-            const stepResult: StepResult = { name: step.name, success: true, output: result };
+            const result = await this.dispatch(
+                step.command!,
+                resolvedArgs,
+                resolvedPositional,
+            );
+            const stepResult: StepResult = {
+                name: step.name,
+                success: true,
+                output: result,
+            };
             ctx.stepOutputs.set(step.name, stepResult);
+
             if (step.output) ctx.stepOutputs.set(step.output, stepResult);
+
             this.stepsRun++;
 
             if (step.assert) {
                 const passed = evaluateCondition(step.assert, ctx);
+
                 if (!passed) {
                     console.error(`Assert failed on "${step.name}": ${step.assert}`);
                     stepResult.success = false;
                     stepResult.error = `Assertion failed: ${step.assert}`;
                     this.stepsFailed++;
+
                     if (!step.continueOnError) return false;
                 }
             }
         } catch (err) {
             let errMsg: string;
+
             if (err instanceof Error) {
                 errMsg = err.message;
             } else if (typeof err === 'object' && err !== null && 'status' in err) {
@@ -174,15 +271,24 @@ class RoutineExecutor {
             } else {
                 errMsg = String(err);
             }
-            const stepResult: StepResult = { name: step.name, success: false, output: null, error: errMsg };
+
+            const stepResult: StepResult = {
+                name: step.name,
+                success: false,
+                output: null,
+                error: errMsg,
+            };
             ctx.stepOutputs.set(step.name, stepResult);
+
             if (step.output) ctx.stepOutputs.set(step.output, stepResult);
+
             this.stepsFailed++;
             this.stepsRun++;
             console.error(`Step "${step.name}" failed: ${errMsg}`);
 
             if (!step.continueOnError) return false;
         }
+
         return true;
     }
 }

--- a/src/routine/loader.ts
+++ b/src/routine/loader.ts
@@ -5,8 +5,11 @@ import type { RoutineDefinition, RoutineStep } from './types';
 
 export function parseRoutine(content: string): RoutineDefinition {
     const doc = yaml.load(content) as Record<string, unknown>;
+
     if (!doc || typeof doc !== 'object') throw new Error('Invalid YAML');
+
     if (!doc.name || typeof doc.name !== 'string') throw new Error("Routine must have a 'name' field");
+
     if (!Array.isArray(doc.steps) || doc.steps.length === 0) throw new Error("Routine must have 'steps' array");
 
     return {
@@ -35,15 +38,18 @@ export function validateRoutine(routine: RoutineDefinition): string[] {
             if (names.has(step.name)) {
                 errors.push(`Duplicate step name: "${step.name}" at ${loc}`);
             }
+
             if (aliases.has(step.name)) {
                 errors.push(`Output alias collision: step name "${step.name}" collides with an output alias at ${loc}`);
             }
+
             names.add(step.name);
 
             if (step.output) {
                 if (names.has(step.output) || aliases.has(step.output)) {
                     errors.push(`Output alias collision: "${step.output}" at ${loc}`);
                 }
+
                 aliases.add(step.output);
             }
 
@@ -58,6 +64,7 @@ export function validateRoutine(routine: RoutineDefinition): string[] {
     }
 
     validateSteps(routine.steps, 'steps');
+
     return errors;
 }
 
@@ -67,10 +74,12 @@ function resolveBuiltin(nameOrPath: string, builtinsMap?: Record<string, string>
 
     // Folder-based: <name>/routine.yaml
     const folderKey = `${nameOrPath}/routine.yaml`;
+
     if (builtinsMap[folderKey]) return builtinsMap[folderKey];
 
     // Flat file: <name>.yaml
     if (builtinsMap[`${nameOrPath}.yaml`]) return builtinsMap[`${nameOrPath}.yaml`];
+
     if (builtinsMap[`${nameOrPath}.yml`]) return builtinsMap[`${nameOrPath}.yml`];
 
     return null;
@@ -83,17 +92,21 @@ function resolveRoutinePath(
 ): string | null {
     if (nameOrPath.endsWith('.yaml') || nameOrPath.endsWith('.yml')) {
         const p = resolve(nameOrPath);
+
         return existsSync(p) ? p : null;
     }
 
     // 1. User routines on disk take precedence
     const folderPath = resolve(routinesDir, nameOrPath, 'routine.yaml');
+
     if (existsSync(folderPath)) return folderPath;
 
     const flatPath = resolve(routinesDir, `${nameOrPath}.yaml`);
+
     if (existsSync(flatPath)) return flatPath;
 
     const flatYml = resolve(routinesDir, `${nameOrPath}.yml`);
+
     if (existsSync(flatYml)) return flatYml;
 
     // 2. Embedded builtins — return a sentinel so loadRoutineFile knows to use builtins
@@ -119,10 +132,12 @@ export function loadRoutineFile(
     if (filePath.startsWith('__builtin__:')) {
         const name = filePath.slice('__builtin__:'.length);
         const content = resolveBuiltin(name, builtinsMap)!;
+
         return parseRoutine(content);
     }
 
     const content = readFileSync(filePath, 'utf-8');
+
     return parseRoutine(content);
 }
 
@@ -133,14 +148,17 @@ export function loadSpecFile(
 ): RoutineDefinition | null {
     // Check user dir first
     const specPath = resolve(routinesDir, nameOrPath, 'spec.yaml');
+
     if (existsSync(specPath)) {
         const content = readFileSync(specPath, 'utf-8');
+
         return parseRoutine(content);
     }
 
     // Then check embedded builtins
     if (builtinsMap) {
         const builtinSpec = builtinsMap[`${nameOrPath}/spec.yaml`];
+
         if (builtinSpec) return parseRoutine(builtinSpec);
     }
 
@@ -149,9 +167,12 @@ export function loadSpecFile(
 
 function collectRoutines(dir: string, prefix: string = ''): string[] {
     if (!existsSync(dir)) return [];
+
     const results: string[] = [];
+
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
         const fullName = prefix ? `${prefix}/${entry.name}` : entry.name;
+
         if (entry.isDirectory()) {
             // Folder-based routine: has routine.yaml inside
             if (existsSync(resolve(dir, entry.name, 'routine.yaml'))) {
@@ -167,13 +188,16 @@ function collectRoutines(dir: string, prefix: string = ''): string[] {
             results.push(prefix ? `${prefix}/${name}` : name);
         }
     }
+
     return results;
 }
 
 /** Collect routine names from an optional builtins map. */
 function collectBuiltinRoutines(builtinsMap?: Record<string, string>): string[] {
     if (!builtinsMap) return [];
+
     const routines = new Set<string>();
+
     for (const key of Object.keys(builtinsMap)) {
     // Folder-based: "e2e/matter/create/routine.yaml" -> "e2e/matter/create"
         if (key.endsWith('/routine.yaml')) {
@@ -183,11 +207,13 @@ function collectBuiltinRoutines(builtinsMap?: Record<string, string>): string[] 
         } else if (key.endsWith('.yaml') || key.endsWith('.yml')) {
             // Flat file: "smoke-test.yaml" -> "smoke-test" (skip if already covered by folder)
             const name = key.replace(/\.ya?ml$/, '');
+
             if (!routines.has(name) && !builtinsMap[`${name}/routine.yaml`]) {
                 routines.add(name);
             }
         }
     }
+
     return [...routines];
 }
 
@@ -201,13 +227,16 @@ export function listRoutines(
     // Merge: user routines take precedence (by cleaned name)
     const seen = new Set(userRoutines.map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim()));
     const merged = [...userRoutines];
+
     for (const r of builtins) {
         const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
+
         if (!seen.has(clean)) {
             merged.push(r);
             seen.add(clean);
         }
     }
+
     return merged;
 }
 
@@ -216,10 +245,12 @@ export function listRoutinesStructured(
 ): Array<{ name: string }> {
     try {
         const raw = listRoutines(routinesDir);
+
         return raw.map((r) => {
             let clean = r.replace(/\x1b\[[0-9;]*m/g, '');
             clean = clean.replace(/\s*\(has spec\)\s*$/, '');
             clean = clean.trim();
+
             return { name: clean };
         });
     } catch {
@@ -239,6 +270,7 @@ export function formatRoutineList(routines: string[], _pathPrefix?: string): str
 
     for (const r of cleaned) {
         const slash = r.indexOf('/');
+
         if (slash === -1) {
             topLevel.push({ name: r });
         } else {
@@ -255,6 +287,7 @@ export function formatRoutineList(routines: string[], _pathPrefix?: string): str
     for (const [dir, count] of [...dirs.entries()].sort()) {
         lines.push(`  ${dir}/  ${dim}${count} routine${count === 1 ? '' : 's'}${reset}`);
     }
+
     // Then top-level routines
     for (const { name } of topLevel) {
         lines.push(`  ${name}`);
@@ -278,13 +311,17 @@ function buildTree(routines: string[]): TreeNode {
         const clean = r.replace(/\x1b\[[0-9;]*m/g, '').trim();
         const parts = clean.split('/');
         let node = root;
+
         for (let i = 0; i < parts.length; i++) {
             const part = parts[i]!;
+
             if (!node.children.has(part)) {
                 node.children.set(part, { name: part, children: new Map(), isRoutine: false });
             }
+
             node = node.children.get(part)!;
         }
+
         node.isRoutine = true;
     }
 
@@ -310,7 +347,9 @@ export function formatRoutineTree(routines: string[]): string {
         entries.sort((a, b) => {
             const aDir = a.children.size > 0 && !a.isRoutine ? 0 : 1;
             const bDir = b.children.size > 0 && !b.isRoutine ? 0 : 1;
+
             if (aDir !== bDir) return aDir - bDir;
+
             return a.name.localeCompare(b.name);
         });
 
@@ -323,5 +362,6 @@ export function formatRoutineTree(routines: string[]): string {
     }
 
     render(root, '', true, true);
+
     return lines.join('\n');
 }

--- a/src/routine/loader.ts
+++ b/src/routine/loader.ts
@@ -227,7 +227,8 @@ export function listRoutinesStructured(
     }
 }
 
-export function formatRoutineList(routines: string[], pathPrefix?: string): string {
+/** @deprecated pathPrefix is unused — remove in next major */
+export function formatRoutineList(routines: string[], _pathPrefix?: string): string {
     const cleaned = routines
         .map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim())
         .sort();

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -11,10 +11,12 @@ const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from)\(
 /** Fisher-Yates shuffle — unbiased random permutation. */
 export function shuffle<T>(arr: T[]): T[] {
     const a = [...arr];
+
     for (let i = a.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
         [a[i], a[j]] = [a[j]!, a[i]!];
     }
+
     return a;
 }
 
@@ -29,36 +31,46 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
     switch (name) {
         case '_random_hex_color': {
             const hex = Math.floor(Math.random() * 0xFFFFFF).toString(16).padStart(6, '0');
+
             return `#${hex}`;
         }
         case '_uuid':
             return crypto.randomUUID();
         case '_random_int': {
             if (!argsStr) return 0;
+
             const [minStr, maxStr] = argsStr.split(',').map(s => s.trim());
             const min = parseInt(minStr, 10);
             const max = parseInt(maxStr, 10);
+
             if (isNaN(min) || isNaN(max)) {
                 process.stderr.write(`Warning: $_random_int requires numeric args, got (${argsStr})\n`);
+
                 return 0;
             }
+
             return Math.floor(Math.random() * (max - min + 1)) + min;
         }
         case '_random_from': {
             if (!argsStr) return '';
+
             const options = argsStr.split(',').map(s => s.trim());
+
             return options[Math.floor(Math.random() * options.length)];
         }
         case '_random_distinct_from': {
             if (!argsStr) return '';
+
             const poolKey = argsStr;
             let pool = distinctPools.get(poolKey);
+
             if (!pool || pool.length === 0) {
             // Reshuffle and refill
                 const items = argsStr.split(',').map(s => s.trim());
                 pool = shuffle(items);
                 distinctPools.set(poolKey, pool);
             }
+
             return pool.pop()!;
         }
         default:
@@ -68,10 +80,13 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
 
 function getByDotPath(obj: unknown, path: string[]): unknown {
     let current = obj;
+
     for (const key of path) {
         if (current == null || typeof current !== 'object') return undefined;
+
         current = (current as Record<string, unknown>)[key];
     }
+
     return current;
 }
 
@@ -87,15 +102,19 @@ export function resolveRef(ref: string, ctx: RoutineContext): unknown {
 
     // 2. Step output
     const step = ctx.stepOutputs.get(root);
+
     if (step) {
         if (rest.length === 0) return step.output;
+
         if (rest[0] === 'success') return step.success;
+
         return getByDotPath(step.output, rest);
     }
 
     // 3. Top-level variables
     if (root in ctx.variables) {
         const val = ctx.variables[root];
+
         return rest.length > 0 ? getByDotPath(val, rest) : val;
     }
 
@@ -104,22 +123,26 @@ export function resolveRef(ref: string, ctx: RoutineContext): unknown {
 
 export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
     if (typeof value !== 'string') return value;
+
     if (!value.includes('$')) return value;
 
     // Exact match: built-in function (no args)
     const funcExact = value.match(/^\$(_random_hex_color|_uuid)$/);
+
     if (funcExact) {
         return evalBuiltinFunc(funcExact[1]!);
     }
 
     // Exact match: built-in function with args
     const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from)\(([^)]*)\)$/);
+
     if (funcCall) {
         return evalBuiltinFunc(funcCall[1]!, funcCall[2]);
     }
 
     // Exact match: entire value is a single $ref — resolve to native type
     const match = value.match(/^\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*)*)$/);
+
     if (match) {
         return resolveRef(match[1]!, ctx);
     }
@@ -132,22 +155,28 @@ export function resolveString(str: string, ctx: RoutineContext): string {
     // First resolve parameterized built-in functions (require parens)
     let result = str.replace(PARAM_FUNC_PATTERN, (_match, name: string, argsStr: string) => {
         const resolved = evalBuiltinFunc(name, argsStr);
+
         return resolved !== undefined ? String(resolved) : _match;
     });
     // Then no-arg built-in functions
     result = result.replace(NOARG_FUNC_PATTERN, (_match, name: string) => {
         const resolved = evalBuiltinFunc(name);
+
         return resolved !== undefined ? String(resolved) : _match;
     });
     // Then resolve variable references
     result = result.replace(REF_PATTERN, (_match, ref: string) => {
         const resolved = resolveRef(ref, ctx);
+
         if (resolved === undefined) {
             process.stderr.write(`Warning: unresolved reference $${ref}\n`);
+
             return '';
         }
+
         return String(resolved);
     });
+
     return result;
 }
 
@@ -156,10 +185,13 @@ export function resolveArgs(
     ctx: RoutineContext,
 ): Record<string, unknown> {
     if (!args) return {};
+
     const resolved: Record<string, unknown> = {};
+
     for (const [key, val] of Object.entries(args)) {
         resolved[key] = resolveValue(val, ctx);
     }
+
     return resolved;
 }
 
@@ -168,5 +200,6 @@ export function resolvePositionalArgs(
     ctx: RoutineContext,
 ): unknown[] {
     if (!args) return [];
+
     return args.map(a => resolveValue(a, ctx));
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -22,13 +22,16 @@ export class SessionManager {
                 if (strategy.refresh) {
                     const refreshed = await strategy.refresh(cached, config);
                     this.save(refreshed);
+
                     return refreshed;
                 }
                 // Expired with no refresh — fall through to re-authenticate
             } else {
                 const restored = await strategy.restore(cached, config);
+
                 if (restored) {
                     this.save(restored);
+
                     return restored;
                 }
                 // restore() returned null — fall through to re-authenticate
@@ -37,6 +40,7 @@ export class SessionManager {
 
         const session = await strategy.authenticate(config);
         this.save(session);
+
         return session;
     }
 
@@ -51,6 +55,7 @@ export class SessionManager {
     private load(): AuthSession | null {
         try {
             if (!existsSync(this.sessionPath)) return null;
+
             return JSON.parse(readFileSync(this.sessionPath, 'utf-8'));
         } catch {
             return null;

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -12,8 +12,11 @@ const REGISTRY_URL = 'https://registry.npmjs.org/@apijack/core/latest';
 
 export function shouldCheckForUpdate(dataDir: string): boolean {
     const data = loadUpdateCheck(dataDir);
+
     if (!data) return true;
+
     const elapsed = Date.now() - new Date(data.lastChecked).getTime();
+
     return elapsed > CHECK_INTERVAL_MS;
 }
 
@@ -21,6 +24,7 @@ export function loadUpdateCheck(dataDir: string): UpdateCheckData | null {
     const filePath = join(dataDir, 'update-check.json');
     try {
         if (!existsSync(filePath)) return null;
+
         return JSON.parse(readFileSync(filePath, 'utf-8')) as UpdateCheckData;
     } catch {
         return null;
@@ -40,18 +44,23 @@ export async function checkForUpdate(
     dataDir: string,
 ): Promise<void> {
     if (process.env.APIJACK_SKIP_UPDATE) return;
+
     if (!shouldCheckForUpdate(dataDir)) return;
+
     if (!process.stdin.isTTY) return;
 
     try {
         const res = await fetch(REGISTRY_URL);
+
         if (!res.ok) return;
+
         const data = await res.json() as { version: string };
         const latest = data.version;
 
         saveUpdateCheck(dataDir, latest);
 
         if (latest === currentVersion) return;
+
         if (!isNewer(latest, currentVersion)) return;
 
         const answer = await prompt(
@@ -66,6 +75,7 @@ export async function checkForUpdate(
                 stderr: 'inherit',
             });
             const exitCode = await proc.exited;
+
             if (exitCode === 0) {
                 // Update Claude Code plugin registration to new version
                 const pluginProc = Bun.spawn([...process.argv.slice(0, 2), 'plugin', 'install'], {
@@ -95,9 +105,12 @@ export async function checkForUpdate(
 function isNewer(latest: string, current: string): boolean {
     const l = latest.split('.').map(Number);
     const c = current.split('.').map(Number);
+
     for (let i = 0; i < 3; i++) {
         if ((l[i] ?? 0) > (c[i] ?? 0)) return true;
+
         if ((l[i] ?? 0) < (c[i] ?? 0)) return false;
     }
+
     return false;
 }

--- a/src/url-classifier.ts
+++ b/src/url-classifier.ts
@@ -24,6 +24,7 @@ export function classifyUrl(
     if (SAFE_HOSTNAMES.has(cleanHost)) {
         return { safe: true, reason: 'localhost' };
     }
+
     if (SAFE_IPS.has(cleanHost)) {
         return { safe: true, reason: cleanHost };
     }
@@ -46,8 +47,11 @@ function isIPv4(host: string): boolean {
 
 export function matchesCidr(ip: string, cidr: string): boolean {
     const [network, bitsStr] = cidr.split('/');
+
     if (!network || !bitsStr) return false;
+
     const bits = parseInt(bitsStr, 10);
+
     if (bits < 0 || bits > 32) return false;
 
     const ipNum = ipToNumber(ip);
@@ -59,6 +63,7 @@ export function matchesCidr(ip: string, cidr: string): boolean {
 
 function ipToNumber(ip: string): number {
     const parts = ip.split('.');
+
     return (
         ((parseInt(parts[0]!) << 24)
             | (parseInt(parts[1]!) << 16)


### PR DESCRIPTION
## Commits

- chore(release): v1.5.6
- fix: restrict stable publish job to main branch only
- chore: replace remaining explicit any types with proper types
- chore: replace explicit any with proper types in routine dep interfaces
- style: apply padding-line-between-statements auto-fix
- chore: add padding-line-between-statements eslint rule
- refactor: extract RoutineExecutor class from runSteps closure
- chore: replace explicit any with proper types in test mocks and error handling
- chore: fix eslint deprecation warning and unused variables
- docs: update repository references from Premo-Cloud to normalled org

---
Shipped via `scripts/ship.sh`