### PR TITLE
feat(resolver): support pluggable custom functions via .apijack/resolvers/ (#30)

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -5,6 +5,7 @@ import type {
     CommandRegistrar,
     DispatcherHandler,
     CommandDispatcher,
+    CustomResolver,
 } from './types';
 import { resolveAuth, verifyCredentials, saveEnvironment, getActiveEnvConfig } from './config';
 import { SessionManager } from './session';
@@ -29,6 +30,7 @@ import { loadPreRequestHook } from './pre-request';
 export interface Cli {
     command(name: string, registrar: CommandRegistrar): void;
     dispatcher(name: string, handler: DispatcherHandler): void;
+    resolver(name: string, handler: CustomResolver): void;
     run(): Promise<void>;
 }
 
@@ -102,6 +104,7 @@ function showCustomHelp(
 export function createCli(options: CliOptions): Cli {
     const consumerCommands: { name: string; registrar: CommandRegistrar }[] = [];
     const consumerDispatchers = new Map<string, DispatcherHandler>();
+    const consumerResolvers = new Map<string, CustomResolver>();
     const cliName = options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
     const configDir = options.configPath
@@ -117,6 +120,10 @@ export function createCli(options: CliOptions): Cli {
 
         dispatcher(name: string, handler: DispatcherHandler): void {
             consumerDispatchers.set(name, handler);
+        },
+
+        resolver(name: string, handler: CustomResolver): void {
+            consumerResolvers.set(name, handler);
         },
 
         async run(): Promise<void> {
@@ -422,11 +429,14 @@ export function createCli(options: CliOptions): Cli {
 
             let dispatch: CommandDispatcher | undefined;
 
+            const customResolvers = consumerResolvers.size > 0 ? consumerResolvers : undefined;
+
             if (ctx) {
                 dispatch = buildDispatcher({
                     commandMap,
                     client: ctx.client,
                     consumerHandlers: consumerDispatchers.size > 0 ? consumerDispatchers : undefined,
+                    customResolvers,
                     preDispatch: options.preDispatch,
                     ctx,
                     routinesDir,
@@ -437,7 +447,7 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 12. Register routine commands
-            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir);
+            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers);
 
             // 11. Handle -o routine-step
             const isRoutineStep

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
-import type { CommandDispatcher } from '../../types';
+import type { CommandDispatcher, CustomResolver } from '../../types';
 import { SessionManager } from '../../session';
 import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from '../../routine/loader';
 import { executeRoutine } from '../../routine/executor';
@@ -43,6 +43,7 @@ export function registerRoutineCommand(
     routinesDir: string,
     dispatch: CommandDispatcher | undefined,
     builtinRoutinesDir?: string,
+    customResolvers?: Map<string, CustomResolver>,
 ): void {
     const builtinsMap = builtinRoutinesDir
         ? loadBuiltinRoutines(builtinRoutinesDir)
@@ -114,6 +115,7 @@ export function registerRoutineCommand(
                     dispatch,
                     overrides,
                     dryRun: opts.dryRun,
+                    customResolvers,
                     invalidateSession: () => sessionMgr.invalidate(),
                     onStep: (step, i, total) => {
                         console.log(`\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}`);
@@ -185,6 +187,7 @@ export function registerRoutineCommand(
                     executeRoutine,
                     dispatch,
                     overrides,
+                    customResolvers,
                     routineName: name,
                     onStep: (step, i, total) => {
                         console.log(

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -1,14 +1,15 @@
-import type { CommandDispatcher } from '../../../types';
+import type { CommandDispatcher, CustomResolver } from '../../../types';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineRunDeps {
     loadRoutine: () => RoutineDefinition;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; customResolvers?: Map<string, CustomResolver>; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     dryRun?: boolean;
+    customResolvers?: Map<string, CustomResolver>;
     invalidateSession: () => void;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -26,6 +27,7 @@ export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success:
 
     const result = await deps.executeRoutine(def, deps.overrides, deps.dispatch, {
         dryRun: deps.dryRun,
+        customResolvers: deps.customResolvers,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -1,13 +1,14 @@
-import type { CommandDispatcher } from '../../../types';
+import type { CommandDispatcher, CustomResolver } from '../../../types';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineTestDeps {
     loadSpec: () => RoutineDefinition | null;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { customResolvers?: Map<string, CustomResolver>; onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
+    customResolvers?: Map<string, CustomResolver>;
     routineName?: string;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -27,6 +28,7 @@ export async function routineTestAction(deps: RoutineTestDeps): Promise<{ succes
     }
 
     return deps.executeRoutine(spec, deps.overrides, deps.dispatch, {
+        customResolvers: deps.customResolvers,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { createCli } from './cli-builder';
 export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher } from './types';
+export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver } from './types';
+export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';
 export { BearerTokenStrategy } from './auth/bearer';

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -1,7 +1,15 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import type { AuthStrategy, SessionAuthConfig } from './auth/types';
-import type { CommandRegistrar, DispatcherHandler } from './types';
+import type { CommandRegistrar, DispatcherHandler, CustomResolver } from './types';
+
+const BUILTIN_RESOLVER_NAMES = new Set([
+    '_random_hex_color',
+    '_uuid',
+    '_random_int',
+    '_random_from',
+    '_random_distinct_from',
+]);
 
 export interface ProjectAuth {
     strategy: AuthStrategy | null;
@@ -84,4 +92,45 @@ export async function loadProjectDispatchers(
     }
 
     return dispatchers;
+}
+
+export async function loadProjectResolvers(
+    apijackDir: string,
+): Promise<Map<string, CustomResolver>> {
+    const resDir = join(apijackDir, 'resolvers');
+
+    if (!existsSync(resDir)) return new Map();
+
+    const resolvers = new Map<string, CustomResolver>();
+    const files = readdirSync(resDir).filter(f => f.endsWith('.ts'));
+
+    for (const file of files) {
+        try {
+            const mod = await import(join(resDir, file));
+            const name = mod.name ?? basename(file, '.ts');
+            const resolver = mod.default as CustomResolver;
+
+            if (typeof resolver !== 'function') continue;
+
+            if (typeof name !== 'string' || !name.startsWith('_')) {
+                process.stderr.write(
+                    `Warning: skipping resolver "${file}" — name "${name}" must start with "_" (e.g. "_my_fn")\n`,
+                );
+                continue;
+            }
+
+            if (BUILTIN_RESOLVER_NAMES.has(name)) {
+                process.stderr.write(
+                    `Warning: skipping resolver "${file}" — name "${name}" collides with a built-in\n`,
+                );
+                continue;
+            }
+
+            resolvers.set(name, resolver);
+        } catch {
+            // Skip files that fail to import
+        }
+    }
+
+    return resolvers;
 }

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -1,4 +1,4 @@
-import type { CliContext, DispatcherHandler, CommandDispatcher } from '../types';
+import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../types';
 import { loadRoutineFile, validateRoutine } from './loader';
 import { executeRoutine } from './executor';
 
@@ -12,6 +12,7 @@ export interface DispatcherConfig {
     }>;
     client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
+    customResolvers?: Map<string, CustomResolver>;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     ctx: CliContext;
     routinesDir: string;
@@ -175,7 +176,9 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                 if (k.startsWith('--set-')) subOverrides[k.slice(6)] = v;
             }
 
-            const result = await _execute(subDef, subOverrides, dispatch);
+            const result = await _execute(subDef, subOverrides, dispatch, {
+                customResolvers: config.customResolvers,
+            });
 
             if (!result.success) throw new Error(`Sub-routine "${routineName}" failed`);
 

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -12,7 +12,7 @@ import {
     shuffle,
 } from './resolver';
 import { evaluateCondition } from './condition';
-import type { CommandDispatcher } from '../types';
+import type { CommandDispatcher, CustomResolver } from '../types';
 
 export interface RoutineResult {
     success: boolean;
@@ -24,6 +24,7 @@ export interface RoutineResult {
 
 interface ExecutorOptions {
     dryRun?: boolean;
+    customResolvers?: Map<string, CustomResolver>;
     onStep?: (step: RoutineStep, index: number, total: number) => void;
     onIteration?: (
         step: RoutineStep,
@@ -71,6 +72,7 @@ class RoutineExecutor {
         const ctx: RoutineContext = {
             variables: rawVars,
             stepOutputs: new Map(),
+            customResolvers: this.options?.customResolvers,
         };
 
         const ok = await this.runSteps(routine.steps, ctx);

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -1,10 +1,13 @@
 import type { RoutineContext } from './types';
 
 const REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*)*)/g;
-// No-arg built-in functions (match without parentheses)
-const NOARG_FUNC_PATTERN = /\$(_random_hex_color|_uuid)/g;
-// Parameterized built-in functions (require parentheses)
-const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)/g;
+// Parameterized built-in / custom functions (require parentheses). Run first in resolveString.
+const PARAM_FUNC_PATTERN = /\$(_[a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)/g;
+// No-arg built-in / custom functions. Run after PARAM_FUNC_PATTERN so only unparenned names remain.
+const NOARG_FUNC_PATTERN = /\$(_[a-zA-Z_][a-zA-Z0-9_]*)/g;
+// Exact-match equivalents for single-value resolution (resolveValue)
+const EXACT_PARAM_FUNC_PATTERN = /^\$(_[a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)$/;
+const EXACT_NOARG_FUNC_PATTERN = /^\$(_[a-zA-Z_][a-zA-Z0-9_]*)$/;
 
 // ── Built-in functions ─────────────────────────────────────────────
 
@@ -118,8 +121,13 @@ function evalBuiltinFunc(name: string, argsStr?: string, ctx?: RoutineContext): 
 
             return found !== undefined ? 'true' : 'false';
         }
-        default:
+        default: {
+            const custom = ctx?.customResolvers?.get(name);
+
+            if (custom) return custom(argsStr);
+
             return undefined;
+        }
     }
 }
 
@@ -179,18 +187,21 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
 
     if (!value.includes('$')) return value;
 
-    // Exact match: built-in function (no args)
-    const funcExact = value.match(/^\$(_random_hex_color|_uuid)$/);
-
-    if (funcExact) {
-        return evalBuiltinFunc(funcExact[1]!, undefined, ctx);
-    }
-
-    // Exact match: built-in function with args
-    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)$/);
+    // Exact match: function call with args (check before no-arg so foo() isn't captured as no-arg)
+    const funcCall = value.match(EXACT_PARAM_FUNC_PATTERN);
 
     if (funcCall) {
         return evalBuiltinFunc(funcCall[1]!, funcCall[2], ctx);
+    }
+
+    // Exact match: function without args. Only dispatch to evalBuiltinFunc if it actually
+    // resolves — otherwise fall through to ref resolution (so e.g. `$_timestamp` variables work).
+    const funcExact = value.match(EXACT_NOARG_FUNC_PATTERN);
+
+    if (funcExact) {
+        const result = evalBuiltinFunc(funcExact[1]!, undefined, ctx);
+
+        if (result !== undefined) return result;
     }
 
     // Exact match: entire value is a single $ref — resolve to native type

--- a/src/routine/types.ts
+++ b/src/routine/types.ts
@@ -29,8 +29,11 @@ export interface StepResult {
     error?: string;
 }
 
+import type { CustomResolver } from '../types';
+
 export interface RoutineContext {
     variables: Record<string, unknown>;
     stepOutputs: Map<string, StepResult>;
     forEachItem?: { name: string; value: unknown };
+    customResolvers?: Map<string, CustomResolver>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export type DispatcherHandler = (
     ctx: CliContext,
 ) => Promise<unknown>;
 
+export type CustomResolver = (argsStr?: string) => unknown;
+
 export type CommandDispatcher = (
     command: string,
     args: Record<string, unknown>,

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -48,10 +48,11 @@ async function captureOutput(fn: () => Promise<void>): Promise<string> {
 }
 
 describe('createCli()', () => {
-    test('returns object with command(), dispatcher(), run() methods', () => {
+    test('returns object with command(), dispatcher(), resolver(), run() methods', () => {
         const cli = createCli(makeOptions());
         expect(typeof cli.command).toBe('function');
         expect(typeof cli.dispatcher).toBe('function');
+        expect(typeof cli.resolver).toBe('function');
         expect(typeof cli.run).toBe('function');
     });
 
@@ -68,6 +69,12 @@ describe('createCli()', () => {
         const handler: DispatcherHandler = async (_args, _pos, _ctx) => ({});
         // Should not throw
         cli.dispatcher('my-dispatch', handler);
+    });
+
+    test('resolver() stores handler for the composed dispatcher', () => {
+        const cli = createCli(makeOptions());
+        // Should not throw
+        cli.resolver('_my_fn', _argsStr => 'ok');
     });
 });
 

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -125,5 +125,79 @@ describe('loadProjectDispatchers()', () => {
         expect(result.size).toBe(1);
         expect(result.has('notify')).toBe(true);
         expect(typeof result.get('notify')).toBe('function');
+    });
+});
+
+describe('loadProjectResolvers()', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('returns empty map when no resolvers/ dir exists', async () => {
+        mkdirSync(testRoot, { recursive: true });
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('loads resolver functions from resolvers/*.ts (name from export)', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'lookup.ts'), `
+            export const name = '_my_lookup';
+            export default (argsStr) => 'resolved:' + argsStr;
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(1);
+        expect(result.has('_my_lookup')).toBe(true);
+        expect(result.get('_my_lookup')!('hello')).toBe('resolved:hello');
+    });
+
+    test('falls back to filename when export name is missing', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, '_from_file.ts'), `
+            export default () => 42;
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(1);
+        expect(result.has('_from_file')).toBe(true);
+        expect(result.get('_from_file')!()).toBe(42);
+    });
+
+    test('skips resolvers whose name does not start with "_"', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'bad.ts'), `
+            export const name = 'no_underscore';
+            export default () => 'x';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('skips resolvers whose filename does not start with "_" when no export name', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'plainname.ts'), `
+            export default () => 'x';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('skips resolvers whose name collides with a built-in', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'uuid.ts'), `
+            export const name = '_uuid';
+            export default () => 'overridden';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
     });
 });

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, mock, beforeEach } from 'bun:test';
 import { buildDispatcher, type DispatcherConfig } from '../../src/routine/dispatcher';
-import type { CliContext, DispatcherHandler, CommandDispatcher } from '../../src/types';
+import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../../src/types';
 
 function makeCtx(overrides: Partial<CliContext> = {}): CliContext {
     return {
@@ -299,6 +299,41 @@ describe('buildDispatcher', () => {
             stepsSkipped: 0,
             stepsFailed: 0,
         });
+    });
+
+    test('routine run forwards customResolvers from DispatcherConfig into executor', async () => {
+        const ctx = makeCtx();
+        const customResolvers = new Map<string, CustomResolver>([
+            ['_my_fn', () => 'hi'],
+        ]);
+
+        const mockLoadRoutineFile = mock(() => ({
+            name: 'sub-routine',
+            steps: [{ name: 'step-1', command: 'cmd-a' }],
+            variables: {},
+        }));
+        const mockValidateRoutine = mock(() => []);
+        const mockExecuteRoutine = mock(async () => ({
+            success: true,
+            stepsRun: 1,
+            stepsSkipped: 0,
+            stepsFailed: 0,
+        }));
+
+        const dispatch = buildDispatcher({
+            ctx,
+            routinesDir: '/tmp/routines',
+            customResolvers,
+            _loadRoutineFile: mockLoadRoutineFile as any,
+            _validateRoutine: mockValidateRoutine as any,
+            _executeRoutine: mockExecuteRoutine as any,
+        } as any);
+
+        await dispatch('routine run', {}, ['my-sub']);
+
+        const executeCall = mockExecuteRoutine.mock.calls[0]!;
+        // 4th arg is the options object — customResolvers should be forwarded
+        expect(executeCall[3]).toEqual({ customResolvers });
     });
 
     test('routine run throws on validation errors', async () => {

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -7,6 +7,7 @@ import {
     resetDistinctPools,
 } from '../../src/routine/resolver';
 import type { RoutineContext } from '../../src/routine/types';
+import type { CustomResolver } from '../../src/types';
 
 function makeCtx(overrides: Partial<RoutineContext> = {}): RoutineContext {
     return {
@@ -422,5 +423,44 @@ describe('$_contains', () => {
         const ctx = ctxWithItems([{ name: 'alice' }, { name: 'bob' }]);
 
         expect(resolveValue('$_contains($items, name, carol)', ctx)).toBe('false');
+    });
+});
+
+describe('custom resolvers via ctx.customResolvers', () => {
+    test('invokes custom resolver with args as exact match', () => {
+        const custom: CustomResolver = argsStr => `lookup:${argsStr}`;
+        const customResolvers = new Map<string, CustomResolver>([['_my_lookup', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_my_lookup(foo)', ctx)).toBe('lookup:foo');
+    });
+
+    test('invokes custom no-arg resolver as exact match', () => {
+        const custom: CustomResolver = () => 42;
+        const customResolvers = new Map<string, CustomResolver>([['_constant', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_constant', ctx)).toBe(42);
+    });
+
+    test('interpolates custom resolver inline in a string', () => {
+        const custom: CustomResolver = argsStr => `[${argsStr}]`;
+        const customResolvers = new Map<string, CustomResolver>([['_wrap', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('value: $_wrap(abc)', ctx)).toBe('value: [abc]');
+    });
+
+    test('built-in wins over custom with colliding name', () => {
+        // _uuid is built-in; a custom resolver with the same name should be ignored by evalBuiltinFunc
+        const custom: CustomResolver = () => 'custom-override';
+        const customResolvers = new Map<string, CustomResolver>([['_uuid', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        const result = resolveValue('$_uuid', ctx) as string;
+        expect(result).not.toBe('custom-override');
+        expect(result).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test('custom resolver name takes effect only when registered', () => {
+        const ctx = makeCtx();
+        // Without registration the exact-match form returns undefined (unknown function)
+        expect(resolveValue('$_not_defined(x)', ctx)).toBeUndefined();
     });
 });


### PR DESCRIPTION
Closes #30

## Summary

Adds a `.apijack/resolvers/` extension directory so projects can register domain-specific resolver functions (e.g. `$_my_lookup(arg)`) without requiring core changes. Mirrors the existing `.apijack/commands/` and `.apijack/dispatchers/` extension patterns.

## API

- `loadProjectResolvers(apijackDir)` — loads `.apijack/resolvers/*.ts` files. Each file exports a default resolver function and an optional `name` (falls back to filename). Names must start with `_`; names that don't, or that collide with a built-in, are skipped with a stderr warning.
- `cli.resolver(name, handler)` — new method on the `Cli` object, parallel to `cli.command()` and `cli.dispatcher()`.
- `CustomResolver` type — `(argsStr?: string) => unknown` (sync for V1).

## Wiring path

Consumer `cli.ts` calls `loadProjectResolvers(configDir)` → forwards each into `cli.resolver(name, fn)` → stored in `consumerResolvers: Map` in `createCli` → passed into `buildDispatcher({ customResolvers })` and `registerRoutineCommand(..., customResolvers)` → forwarded into `executeRoutine({ customResolvers })` → attached to `ctx.customResolvers` → consulted inside `evalBuiltinFunc`'s `default:` branch.

## Usage example

```ts
// .apijack/resolvers/lookup.ts
export const name = '_project_id';
export default (argsStr?: string) => lookupProjectId(argsStr ?? '');

// cli.ts
import { loadProjectResolvers } from '@apijack/core';

const resolvers = await loadProjectResolvers('.apijack');
for (const [name, fn] of resolvers) cli.resolver(name, fn);
```

```yaml
# routine.yaml
steps:
  - name: fetch
    command: projects get
    args:
      --id: "$_project_id(my-project)"
```

## Design notes

- Built-ins win over custom resolvers on name collision (warned at load time).
- Regex patterns broadened from a whitelist of names to `_[a-zA-Z_][a-zA-Z0-9_]*`; `evalBuiltinFunc` is now the source of truth for which names resolve.
- `resolveValue` exact-match for no-arg functions falls through to ref resolution if `evalBuiltinFunc` returns undefined — preserves `$_timestamp` / `$_date` variable behavior.

## Test plan

- [x] `bun test` — 695 passing (99 in the four touched files)
- [x] `bun run lint` — 0 errors
- [ ] E2E skipped — change is internal to the resolver; unit tests cover the behavior