### PR TITLE
feat(plugin): install via claude CLI instead of writing to ~/.claude directly

### DIFF
--- a/src/plugin/claude-cli.ts
+++ b/src/plugin/claude-cli.ts
@@ -1,0 +1,36 @@
+export type ClaudeRunner = (args: string[]) => Promise<void>;
+
+/** Checks that the `claude` CLI is available on PATH. Throws a helpful error if not. */
+export function ensureClaudeCli(): void {
+    let ok = false;
+
+    try {
+        const proc = Bun.spawnSync(['claude', '--version'], {
+            stdout: 'pipe',
+            stderr: 'pipe',
+        });
+
+        ok = proc.exitCode === 0;
+    } catch {
+        // Command not found — spawnSync threw
+    }
+
+    if (!ok) {
+        throw new Error(
+            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin" commands.',
+        );
+    }
+}
+
+/** Invokes the real `claude` CLI and throws on non-zero exit. stderr/stdout pass through to the parent process. */
+export async function runClaudeCli(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
+}

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,68 +1,65 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
 import { join } from 'path';
+
+export type ClaudeRunner = (args: string[]) => Promise<void>;
 
 export interface InstallOptions {
     version: string;
-    claudeDir: string;
     userDataDir: string;
+    marketplaceDir: string;
     sourceDir: string;
     cliInvocation: string[];
     generatedDir: string;
+    /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
+    runClaude?: ClaudeRunner;
 }
 
 export interface InstallResult {
     success: boolean;
     marketplaceDir: string;
+    pluginDir: string;
     message: string;
 }
 
 export async function installPlugin(opts: InstallOptions): Promise<InstallResult> {
     const {
         version,
-        claudeDir,
         userDataDir,
+        marketplaceDir,
         sourceDir,
         cliInvocation,
         generatedDir,
     } = opts;
 
-    // 1. Place plugin files in local marketplace: marketplaces/local/apijack/
-    const localMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'local');
-    const pluginDir = join(localMarketplaceDir, 'apijack');
-    mkdirSync(join(localMarketplaceDir, '.claude-plugin'), { recursive: true });
+    const runClaude = opts.runClaude ?? defaultRunClaude;
+
+    if (!opts.runClaude) ensureClaudeCli();
+
+    const pluginDir = join(marketplaceDir, 'apijack');
+
+    // 1. Lay out the marketplace directory
+    mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
     mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
 
-    // Register in local marketplace.json with source: "./apijack"
-    const localMarketplacePath = join(localMarketplaceDir, '.claude-plugin', 'marketplace.json');
-    let localMarketplace: Record<string, unknown> = {
-        $schema: 'https://anthropic.com/claude-code/marketplace.schema.json',
-        name: 'local',
-        owner: { name: 'Local Plugins' },
-        plugins: [],
-    };
+    writeFileSync(
+        join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
+        JSON.stringify({
+            name: 'apijack',
+            owner: { name: 'apijack' },
+            metadata: {
+                description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
+            },
+            plugins: [
+                {
+                    name: 'apijack',
+                    description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+                    category: 'development',
+                    source: './apijack',
+                },
+            ],
+        }, null, 2) + '\n',
+    );
 
-    if (existsSync(localMarketplacePath)) {
-        try {
-            localMarketplace = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
-        } catch {}
-    }
-
-    const plugins = (localMarketplace.plugins as Array<{ name: string; [k: string]: unknown }>) || [];
-    const idx = plugins.findIndex(p => p.name === 'apijack');
-    const marketplaceEntry = {
-        name: 'apijack',
-        description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-        category: 'development',
-        source: './apijack',
-    };
-
-    if (idx >= 0) plugins[idx] = marketplaceEntry;
-    else plugins.push(marketplaceEntry);
-
-    localMarketplace.plugins = plugins;
-    writeFileSync(localMarketplacePath, JSON.stringify(localMarketplace, null, 2) + '\n');
-
-    // Write plugin.json manifest
     writeFileSync(
         join(pluginDir, '.claude-plugin', 'plugin.json'),
         JSON.stringify({
@@ -76,7 +73,6 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         }, null, 2) + '\n',
     );
 
-    // Write .mcp.json with CLAUDE_PLUGIN_ROOT reference
     writeFileSync(
         join(pluginDir, '.mcp.json'),
         JSON.stringify({
@@ -90,7 +86,7 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         }, null, 2) + '\n',
     );
 
-    // Copy bundle
+    // 2. Copy bundle
     const distDir = join(pluginDir, 'dist');
     mkdirSync(distDir, { recursive: true });
     const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
@@ -99,7 +95,7 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
     }
 
-    // Copy skills (clear first to remove stale entries from previous versions)
+    // 3. Copy skills (clear first to remove stale entries from previous versions)
     const skillsDst = join(pluginDir, 'skills');
 
     if (existsSync(skillsDst)) {
@@ -112,62 +108,46 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         cpSync(skillsSrc, skillsDst, { recursive: true });
     }
 
