### PR TITLE
feat: add $_env() built-in for routine env var access

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // bin/apijack.ts
 import { resolve, join, dirname } from 'path';
-import { mkdirSync } from 'fs';
+import { mkdirSync, existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { createCli } from '../src/cli-builder';
 import type { AuthStrategy, SessionAuthConfig } from '../src/auth/types';
@@ -29,6 +29,34 @@ const projectConfigPath = findProjectConfig(process.cwd());
 const projectConfig = projectConfigPath ? loadProjectConfig(projectConfigPath) : null;
 const configDir = resolveConfigDir(projectConfigPath);
 const projectRoot = projectConfigPath ? dirname(projectConfigPath) : null;
+
+// Load .env from project root (Bun auto-loads from cwd, which may differ when invoked via symlink)
+if (projectRoot) {
+    const envPath = join(projectRoot, '.env');
+
+    if (existsSync(envPath)) {
+        for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
+            const trimmed = line.trim();
+
+            if (!trimmed || trimmed.startsWith('#')) continue;
+
+            const eq = trimmed.indexOf('=');
+
+            if (eq < 0) continue;
+
+            const key = trimmed.slice(0, eq).trim();
+            let val = trimmed.slice(eq + 1).trim();
+
+            if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+                val = val.slice(1, -1);
+            }
+
+            if (!(key in process.env)) {
+                process.env[key] = val;
+            }
+        }
+    }
+}
 
 // 4. Resolve generated dir
 let generatedDir: string;

--- a/skills/write-routine/SKILL.md
+++ b/skills/write-routine/SKILL.md
@@ -81,6 +81,9 @@ steps:
 - `$_random_from(a,b,c)` — pick one randomly (may repeat)
 - `$_random_distinct_from(a,b,c)` — pick one randomly, no repeats until all used (then cycles)
 
+**Environment:**
+- `$_env(VAR)` / `$_env(VAR, default)` — read from environment. `.env` at the project root is auto-loaded at startup; real env vars take precedence.
+
 Variables can reference other variables in defaults: `run_id: "run-$_timestamp"`.
 
 Override at runtime: `<cli> routine run my-routine --set project_name=prod`.

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -4,7 +4,7 @@ const REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*
 // No-arg built-in functions (match without parentheses)
 const NOARG_FUNC_PATTERN = /\$(_random_hex_color|_uuid)/g;
 // Parameterized built-in functions (require parentheses)
-const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from)\(([^)]*)\)/g;
+const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)/g;
 
 // ── Built-in functions ─────────────────────────────────────────────
 
@@ -73,6 +73,22 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
 
             return pool.pop()!;
         }
+        case '_env': {
+            if (!argsStr) return '';
+
+            const firstComma = argsStr.indexOf(',');
+            const varName = (firstComma === -1 ? argsStr : argsStr.slice(0, firstComma)).trim();
+            const defaultVal = firstComma === -1 ? undefined : argsStr.slice(firstComma + 1).trim();
+
+            const value = process.env[varName];
+
+            if (value !== undefined) return value;
+            if (defaultVal !== undefined) return defaultVal;
+
+            process.stderr.write(`Warning: env var ${varName} is not set\n`);
+
+            return '';
+        }
         default:
             return undefined;
     }
@@ -134,7 +150,7 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
     }
 
     // Exact match: built-in function with args
-    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from)\(([^)]*)\)$/);
+    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)$/);
 
     if (funcCall) {
         return evalBuiltinFunc(funcCall[1]!, funcCall[2]);

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -299,3 +299,31 @@ describe("$_random_distinct_from", () => {
     expect(result).toBe("only");
   });
 });
+
+describe("$_env", () => {
+  const ctx = makeCtx();
+
+  test("resolves env var value when set", () => {
+    process.env.APIJACK_TEST_KEY = "secret";
+    expect(resolveValue("$_env(APIJACK_TEST_KEY)", ctx)).toBe("secret");
+    delete process.env.APIJACK_TEST_KEY;
+  });
+
+  test("falls back to default when var unset", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING_VAR, fallback)", ctx)).toBe("fallback");
+  });
+
+  test("returns empty string when var unset and no default", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING_VAR)", ctx)).toBe("");
+  });
+
+  test("interpolates within larger string", () => {
+    process.env.APIJACK_TEST_KEY = "xyz";
+    expect(resolveValue("key=$_env(APIJACK_TEST_KEY)", ctx)).toBe("key=xyz");
+    delete process.env.APIJACK_TEST_KEY;
+  });
+
+  test("default value preserves commas", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING, a,b,c)", ctx)).toBe("a,b,c");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `$_env(VAR)` / `$_env(VAR, default)` built-in function to the routine resolver
- Auto-loads `.env` from the project root at startup (Bun only auto-loads from cwd, which is unreliable for symlinked CLIs like rrc-cli)
- Real env vars still take precedence over `.env`

## Context
Consumers (e.g. rrc-cli) want routines that reference secrets like API keys from `.env` without hardcoding them in YAML or piping them through `--set` every invocation.

## Test plan
- [x] 5 new resolver tests (value, default, missing, interpolation, commas in default) — all pass
- [x] Full test suite: 677 pass, 0 fail
- [ ] Manual: `.env` at project root resolves via `\$_env` when CLI is invoked from any directory (via symlink)

🤖 Generated with [Claude Code](https://claude.com/claude-code)