### PR TITLE
feat(cli): auto-load .apijack/resolvers/ and e2e-cover custom resolvers

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -9,7 +9,7 @@ import { BasicAuthStrategy } from '../src/auth/basic';
 import { BearerTokenStrategy } from '../src/auth/bearer';
 import { ApiKeyStrategy } from '../src/auth/api-key';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir } from '../src/project';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
 import { checkForUpdate } from '../src/updater';
 import { getActiveEnvConfig } from '../src/config';
 import pkg from '../package.json';
@@ -156,6 +156,12 @@ if (projectRoot) {
 
     for (const [name, handler] of dispatchers) {
         cli.dispatcher(name, handler);
+    }
+
+    const resolvers = await loadProjectResolvers(join(projectRoot, '.apijack'));
+
+    for (const [name, fn] of resolvers) {
+        cli.resolver(name, fn);
     }
 }
 

--- a/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
+++ b/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
@@ -1,0 +1,5 @@
+export const name = '_uppercase';
+
+export default function uppercase(argsStr?: string): string {
+    return (argsStr ?? '').toUpperCase();
+}

--- a/tests/e2e-tutorial/tutorial-e2e.yaml
+++ b/tests/e2e-tutorial/tutorial-e2e.yaml
@@ -1,10 +1,23 @@
 name: tutorial-e2e
 description: >
   End-to-end test of the full tutorial workflow:
+  verify custom resolver ($_uppercase) round-trips via a TODO,
   create 50 TODOs, color each randomly in shuffled order,
   delete all in reverse creation order, verify empty.
 
 steps:
+  - name: custom-resolver-create
+    command: todos create
+    args:
+      --title: "$_uppercase(hello-resolver)"
+    output: uppercased
+    assert: "$uppercased.title == HELLO-RESOLVER"
+
+  - name: custom-resolver-cleanup
+    command: todos delete
+    args:
+      --id: "$uppercased.id"
+
   - name: create-todos
     range: [1, 50]
     as: n


### PR DESCRIPTION
## Summary

- Wires `loadProjectResolvers()` into `bin/apijack.ts` so projects can drop a file into `.apijack/resolvers/<name>.ts` and have it auto-registered — matching the existing `.apijack/commands/` and `.apijack/dispatchers/` behavior. Without this, the loader added in #30 existed but was never called by the real CLI entrypoint.
- Adds a tutorial e2e resolver (`$_uppercase`) and two steps at the top of `tutorial-e2e.yaml` that create a TODO with `"$_uppercase(hello-resolver)"` as its title and assert the response title is `HELLO-RESOLVER`, then delete the TODO. This exercises the full path: file load → `cli.resolver()` registration → routine YAML → `evalBuiltinFunc` custom dispatch → API request.

## Test plan

- [x] `bun test` — 708 pass
- [x] `bun run lint` — 0 errors
- [x] `./tests/e2e-tutorial/run.sh` — PASSED; the two new steps ran and the assertion evaluated true inside Docker