### PR TITLE
feat(resolver): pass resolve() helper to custom resolvers (#34)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { createCli } from './cli-builder';
 export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver } from './types';
+export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver, CustomResolverHelpers } from './types';
 export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -122,11 +122,13 @@ function evalBuiltinFunc(name: string, argsStr?: string, ctx?: RoutineContext): 
             return found !== undefined ? 'true' : 'false';
         }
         default: {
-            const custom = ctx?.customResolvers?.get(name);
+            if (!ctx) return undefined;
 
-            if (custom) return custom(argsStr);
+            const custom = ctx.customResolvers?.get(name);
 
-            return undefined;
+            if (!custom) return undefined;
+
+            return custom(argsStr, { resolve: v => resolveValue(v, ctx) });
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,12 @@ export type DispatcherHandler = (
     ctx: CliContext,
 ) => Promise<unknown>;
 
-export type CustomResolver = (argsStr?: string) => unknown;
+export interface CustomResolverHelpers {
+    /** Resolve `$refs` and built-in functions inside a string against the current routine context. */
+    resolve: (value: string) => unknown;
+}
+
+export type CustomResolver = (argsStr?: string, helpers?: CustomResolverHelpers) => unknown;
 
 export type CommandDispatcher = (
     command: string,

--- a/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
+++ b/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
@@ -1,5 +1,10 @@
+import type { CustomResolverHelpers } from '../../../../../src/types';
+
 export const name = '_uppercase';
 
-export default function uppercase(argsStr?: string): string {
-    return (argsStr ?? '').toUpperCase();
+export default function uppercase(argsStr?: string, helpers?: CustomResolverHelpers): string {
+    const raw = argsStr ?? '';
+    const resolved = helpers ? String(helpers.resolve(raw)) : raw;
+
+    return resolved.toUpperCase();
 }

--- a/tests/e2e-tutorial/tutorial-e2e.yaml
+++ b/tests/e2e-tutorial/tutorial-e2e.yaml
@@ -5,18 +5,33 @@ description: >
   create 50 TODOs, color each randomly in shuffled order,
   delete all in reverse creation order, verify empty.
 
+variables:
+  greeting: "hello-from-variable"
+
 steps:
-  - name: custom-resolver-create
+  - name: custom-resolver-literal
     command: todos create
     args:
       --title: "$_uppercase(hello-resolver)"
-    output: uppercased
-    assert: "$uppercased.title == HELLO-RESOLVER"
+    output: literal
+    assert: "$literal.title == HELLO-RESOLVER"
 
-  - name: custom-resolver-cleanup
+  - name: custom-resolver-ref
+    command: todos create
+    args:
+      --title: "$_uppercase($greeting)"
+    output: resolved
+    assert: "$resolved.title == HELLO-FROM-VARIABLE"
+
+  - name: custom-resolver-cleanup-literal
     command: todos delete
     args:
-      --id: "$uppercased.id"
+      --id: "$literal.id"
+
+  - name: custom-resolver-cleanup-ref
+    command: todos delete
+    args:
+      --id: "$resolved.id"
 
   - name: create-todos
     range: [1, 50]

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -463,4 +463,32 @@ describe('custom resolvers via ctx.customResolvers', () => {
         // Without registration the exact-match form returns undefined (unknown function)
         expect(resolveValue('$_not_defined(x)', ctx)).toBeUndefined();
     });
+
+    test('helpers.resolve resolves $refs inside custom resolver args', () => {
+        const custom: CustomResolver = (argsStr, helpers) => {
+            const value = helpers ? String(helpers.resolve(argsStr ?? '')) : argsStr;
+
+            return String(value).toUpperCase();
+        };
+        const customResolvers = new Map<string, CustomResolver>([['_upper', custom]]);
+        const ctx = makeCtx({ variables: { greeting: 'hello' }, customResolvers });
+        expect(resolveValue('$_upper($greeting)', ctx)).toBe('HELLO');
+    });
+
+    test('helpers.resolve resolves built-in functions inside custom resolver args', () => {
+        const custom: CustomResolver = (argsStr, helpers) =>
+            (helpers ? helpers.resolve(argsStr ?? '') : argsStr);
+        const customResolvers = new Map<string, CustomResolver>([['_passthrough', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        const result = resolveValue('$_passthrough($_uuid)', ctx) as string;
+        expect(result).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test('legacy (argsStr-only) resolvers still work without helpers', () => {
+        // Backwards-compat: existing resolvers that ignore the second arg keep working.
+        const custom: CustomResolver = argsStr => `legacy:${argsStr}`;
+        const customResolvers = new Map<string, CustomResolver>([['_legacy', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_legacy(anything)', ctx)).toBe('legacy:anything');
+    });
 });


### PR DESCRIPTION
## Summary

Custom resolvers received raw, unresolved `argsStr` — so `$_uppercase($input)` passed the literal string `"$input"` instead of the resolved value. This matches how built-ins like `$_env` work (literal arg, parsed internally), but was surprising for user-defined resolvers, which almost always want resolved values.

Extends `CustomResolver` with an optional second argument, a `helpers` object exposing `{ resolve(v: string) }`. `resolve()` dispatches through `resolveValue` against the current routine context, so refs and built-in functions inside args can be evaluated on demand.

Backwards-compatible — legacy (`argsStr`-only) resolvers keep working since the second argument is optional.

```ts
import type { CustomResolver } from '@apijack/core';

const uppercase: CustomResolver = (argsStr, helpers) => {
    const resolved = helpers ? String(helpers.resolve(argsStr ?? '')) : argsStr;
    return String(resolved).toUpperCase();
};
```

```yaml
variables:
  greeting: "hello-from-variable"

steps:
  - command: todos create
    args:
      --title: "$_uppercase($greeting)"   # → "HELLO-FROM-VARIABLE"
```

## Test plan

- [x] `bun test` — 711 pass (3 new tests for `helpers.resolve` + backwards-compat)
- [x] `bun run lint` — 0 errors
- [x] `./tests/e2e-tutorial/run.sh` — PASSED; tutorial now creates two TODOs, one via literal arg and one via `$greeting` ref, and asserts both titles are uppercased

Closes #34