### PR TITLE
fix: dispatcher drops body fields that share a name with path params

### DIFF
--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -3,7 +3,13 @@ import { loadRoutineFile, validateRoutine } from './loader';
 import { executeRoutine } from './executor';
 
 export interface DispatcherConfig {
-    commandMap?: Record<string, { operationId: string; pathParams: string[]; queryParams: string[]; hasBody: boolean }>;
+    commandMap?: Record<string, {
+        operationId: string;
+        pathParams: string[];
+        queryParams: string[];
+        hasBody: boolean;
+        bodyFields?: Array<{ name: string; type: string; required: boolean; description?: string }>;
+    }>;
     client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
@@ -52,19 +58,18 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
             // Body from args
             if (mapping.hasBody) {
                 const body: Record<string, unknown> = {};
+                const bodyFieldNames = new Set(mapping.bodyFields?.map(f => f.name) ?? []);
 
                 for (const [key, val] of Object.entries(args)) {
                     if (key.startsWith('--')) {
-                        // Skip path params and query params — they're handled separately
-                        const isPathParam = mapping.pathParams.some(
-                            (p: string) => `--${p}` === key,
-                        );
-                        const isQueryParam = mapping.queryParams.some(
-                            (p: string) => `--${p}` === key,
-                        );
+                        const propName = key.slice(2);
+                        const isBodyField = bodyFieldNames.has(propName);
+                        // A field that's declared as a body field stays in the body
+                        // even if its name collides with a path or query param.
+                        const isPathParam = mapping.pathParams.includes(propName);
+                        const isQueryParam = mapping.queryParams.includes(propName);
 
-                        if (!isPathParam && !isQueryParam) {
-                            const propName = key.slice(2);
+                        if (isBodyField || (!isPathParam && !isQueryParam)) {
                             body[propName] = val;
                         }
                     }

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -437,6 +437,42 @@ describe('buildDispatcher', () => {
         expect(client.updateItem).toHaveBeenCalledWith(5, { title: 'New' }, { force: true });
     });
 
+    test('command-map body keeps field that is both a path param and a body field', async () => {
+        // Regression: fetch-agent takes agentId as a path param AND requires it in the request body.
+        // Previously the dispatcher stripped any flag whose name matched a path param, dropping agentId from the body.
+        const client = {
+            fetchAgent: mock(async (..._args: unknown[]) => ({ ok: true })),
+        };
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: {
+                'fetch-agent': {
+                    operationId: 'fetchAgent',
+                    pathParams: ['agentId'],
+                    queryParams: [],
+                    hasBody: true,
+                    bodyFields: [
+                        { name: 'authenticationId', type: 'number', required: true },
+                        { name: 'agentId', type: 'string', required: true },
+                    ],
+                },
+            },
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        await dispatch('fetch-agent', {
+            '--agentId': 'v2_agt_abc',
+            '--authenticationId': 1,
+        });
+
+        expect(client.fetchAgent).toHaveBeenCalledWith(
+            'v2_agt_abc',
+            { authenticationId: 1, agentId: 'v2_agt_abc' },
+        );
+    });
+
     test('command-map throws if client method not found', async () => {
         const client = {}; // no methods
         const ctx = makeCtx({ client });


### PR DESCRIPTION
## Summary
- Dispatcher previously stripped any \`--flag\` whose name matched a path param from the request body
- When a field is declared as both a path param and a body field (e.g. \`agentId\` on \`POST /siteAdmin/attorneyPersonas/agents/{agentId}\` with body \`{authenticationId, agentId}\`), the value never made it into the body
- Fix: consult the already-generated \`bodyFields\` in the command map — if a flag matches a declared body field, keep it in the body even if its name also appears in path/query params

## Test plan
- [x] New regression test: \`command-map body keeps field that is both a path param and a body field\`
- [x] Full suite: 679 pass, 0 fail
- [x] Existing \`command-map body skips path params and query params\` test still passes (non-body-field path/query params still excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)