-    // Clean up old registrations and cache before re-registering
-    const installedPath = join(claudeDir, 'plugins', 'installed_plugins.json');
-    const settingsPath = join(claudeDir, 'settings.json');
-
-    const oldCacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
-
-    if (existsSync(oldCacheDir)) {
-        rmSync(oldCacheDir, { recursive: true, force: true });
-    }
-
-    const oldMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
-
-    if (existsSync(oldMarketplaceDir)) {
-        rmSync(oldMarketplaceDir, { recursive: true, force: true });
-    }
-
-    // 3. Register in installed_plugins.json and enable in settings.json
-    const installedPlugins = existsSync(installedPath)
-        ? JSON.parse(readFileSync(installedPath, 'utf-8'))
-        : { version: 2, plugins: {} };
-
-    if (!installedPlugins.plugins) installedPlugins.plugins = {};
-
-    delete installedPlugins.plugins['apijack@apijack'];
-    installedPlugins.plugins['apijack@local'] = [{
-        scope: 'user',
-        installPath: pluginDir,
-        version,
-        installedAt: new Date().toISOString(),
-        lastUpdated: new Date().toISOString(),
-        gitCommitSha: '',
-    }];
-    writeFileSync(installedPath, JSON.stringify(installedPlugins, null, 2) + '\n');
-
-    const settings = existsSync(settingsPath)
-        ? JSON.parse(readFileSync(settingsPath, 'utf-8'))
-        : {};
-
-    if (!settings.enabledPlugins) settings.enabledPlugins = {};
-
-    delete settings.enabledPlugins['apijack@apijack'];
-    settings.enabledPlugins['apijack@local'] = true;
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-
-    // 4. Create user data directory
+    // 4. Write runtime config for the MCP entry point
     mkdirSync(join(userDataDir, 'routines'), { recursive: true });
-
-    // 5. Write plugin config for the MCP entry point
     writeFileSync(
         join(userDataDir, 'plugin.json'),
         JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
     );
 
+    // 5. Register marketplace and install via claude CLI
+    await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
+    await runClaude(['plugin', 'install', 'apijack@apijack']);
+
     return {
         success: true,
-        marketplaceDir: pluginDir,
+        marketplaceDir,
+        pluginDir,
         message: `apijack plugin v${version} installed`,
     };
