### PR TITLE
dev → main (2 commits)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -43,7 +43,12 @@ const CORE_COMMANDS = new Set([
     'plugin',
 ]);
 
-function showCustomHelp(program: Command, cliName: string, showAll: boolean): void {
+function showCustomHelp(
+    program: Command,
+    cliName: string,
+    showAll: boolean,
+    customCommandNames: Set<string>,
+): void {
     console.log(`Usage: ${program.name()} [options] [command]\n`);
     console.log(`${program.description()}\n`);
 
@@ -58,14 +63,23 @@ function showCustomHelp(program: Command, cliName: string, showAll: boolean): vo
 
     // Core commands
     const core = program.commands.filter(c => CORE_COMMANDS.has(c.name()));
+    const custom = program.commands.filter(c => customCommandNames.has(c.name()));
     const api = program.commands.filter(
-        c => !CORE_COMMANDS.has(c.name()) && c.name() !== 'help',
+        c => !CORE_COMMANDS.has(c.name()) && !customCommandNames.has(c.name()) && c.name() !== 'help',
     );
 
     if (core.length > 0) {
         console.log('\nCommands:');
 
         for (const cmd of core) {
+            console.log(`  ${cmd.name().padEnd(30)} ${cmd.description()}`);
+        }
+    }
+
+    if (custom.length > 0) {
+        console.log('\nCustom Commands:');
+
+        for (const cmd of custom) {
             console.log(`  ${cmd.name().padEnd(30)} ${cmd.description()}`);
         }
     }
@@ -521,7 +535,8 @@ export function createCli(options: CliOptions): Cli {
             ) {
                 const showAll
                     = userArgs[0] === '--help' || userArgs[0] === '-h';
-                showCustomHelp(program, cliName, showAll);
+                const customCommandNames = new Set(consumerCommands.map(c => c.name));
+                showCustomHelp(program, cliName, showAll, customCommandNames);
                 process.exit(0);
             }
 

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -210,24 +210,39 @@ describe("built-in commands", () => {
 
     process.argv = ["node", "testcli", "--help"];
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
-
-    console.log = origLog;
-    const output = logs.join("\n");
+    const output = await captureOutput(() => cli.run());
 
     // Should show "Commands:" section with core commands
     expect(output).toContain("Commands:");
     // Should show usage and description
     expect(output).toContain("Usage: testcli");
     expect(output).toContain("A test CLI");
+  });
+
+  test("custom commands appear in their own section, visible without --help", async () => {
+    const cli = createCli(makeOptions());
+    cli.command("my-tool", (program) => {
+      program.command("my-tool").description("A custom tool");
+    });
+
+    // No --help flag — just bare invocation
+    process.argv = ["node", "testcli"];
+
+    const output = await captureOutput(() => cli.run());
+
+    expect(output).toContain("Custom Commands:");
+    expect(output).toContain("my-tool");
+    expect(output).toContain("A custom tool");
+  });
+
+  test("custom commands section is hidden when there are none", async () => {
+    const cli = createCli(makeOptions());
+
+    process.argv = ["node", "testcli"];
+
+    const output = await captureOutput(() => cli.run());
+
+    expect(output).not.toContain("Custom Commands:");
   });
 
   test("routine subcommands are registered (list, run, validate, test, init)", async () => {


### PR DESCRIPTION
## Commits

- chore(release): v1.6.1
- fix: show custom commands in their own section in default help view

---
Shipped via `scripts/ship.sh`