### PR TITLE
feat: add onChallenge hook for auth challenges (MFA, consent, etc.)

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -57,12 +57,15 @@ let authStrategy: AuthStrategy = new BasicAuthStrategy();
 let authResolved = false;
 
 // Check for project-level custom auth first
+let projectOnChallenge: SessionAuthConfig['onChallenge'] | null = null;
+
 if (projectRoot) {
     const projectAuth = await loadProjectAuth(join(projectRoot, '.apijack'));
-    if (projectAuth) {
-        authStrategy = projectAuth;
+    if (projectAuth.strategy) {
+        authStrategy = projectAuth.strategy;
         authResolved = true;
     }
+    projectOnChallenge = projectAuth.onChallenge ?? null;
 }
 
 // Fall back to config-based auth type
@@ -86,6 +89,9 @@ let sessionAuth: SessionAuthConfig | undefined;
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
     if (env) {
         sessionAuth = (env as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
+    }
+    if (sessionAuth && projectOnChallenge) {
+        sessionAuth.onChallenge = projectOnChallenge;
     }
 }
 

--- a/src/auth/config-merge.ts
+++ b/src/auth/config-merge.ts
@@ -9,9 +9,21 @@ export function deepMergeSessionAuth(
     base: SessionAuthConfig,
     override: Partial<SessionAuthConfig> | undefined,
 ): SessionAuthConfig {
-    if (!override) return structuredClone(base);
+    // Preserve function fields that structuredClone would strip
+    const baseFn = base.onChallenge;
+    const overrideFn = override?.onChallenge;
 
-    return deepMerge(structuredClone(base), override) as SessionAuthConfig;
+    const cloned = structuredClone({ ...base, onChallenge: undefined });
+
+    if (override) {
+        const { onChallenge: _, ...overrideData } = override;
+        deepMerge(cloned, overrideData);
+    }
+
+    const result = cloned as SessionAuthConfig;
+    result.onChallenge = overrideFn ?? baseFn;
+
+    return result;
 }
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/src/auth/session-auth.ts
+++ b/src/auth/session-auth.ts
@@ -14,20 +14,59 @@ export class SessionAuthStrategy implements AuthStrategy {
         const baseSession = await this.base.authenticate(config);
 
         const method = this.config.session.method ?? 'GET';
-        const url = config.baseUrl + this.config.session.endpoint;
+        const baseUrl = config.baseUrl + this.config.session.endpoint;
 
-        const res = await fetch(url, {
+        let res = await fetch(baseUrl, {
             method,
             headers: baseSession.headers,
             redirect: 'manual',
         });
 
-        if (!res.ok) {
-            const body = await res.text();
-            throw new Error(`Session endpoint ${url} returned ${res.status}: ${body}`);
+        let challengeCookies: Record<string, string> | undefined;
+
+        if (!res.ok && this.config.onChallenge) {
+            let body = await res.text();
+            challengeCookies = this.collectAllCookies(res);
+            let params = await this.config.onChallenge(res.status, body);
+
+            while (params) {
+                const retryUrl = new URL(baseUrl);
+
+                for (const [k, v] of Object.entries(params)) {
+                    retryUrl.searchParams.set(k, v);
+                }
+
+                const retryHeaders: Record<string, string> = { ...baseSession.headers };
+
+                if (Object.keys(challengeCookies).length > 0) {
+                    retryHeaders.Cookie = Object.entries(challengeCookies)
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join('; ');
+                }
+
+                res = await fetch(retryUrl.toString(), {
+                    method,
+                    headers: retryHeaders,
+                    redirect: 'manual',
+                });
+
+                // Accumulate cookies across retries
+                Object.assign(challengeCookies, this.collectAllCookies(res));
+
+                if (res.ok) break;
+
+                body = await res.text();
+                params = await this.config.onChallenge(res.status, body);
+            }
         }
 
-        const cookies = this.extractCookies(res);
+        if (!res.ok) {
+            const body = await res.text().catch(() => '');
+            throw new Error(`Session endpoint ${baseUrl} returned ${res.status}: ${body}`);
+        }
+
+        // Merge challenge cookies (e.g. remember_device) with extracted session cookies
+        const cookies = { ...challengeCookies, ...this.extractCookies(res) };
 
         return {
             headers: baseSession.headers,
@@ -56,6 +95,21 @@ export class SessionAuthStrategy implements AuthStrategy {
 
     async refresh(_session: AuthSession, config: ResolvedAuth): Promise<AuthSession> {
         return this.authenticate(config);
+    }
+
+    private collectAllCookies(res: Response): Record<string, string> {
+        const cookies: Record<string, string> = {};
+
+        for (const raw of res.headers.getSetCookie()) {
+            const [nameValue] = raw.split(';');
+            const eqIdx = nameValue.indexOf('=');
+
+            if (eqIdx < 0) continue;
+
+            cookies[nameValue.slice(0, eqIdx).trim()] = nameValue.slice(eqIdx + 1).trim();
+        }
+
+        return cookies;
     }
 
     private extractCookies(res: Response): Record<string, string> {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -32,4 +32,6 @@ export interface SessionAuthConfig {
         applyTo?: string[];
     }>;
     refreshOn?: number[];
+    /** Called when the session endpoint returns a non-OK response. Return query params to retry, or null to give up. */
+    onChallenge?: (status: number, body: string) => Promise<Record<string, string> | null>;
 }

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -1,21 +1,29 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
-import type { AuthStrategy } from './auth/types';
+import type { AuthStrategy, SessionAuthConfig } from './auth/types';
 import type { CommandRegistrar, DispatcherHandler } from './types';
+
+export interface ProjectAuth {
+    strategy: AuthStrategy | null;
+    onChallenge: SessionAuthConfig['onChallenge'] | null;
+}
 
 export async function loadProjectAuth(
     apijackDir: string,
-): Promise<AuthStrategy | null> {
+): Promise<ProjectAuth> {
     const authPath = join(apijackDir, 'auth.ts');
 
-    if (!existsSync(authPath)) return null;
+    if (!existsSync(authPath)) return { strategy: null, onChallenge: null };
 
     try {
         const mod = await import(authPath);
 
-        return (mod.default ?? mod) as AuthStrategy;
+        const strategy = (mod.default ?? null) as AuthStrategy | null;
+        const onChallenge = (mod.onChallenge ?? null) as SessionAuthConfig['onChallenge'] | null;
+
+        return { strategy, onChallenge };
     } catch {
-        return null;
+        return { strategy: null, onChallenge: null };
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an optional `onChallenge` callback to `SessionAuthStrategy` so consumers can handle auth challenges (MFA, consent prompts, anything interactive) at the session endpoint without replacing the whole strategy.

When the endpoint returns a non-OK response and `onChallenge` is configured, the strategy loops:

1. Calls `onChallenge(status, body)` expecting retry query params or `null`
2. Retries the endpoint with those params, carrying cookies between attempts
3. Exits on success, `null` return, or no handler

Accumulated challenge cookies (e.g. `remember_device` after 2FA) are merged into the final session so subsequent API requests can skip the challenge entirely.

## Changes

- `src/auth/types.ts` — added `onChallenge?` to `SessionAuthConfig`
- `src/auth/session-auth.ts` — retry loop in `authenticate()`, `collectAllCookies` helper, merges challenge cookies into final session
- `src/auth/config-merge.ts` — preserves `onChallenge` across `structuredClone` in `deepMergeSessionAuth` (clone strips functions)
- `src/project-loader.ts` — `loadProjectAuth` returns `{ strategy, onChallenge }` — projects can export an `onChallenge` function from `.apijack/auth.ts`
- `bin/apijack.ts` — wires the project-level `onChallenge` into the env's `sessionAuth` before `createCli`

## Motivation

Driver was RRC 2FA support in a consuming CLI. A Basic-auth session hits a `TwoFactorAuthenticationException` with \`status: contact_type_required\` on the \`/session\` endpoint. Completing the challenge requires a multi-step query-param flow that could only be solved by either (a) duplicating all of \`SessionAuthStrategy\` in the consumer, or (b) forking core. This hook is the smaller seam.

## Backward compatibility

Fully compatible. \`onChallenge\` is optional and only fires on non-OK responses — existing configs and consumers are unaffected.

## Test plan

- [ ] Existing auth tests still pass
- [ ] Consumer validates end-to-end 2FA flow against a live instance: prompts once, caches \`remember_device\`, skips 2FA on subsequent calls
- [ ] All params accumulated across retries match the reference Angular client's \`/session\` login behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)