+}
+
+function ensureClaudeCli(): void {
+    const proc = Bun.spawnSync(['claude', '--version'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+
+    if (proc.exitCode !== 0) {
+        throw new Error(
+            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin install".',
+        );
+    }
+}
+
+async function defaultRunClaude(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
 }

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
 import { join } from 'path';
+import { type ClaudeRunner, ensureClaudeCli, runClaudeCli } from './claude-cli';
 
-export type ClaudeRunner = (args: string[]) => Promise<void>;
+export type { ClaudeRunner } from './claude-cli';
 
 export interface InstallOptions {
     version: string;
@@ -12,6 +13,8 @@ export interface InstallOptions {
     generatedDir: string;
     /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
     runClaude?: ClaudeRunner;
+    /** Overridable for tests. Defaults to checking the real `claude` CLI on PATH. */
+    checkClaudeCli?: () => void;
 }
 
 export interface InstallResult {
@@ -31,93 +34,75 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         generatedDir,
     } = opts;
 
-    const runClaude = opts.runClaude ?? defaultRunClaude;
+    const runClaude = opts.runClaude ?? runClaudeCli;
+    const checkCli = opts.checkClaudeCli ?? ensureClaudeCli;
 
-    if (!opts.runClaude) ensureClaudeCli();
+    // Fail fast if the CLI isn't available — we don't want to lay out files we can't register
+    if (!opts.runClaude) checkCli();
 
+    const marketplaceDirExisted = existsSync(marketplaceDir);
     const pluginDir = join(marketplaceDir, 'apijack');
 
-    // 1. Lay out the marketplace directory
-    mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
-    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    try {
+        // 1. Lay out the marketplace directory
+        mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
+        mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
 
-    writeFileSync(
-        join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
-        JSON.stringify({
-            name: 'apijack',
-            owner: { name: 'apijack' },
-            metadata: {
-                description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
-            },
-            plugins: [
-                {
-                    name: 'apijack',
-                    description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-                    category: 'development',
-                    source: './apijack',
-                },
-            ],
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
+            JSON.stringify(buildMarketplaceManifest(), null, 2) + '\n',
+        );
 
-    writeFileSync(
-        join(pluginDir, '.claude-plugin', 'plugin.json'),
-        JSON.stringify({
-            name: 'apijack',
-            description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-            version,
-            author: { name: 'apijack' },
-            repository: 'https://github.com/normalled/apijack',
-            license: 'MIT',
-            keywords: ['openapi', 'cli', 'mcp', 'api', 'routines'],
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(pluginDir, '.claude-plugin', 'plugin.json'),
+            JSON.stringify(buildPluginManifest(version), null, 2) + '\n',
+        );
 
-    writeFileSync(
-        join(pluginDir, '.mcp.json'),
-        JSON.stringify({
-            mcpServers: {
-                apijack: {
-                    type: 'stdio',
-                    command: 'bun',
-                    args: ['run', '${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js'],
-                },
-            },
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(pluginDir, '.mcp.json'),
+            JSON.stringify(buildMcpConfig(), null, 2) + '\n',
+        );
 
-    // 2. Copy bundle
-    const distDir = join(pluginDir, 'dist');
-    mkdirSync(distDir, { recursive: true });
-    const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
+        // 2. Copy bundle
+        const distDir = join(pluginDir, 'dist');
+        mkdirSync(distDir, { recursive: true });
+        const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
 
-    if (existsSync(bundleSrc)) {
-        cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
+        if (existsSync(bundleSrc)) {
+            cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
+        }
+
+        // 3. Copy skills (clear first to remove stale entries from previous versions)
+        const skillsDst = join(pluginDir, 'skills');
+
+        if (existsSync(skillsDst)) {
+            rmSync(skillsDst, { recursive: true, force: true });
+        }
+
+        const skillsSrc = join(sourceDir, 'skills');
+
+        if (existsSync(skillsSrc)) {
+            cpSync(skillsSrc, skillsDst, { recursive: true });
+        }
+
+        // 4. Write runtime config for the MCP entry point
+        mkdirSync(join(userDataDir, 'routines'), { recursive: true });
+        writeFileSync(
+            join(userDataDir, 'plugin.json'),
+            JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
+        );
+
+        // 5. Register marketplace and install via claude CLI
+        await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
+        await runClaude(['plugin', 'install', 'apijack@apijack']);
+    } catch (err) {
+        // Roll back the marketplace dir we created so the next install starts clean
+        if (!marketplaceDirExisted && existsSync(marketplaceDir)) {
+            rmSync(marketplaceDir, { recursive: true, force: true });
+        }
+
+        throw err;
     }
-
-    // 3. Copy skills (clear first to remove stale entries from previous versions)
-    const skillsDst = join(pluginDir, 'skills');
-
-    if (existsSync(skillsDst)) {
-        rmSync(skillsDst, { recursive: true, force: true });
-    }
-
-    const skillsSrc = join(sourceDir, 'skills');
-
-    if (existsSync(skillsSrc)) {
-        cpSync(skillsSrc, skillsDst, { recursive: true });
-    }
-
-    // 4. Write runtime config for the MCP entry point
-    mkdirSync(join(userDataDir, 'routines'), { recursive: true });
-    writeFileSync(
-        join(userDataDir, 'plugin.json'),
-        JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
-    );
-
-    // 5. Register marketplace and install via claude CLI
-    await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
-    await runClaude(['plugin', 'install', 'apijack@apijack']);
 
     return {
         success: true,
@@ -127,27 +112,44 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     };
 }
 
-function ensureClaudeCli(): void {
-    const proc = Bun.spawnSync(['claude', '--version'], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-    });
-
-    if (proc.exitCode !== 0) {
-        throw new Error(
-            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin install".',
-        );
-    }
+function buildMarketplaceManifest(): Record<string, unknown> {
+    return {
+        name: 'apijack',
+        owner: { name: 'apijack' },
+        metadata: {
+            description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
+        },
+        plugins: [
+            {
+                name: 'apijack',
+                description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+                category: 'development',
+                source: './apijack',
+            },
+        ],
+    };
 }
 
-async function defaultRunClaude(args: string[]): Promise<void> {
-    const proc = Bun.spawn(['claude', ...args], {
-        stdout: 'inherit',
-        stderr: 'inherit',
-    });
-    const exitCode = await proc.exited;
+function buildPluginManifest(version: string): Record<string, unknown> {
+    return {
+        name: 'apijack',
+        description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+        version,
+        author: { name: 'apijack' },
+        repository: 'https://github.com/normalled/apijack',
+        license: 'MIT',
+        keywords: ['openapi', 'cli', 'mcp', 'api', 'routines'],
+    };
+}
 
-    if (exitCode !== 0) {
-        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
-    }
+function buildMcpConfig(): Record<string, unknown> {
+    return {
+        mcpServers: {
+            apijack: {
+                type: 'stdio',
+                command: 'bun',
+                args: ['run', '${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js'],
+            },
+        },
+    };
 }

--- a/src/plugin/paths.ts
+++ b/src/plugin/paths.ts
@@ -2,23 +2,17 @@ import { homedir } from 'os';
 import { join, resolve } from 'path';
 
 export interface PluginPaths {
-    claudeDir: string;
-    installedPluginsFile: string;
-    settingsFile: string;
     userDataDir: string;
+    marketplaceDir: string;
     sourceDir: string;
 }
 
 export function getPluginPaths(_version: string): PluginPaths {
-    const home = homedir();
-    const claudeDir = join(home, '.claude');
-    const pluginsDir = join(claudeDir, 'plugins');
+    const userDataDir = join(homedir(), '.apijack');
 
     return {
-        claudeDir,
-        installedPluginsFile: join(pluginsDir, 'installed_plugins.json'),
-        settingsFile: join(claudeDir, 'settings.json'),
-        userDataDir: join(home, '.apijack'),
+        userDataDir,
+        marketplaceDir: join(userDataDir, 'plugin-marketplace'),
         sourceDir: resolve(import.meta.dir, '../..'),
     };
 }

--- a/src/plugin/register.ts
+++ b/src/plugin/register.ts
@@ -44,27 +44,20 @@ export function registerPluginCommand(
 
             const result = await installPlugin({
                 version,
-                claudeDir: paths.claudeDir,
                 userDataDir: paths.userDataDir,
+                marketplaceDir: paths.marketplaceDir,
                 sourceDir: paths.sourceDir,
                 cliInvocation,
                 generatedDir: opts.generatedDir ?? 'src/generated',
             });
 
             if (result.success) {
-                console.log(result.message);
-                console.log(`\n  Plugin dir:    ${result.marketplaceDir}`);
+                console.log(`\n${result.message}`);
+                console.log(`\n  Marketplace:   ${result.marketplaceDir}`);
+                console.log(`  Plugin dir:    ${result.pluginDir}`);
                 console.log(`  User data:     ${paths.userDataDir}`);
                 console.log(`  CLI invocation: ${cliInvocation.join(' ')}`);
-                console.log('\n── Next steps ──────────────────────────────────────');
-                console.log('1. In Claude Code, run:  /reload-plugins');
-                console.log('2. Then try a prompt like:');
-                console.log('');
-                console.log('   "Use /setup-api to connect apijack to my todo list');
-                console.log('    API at http://localhost:8080, then use /write-routine');
-                console.log('    to automate an e2e test: create 10 todos and then');
-                console.log('    delete them all."');
-                console.log('');
+                console.log('\nIn Claude Code, run /reload-plugins to activate.');
             }
         });
 
@@ -73,7 +66,7 @@ export function registerPluginCommand(
         .description('Remove Claude Code plugin registration')
         .action(async () => {
             const paths = getPluginPaths(version);
-            const result = await uninstallPlugin({ claudeDir: paths.claudeDir });
+            const result = await uninstallPlugin({ marketplaceDir: paths.marketplaceDir });
             console.log(result.message);
         });
 

--- a/src/plugin/uninstall.ts
+++ b/src/plugin/uninstall.ts
@@ -1,6 +1,7 @@
 import { existsSync, rmSync } from 'fs';
+import { type ClaudeRunner, runClaudeCli } from './claude-cli';
 
-export type ClaudeRunner = (args: string[]) => Promise<void>;
+export type { ClaudeRunner } from './claude-cli';
 
 export interface UninstallOptions {
     marketplaceDir: string;
@@ -11,34 +12,39 @@ export interface UninstallOptions {
 export interface UninstallResult {
     success: boolean;
     message: string;
+    warnings: string[];
 }
 
 export async function uninstallPlugin(opts: UninstallOptions): Promise<UninstallResult> {
     const { marketplaceDir } = opts;
-    const runClaude = opts.runClaude ?? defaultRunClaude;
+    const runClaude = opts.runClaude ?? runClaudeCli;
+    const warnings: string[] = [];
 
-    // Best-effort unregister via claude CLI — ignore failures so cleanup continues
-    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch(() => {});
-    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch(() => {});
+    // Unregister via claude CLI. Failures are surfaced as warnings so filesystem cleanup
+    // still runs even if the CLI is unavailable or the plugin is already gone.
+    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch((err) => {
+        warnings.push(`claude plugin uninstall apijack@apijack: ${formatError(err)}`);
+    });
+    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch((err) => {
+        warnings.push(`claude plugin marketplace remove apijack: ${formatError(err)}`);
+    });
 
     if (existsSync(marketplaceDir)) {
         rmSync(marketplaceDir, { recursive: true, force: true });
     }
 
+    const baseMessage = 'apijack plugin uninstalled. User data preserved at ~/.apijack/';
+    const message = warnings.length > 0
+        ? `${baseMessage}\nWarnings:\n  - ${warnings.join('\n  - ')}`
+        : baseMessage;
+
     return {
         success: true,
-        message: 'apijack plugin uninstalled. User data preserved at ~/.apijack/',
+        message,
+        warnings,
     };
 }
 
-async function defaultRunClaude(args: string[]): Promise<void> {
-    const proc = Bun.spawn(['claude', ...args], {
-        stdout: 'ignore',
-        stderr: 'ignore',
-    });
-    const exitCode = await proc.exited;
-
-    if (exitCode !== 0) {
-        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
-    }
+function formatError(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
 }

--- a/src/plugin/uninstall.ts
+++ b/src/plugin/uninstall.ts
@@ -1,8 +1,11 @@
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { existsSync, rmSync } from 'fs';
+
+export type ClaudeRunner = (args: string[]) => Promise<void>;
 
 export interface UninstallOptions {
-    claudeDir: string;
+    marketplaceDir: string;
+    /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
+    runClaude?: ClaudeRunner;
 }
 
 export interface UninstallResult {
@@ -11,71 +14,31 @@ export interface UninstallResult {
 }
 
 export async function uninstallPlugin(opts: UninstallOptions): Promise<UninstallResult> {
-    const { claudeDir } = opts;
+    const { marketplaceDir } = opts;
+    const runClaude = opts.runClaude ?? defaultRunClaude;
 
-    // 1. Remove plugin directory from local marketplace
-    const pluginDir = join(claudeDir, 'plugins', 'marketplaces', 'local', 'apijack');
+    // Best-effort unregister via claude CLI — ignore failures so cleanup continues
+    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch(() => {});
+    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch(() => {});
 
-    if (existsSync(pluginDir)) {
-        rmSync(pluginDir, { recursive: true, force: true });
+    if (existsSync(marketplaceDir)) {
+        rmSync(marketplaceDir, { recursive: true, force: true });
     }
-
-    // Remove legacy separate marketplace directory
-    const legacyMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
-
-    if (existsSync(legacyMarketplaceDir)) {
-        rmSync(legacyMarketplaceDir, { recursive: true, force: true });
-    }
-
-    // 2. Remove apijack entry from local marketplace.json
-    const localMarketplacePath = join(claudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json');
-
-    if (existsSync(localMarketplacePath)) {
-        try {
-            const local = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
-            local.plugins = (local.plugins || []).filter((p: { name: string }) => p.name !== 'apijack');
-            writeFileSync(localMarketplacePath, JSON.stringify(local, null, 2) + '\n');
-        } catch {}
-    }
-
-    // 3. Clean up registrations (current + legacy)
-    const installedPath = join(claudeDir, 'plugins', 'installed_plugins.json');
-
-    if (existsSync(installedPath)) {
-        try {
-            const installed = JSON.parse(readFileSync(installedPath, 'utf-8'));
-            delete installed.plugins['apijack@apijack'];
-            delete installed.plugins['apijack@local'];
-            writeFileSync(installedPath, JSON.stringify(installed, null, 2) + '\n');
-        } catch {}
-    }
-
-    const settingsPath = join(claudeDir, 'settings.json');
-
-    if (existsSync(settingsPath)) {
-        try {
-            const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-            if (settings.enabledPlugins) {
-                delete settings.enabledPlugins['apijack@apijack'];
-                delete settings.enabledPlugins['apijack@local'];
-            }
-
-            writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-        } catch {}
-    }
-
-    // 4. Remove old plugin cache
-    const cacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
-
-    if (existsSync(cacheDir)) {
-        rmSync(cacheDir, { recursive: true, force: true });
-    }
-
-    // NOTE: User data at ~/.apijack/ is intentionally preserved
 
     return {
         success: true,
         message: 'apijack plugin uninstalled. User data preserved at ~/.apijack/',
     };
+}
+
+async function defaultRunClaude(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'ignore',
+        stderr: 'ignore',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
 }

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -116,4 +116,47 @@ describe('installPlugin()', () => {
 
         expect(installPlugin(opts)).rejects.toThrow('boom');
     });
+
+    test('rolls back marketplace dir if claude CLI fails on a fresh install', async () => {
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('register failed');
+            },
+        });
+
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+        await installPlugin(opts).catch(() => {});
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
+
+    test('does not roll back a pre-existing marketplace dir on failure', async () => {
+        mkdirSync(testMarketplaceDir, { recursive: true });
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('register failed');
+            },
+        });
+
+        await installPlugin(opts).catch(() => {});
+        expect(existsSync(testMarketplaceDir)).toBe(true);
+    });
+
+    test('surfaces checkClaudeCli errors and does not touch filesystem', async () => {
+        const opts = {
+            version: '0.1.0',
+            userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
+            sourceDir: join(import.meta.dir, '../..'),
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+            checkClaudeCli: () => {
+                throw new Error('claude not found');
+            },
+        };
+
+        await installPlugin(opts).catch((err) => {
+            expect(err.message).toContain('claude not found');
+        });
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
 });

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -5,22 +5,30 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-plugin-test-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 
 function readJson(path: string): any {
     return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
 function makeOpts(overrides?: Record<string, unknown>) {
+    const claudeCalls: string[][] = [];
+
     return {
-        version: '0.1.0',
-        claudeDir: testClaudeDir,
-        userDataDir: testDataDir,
-        sourceDir: join(import.meta.dir, '../..'),
-        cliInvocation: ['bun', 'run', 'src/cli.ts'],
-        generatedDir: 'src/generated',
-        ...overrides,
+        opts: {
+            version: '0.1.0',
+            userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
+            sourceDir: join(import.meta.dir, '../..'),
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+            runClaude: async (args: string[]) => {
+                claudeCalls.push(args);
+            },
+            ...overrides,
+        },
+        claudeCalls,
     };
 }
 
@@ -33,78 +41,79 @@ describe('installPlugin()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('registers in local marketplace', async () => {
-        const result = await installPlugin(makeOpts());
+    test('writes marketplace.json with apijack plugin entry', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
         expect(result.success).toBe(true);
 
-        const marketplacePath = join(
-            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
-        );
+        const marketplacePath = join(testMarketplaceDir, '.claude-plugin', 'marketplace.json');
         expect(existsSync(marketplacePath)).toBe(true);
 
         const marketplace = readJson(marketplacePath);
+        expect(marketplace.name).toBe('apijack');
+        expect(marketplace.metadata?.description).toBeTruthy();
         const plugin = marketplace.plugins.find((p: any) => p.name === 'apijack');
         expect(plugin).toBeDefined();
         expect(plugin.source).toBe('./apijack');
     });
 
-    test('returns plugin dir inside local marketplace', async () => {
-        const result = await installPlugin(makeOpts());
-        expect(result.marketplaceDir).toContain(join('marketplaces', 'local', 'apijack'));
+    test('returns plugin dir nested in marketplace', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        expect(result.marketplaceDir).toBe(testMarketplaceDir);
+        expect(result.pluginDir).toBe(join(testMarketplaceDir, 'apijack'));
     });
 
-    test('copies skills to plugin dir', async () => {
-        const result = await installPlugin(makeOpts());
-        expect(existsSync(join(result.marketplaceDir, 'skills', 'write-routine', 'SKILL.md'))).toBe(true);
-        expect(existsSync(join(result.marketplaceDir, 'skills', 'setup-api', 'SKILL.md'))).toBe(true);
+    test('writes plugin.json manifest under plugin dir', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        const manifest = readJson(join(result.pluginDir, '.claude-plugin', 'plugin.json'));
+        expect(manifest.name).toBe('apijack');
+        expect(manifest.version).toBe('0.1.0');
     });
 
-    test('writes .mcp.json with CLAUDE_PLUGIN_ROOT', async () => {
-        const result = await installPlugin(makeOpts());
-        const mcpJson = readJson(join(result.marketplaceDir, '.mcp.json'));
+    test('copies skills into plugin dir', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        expect(existsSync(join(result.pluginDir, 'skills', 'write-routine', 'SKILL.md'))).toBe(true);
+        expect(existsSync(join(result.pluginDir, 'skills', 'setup-api', 'SKILL.md'))).toBe(true);
+    });
+
+    test('writes .mcp.json with CLAUDE_PLUGIN_ROOT reference', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        const mcpJson = readJson(join(result.pluginDir, '.mcp.json'));
         expect(mcpJson.mcpServers.apijack.args).toContain('${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js');
     });
 
-    test('creates user data directory', async () => {
-        await installPlugin(makeOpts());
+    test('creates user data directory and writes runtime plugin.json', async () => {
+        const { opts } = makeOpts();
+        await installPlugin(opts);
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
-    });
 
-    test('writes plugin.json with cliInvocation to user data dir', async () => {
-        await installPlugin(makeOpts());
         const pluginConfig = readJson(join(testDataDir, 'plugin.json'));
         expect(pluginConfig.cliInvocation).toEqual(['bun', 'run', 'src/cli.ts']);
         expect(pluginConfig.generatedDir).toBe('src/generated');
     });
 
-    test('registers in installed_plugins.json and settings.json', async () => {
-        await installPlugin(makeOpts());
+    test('invokes claude CLI to register marketplace and install plugin', async () => {
+        const { opts, claudeCalls } = makeOpts();
+        await installPlugin(opts);
 
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local']).toBeDefined();
-        expect(installed.plugins['apijack@local'][0].version).toBe('0.1.0');
-
-        const settings = readJson(join(testClaudeDir, 'settings.json'));
-        expect(settings.enabledPlugins['apijack@local']).toBe(true);
+        expect(claudeCalls).toEqual([
+            ['plugin', 'marketplace', 'add', testMarketplaceDir],
+            ['plugin', 'install', 'apijack@apijack'],
+        ]);
     });
 
-    test('preserves other plugins in local marketplace', async () => {
-        const localDir = join(testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin');
-        mkdirSync(localDir, { recursive: true });
-        await Bun.write(
-            join(localDir, 'marketplace.json'),
-            JSON.stringify({
-                name: 'local',
-                owner: { name: 'Local Plugins' },
-                plugins: [{ name: 'other-plugin', description: 'Other', source: './other-plugin' }],
-            }),
-        );
+    test('propagates errors from runClaude', async () => {
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('boom');
+            },
+        });
 
-        await installPlugin(makeOpts());
-
-        const marketplace = readJson(join(localDir, 'marketplace.json'));
-        expect(marketplace.plugins.find((p: any) => p.name === 'other-plugin')).toBeDefined();
-        expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
+        expect(installPlugin(opts)).rejects.toThrow('boom');
     });
 });

--- a/tests/plugin/integration.test.ts
+++ b/tests/plugin/integration.test.ts
@@ -6,8 +6,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-integration-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 const sourceDir = join(import.meta.dir, '../..');
 
 function readJson(path: string): any {
@@ -20,36 +20,41 @@ describe('plugin install → uninstall roundtrip', () => {
     });
 
     test('full lifecycle: install, verify, uninstall, verify preservation', async () => {
+        const installCalls: string[][] = [];
         const installResult = await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async (args) => {
+                installCalls.push(args);
+            },
         });
         expect(installResult.success).toBe(true);
+        expect(installCalls).toHaveLength(2);
 
-        // Verify marketplace
-        const marketplacePath = join(
-            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
-        );
-        const marketplace = readJson(marketplacePath);
+        // Marketplace + nested plugin manifest
+        const marketplace = readJson(join(testMarketplaceDir, '.claude-plugin', 'marketplace.json'));
         expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
 
-        // Verify installed
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local']).toBeDefined();
+        const manifest = readJson(join(testMarketplaceDir, 'apijack', '.claude-plugin', 'plugin.json'));
+        expect(manifest.name).toBe('apijack');
 
-        // Verify user data
+        // User data written
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
         expect(existsSync(join(testDataDir, 'plugin.json'))).toBe(true);
 
         // Uninstall
-        const uninstallResult = await uninstallPlugin({ claudeDir: testClaudeDir });
+        const uninstallResult = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
         expect(uninstallResult.success).toBe(true);
 
-        // Verify user data preserved
+        // Marketplace gone, user data preserved
+        expect(existsSync(testMarketplaceDir)).toBe(false);
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
     });
@@ -57,27 +62,32 @@ describe('plugin install → uninstall roundtrip', () => {
     test('reinstall after uninstall works cleanly', async () => {
         await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
 
         const result = await installPlugin({
             version: '0.2.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
 
         expect(result.success).toBe(true);
 
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local'][0].version).toBe('0.2.0');
+        const manifest = readJson(join(testMarketplaceDir, 'apijack', '.claude-plugin', 'plugin.json'));
+        expect(manifest.version).toBe('0.2.0');
     });
 });

--- a/tests/plugin/paths.test.ts
+++ b/tests/plugin/paths.test.ts
@@ -6,24 +6,12 @@ import { join } from 'path';
 describe('getPluginPaths()', () => {
     const paths = getPluginPaths('0.1.0');
 
-    test('claudeDir points to ~/.claude', () => {
-        expect(paths.claudeDir).toBe(join(homedir(), '.claude'));
-    });
-
-    test('installedPluginsFile points to installed_plugins.json', () => {
-        expect(paths.installedPluginsFile).toBe(
-            join(homedir(), '.claude', 'plugins', 'installed_plugins.json'),
-        );
-    });
-
-    test('settingsFile points to settings.json', () => {
-        expect(paths.settingsFile).toBe(
-            join(homedir(), '.claude', 'settings.json'),
-        );
-    });
-
     test('userDataDir points to ~/.apijack', () => {
         expect(paths.userDataDir).toBe(join(homedir(), '.apijack'));
+    });
+
+    test('marketplaceDir points to ~/.apijack/plugin-marketplace', () => {
+        expect(paths.marketplaceDir).toBe(join(homedir(), '.apijack', 'plugin-marketplace'));
     });
 
     test('sourceDir points to project root', () => {

--- a/tests/plugin/uninstall.test.ts
+++ b/tests/plugin/uninstall.test.ts
@@ -1,28 +1,28 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { installPlugin } from '../../src/plugin/install';
 import { uninstallPlugin } from '../../src/plugin/uninstall';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-uninstall-test-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
-
-function readJson(path: string): any {
-    return JSON.parse(readFileSync(path, 'utf-8'));
-}
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 
 describe('uninstallPlugin()', () => {
+    const claudeCalls: string[][] = [];
+
     beforeEach(async () => {
         mkdirSync(testRoot, { recursive: true });
+        claudeCalls.length = 0;
         await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir: join(import.meta.dir, '../..'),
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
     });
 
@@ -30,56 +30,63 @@ describe('uninstallPlugin()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('removes from installed_plugins.json when present', async () => {
-    // Set up legacy installed_plugins.json
-        const installedPath = join(testClaudeDir, 'plugins', 'installed_plugins.json');
-        mkdirSync(join(testClaudeDir, 'plugins'), { recursive: true });
-        writeFileSync(
-            installedPath,
-            JSON.stringify({ plugins: { 'apijack@local': [{ version: '0.1.0', scope: 'user' }] } }),
-        );
+    test('removes the marketplace directory', async () => {
+        expect(existsSync(testMarketplaceDir)).toBe(true);
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                claudeCalls.push(args);
+            },
+        });
 
-        const installed = readJson(installedPath);
-        expect(installed.plugins['apijack@local']).toBeUndefined();
+        expect(existsSync(testMarketplaceDir)).toBe(false);
     });
 
-    test('removes from enabledPlugins in settings.json when present', async () => {
-    // Set up settings.json with enabledPlugins
-        const settingsPath = join(testClaudeDir, 'settings.json');
-        writeFileSync(
-            settingsPath,
-            JSON.stringify({ enabledPlugins: { 'apijack@local': true } }),
-        );
+    test('invokes claude CLI to uninstall plugin and remove marketplace', async () => {
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                claudeCalls.push(args);
+            },
+        });
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-
-        const settings = readJson(settingsPath);
-        expect(settings.enabledPlugins['apijack@local']).toBeUndefined();
-    });
-
-    test('removes plugin cache directory when present', async () => {
-    // Set up cache directory
-        const cacheDir = join(testClaudeDir, 'plugins', 'cache', 'local', 'apijack');
-        mkdirSync(cacheDir, { recursive: true });
-        expect(existsSync(cacheDir)).toBe(true);
-
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-
-        expect(existsSync(cacheDir)).toBe(false);
+        expect(claudeCalls).toEqual([
+            ['plugin', 'uninstall', 'apijack@apijack'],
+            ['plugin', 'marketplace', 'remove', 'apijack'],
+        ]);
     });
 
     test('preserves user data directory', async () => {
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
 
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
     });
 
+    test('tolerates claude CLI failures and still cleans up files', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {
+                throw new Error('claude not found');
+            },
+        });
+
+        expect(result.success).toBe(true);
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
+
     test('handles already-uninstalled gracefully', async () => {
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-        const result = await uninstallPlugin({ claudeDir: testClaudeDir });
+        rmSync(testMarketplaceDir, { recursive: true, force: true });
+
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
+
         expect(result.success).toBe(true);
     });
 });

--- a/tests/plugin/uninstall.test.ts
+++ b/tests/plugin/uninstall.test.ts
@@ -79,6 +79,30 @@ describe('uninstallPlugin()', () => {
         expect(existsSync(testMarketplaceDir)).toBe(false);
     });
 
+    test('surfaces claude CLI failures as warnings', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                throw new Error(`fake: ${args.join(' ')}`);
+            },
+        });
+
+        expect(result.warnings).toHaveLength(2);
+        expect(result.warnings[0]).toContain('plugin uninstall apijack@apijack');
+        expect(result.warnings[1]).toContain('plugin marketplace remove apijack');
+        expect(result.message).toContain('Warnings:');
+    });
+
+    test('no warnings when claude CLI succeeds', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
+
+        expect(result.warnings).toHaveLength(0);
+        expect(result.message).not.toContain('Warnings:');
+    });
+
     test('handles already-uninstalled gracefully', async () => {
         rmSync(testMarketplaceDir, { recursive: true, force: true });
 


### PR DESCRIPTION
## Summary

The old `apijack plugin install` wrote directly to `~/.claude/plugins/marketplaces/local/apijack/` and mutated `installed_plugins.json` + `settings.json` by hand. Claude Code never recognized the installation — running `/doctor` reported:

```
Plugin (apijack@local): Plugin apijack not found in marketplace local
```

The "local" marketplace was never registered in `known_marketplaces.json`, which is managed by Claude Code and shouldn't be edited by third parties.

## New flow

Use the documented Claude Code plugin flow:

1. Lay out a marketplace at `~/.apijack/plugin-marketplace/` (our user data dir, not Claude's)
2. Nested plugin at `~/.apijack/plugin-marketplace/apijack/` with `.claude-plugin/plugin.json`, `.mcp.json`, `dist/`, `skills/`
3. `marketplace.json` uses the documented schema: `name`, `owner`, `metadata.description`, `plugins[{ source: "./apijack" }]` (validated with `claude plugin validate`)
4. Invoke `claude plugin marketplace add <path>` and `claude plugin install apijack@apijack` as subprocesses
5. Uninstall mirrors this: `claude plugin uninstall apijack@apijack` then `claude plugin marketplace remove apijack`, then rm the marketplace dir
6. Fail fast if the `claude` CLI isn't on PATH — no manual-instruction fallback

## Changes

- `src/plugin/paths.ts` — drop `claudeDir`, `installedPluginsFile`, `settingsFile`; add `marketplaceDir`
- `src/plugin/install.ts` — rewrite around the new marketplace layout and `claude plugin` CLI invocations. `runClaude` is injectable via `InstallOptions` for testing.
- `src/plugin/uninstall.ts` — mirror: `claude plugin uninstall` + `claude plugin marketplace remove`, best-effort (tolerates `claude` failures for cleanup)
- `src/plugin/register.ts` — update wiring and post-install output
- `tests/plugin/*.test.ts` — rewritten for the new shape; tests inject a `runClaude` mock and assert on the exact argument sequence

## Verification

- `bun test` — 677 pass, 0 fail
- `bun run lint` — 0 errors (99 existing warnings, unchanged)
- End-to-end: ran `bun run bin/apijack.ts plugin install` against a clean `~/.apijack/` and Claude Code plugin registry:
  - Marketplace registered: `claude plugin marketplace list` shows `apijack`
  - Plugin installed and enabled: `claude plugin list` shows `apijack@apijack ✔ enabled`
  - `/doctor` no longer reports the error
- End-to-end uninstall then reinstall also clean

## Breaking changes

- `InstallOptions.claudeDir` → removed; use `marketplaceDir` instead
- `UninstallOptions.claudeDir` → removed; use `marketplaceDir` instead
- `getPluginPaths()` no longer returns `claudeDir`/`installedPluginsFile`/`settingsFile`

Consumers of this API (rrc-cli etc.) call through `registerPluginCommand` which adapts automatically — no consumer changes needed.

## Test plan

- [ ] `bun test` passes on CI
- [ ] `bun run lint` passes on CI
- [ ] Manual verification on a fresh machine: `apijack plugin install` → `/doctor` reports clean → plugin MCP tools appear in Claude Code after `/reload-plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)