### PR TITLE
v1.7.0: custom resolvers, $_find / $_contains, $_env, auth challenges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,21 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install
+      - run: bun run lint
+
   unit-tests:
     strategy:
       matrix:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   codegen-petstore:

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 // bin/apijack.ts
 import { resolve, join, dirname } from 'path';
-import { mkdirSync } from 'fs';
+import { mkdirSync, existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { createCli } from '../src/cli-builder';
 import type { AuthStrategy, SessionAuthConfig } from '../src/auth/types';
@@ -29,6 +29,34 @@ const projectConfigPath = findProjectConfig(process.cwd());
 const projectConfig = projectConfigPath ? loadProjectConfig(projectConfigPath) : null;
 const configDir = resolveConfigDir(projectConfigPath);
 const projectRoot = projectConfigPath ? dirname(projectConfigPath) : null;
+
+// Load .env from project root (Bun auto-loads from cwd, which may differ when invoked via symlink)
+if (projectRoot) {
+    const envPath = join(projectRoot, '.env');
+
+    if (existsSync(envPath)) {
+        for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
+            const trimmed = line.trim();
+
+            if (!trimmed || trimmed.startsWith('#')) continue;
+
+            const eq = trimmed.indexOf('=');
+
+            if (eq < 0) continue;
+
+            const key = trimmed.slice(0, eq).trim();
+            let val = trimmed.slice(eq + 1).trim();
+
+            if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+                val = val.slice(1, -1);
+            }
+
+            if (!(key in process.env)) {
+                process.env[key] = val;
+            }
+        }
+    }
+}
 
 // 4. Resolve generated dir
 let generatedDir: string;

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -9,7 +9,7 @@ import { BasicAuthStrategy } from '../src/auth/basic';
 import { BearerTokenStrategy } from '../src/auth/bearer';
 import { ApiKeyStrategy } from '../src/auth/api-key';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir } from '../src/project';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
 import { checkForUpdate } from '../src/updater';
 import { getActiveEnvConfig } from '../src/config';
 import pkg from '../package.json';
@@ -156,6 +156,12 @@ if (projectRoot) {
 
     for (const [name, handler] of dispatchers) {
         cli.dispatcher(name, handler);
+    }
+
+    const resolvers = await loadProjectResolvers(join(projectRoot, '.apijack'));
+
+    for (const [name, fn] of resolvers) {
+        cli.resolver(name, fn);
     }
 }
 

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -60,6 +60,7 @@ if (projectRoot) {
 
 // 4. Resolve generated dir
 let generatedDir: string;
+
 if (projectConfig?.generatedDir && projectRoot) {
     generatedDir = resolve(projectRoot, projectConfig.generatedDir);
 } else if (projectRoot) {
@@ -72,6 +73,7 @@ if (projectConfig?.generatedDir && projectRoot) {
 
 // 5. Resolve spec path
 let specPath = '/v3/api-docs';
+
 if (projectConfig?.specUrl) {
     try {
         specPath = new URL(projectConfig.specUrl).pathname;
@@ -89,20 +91,24 @@ let projectOnChallenge: SessionAuthConfig['onChallenge'] | null = null;
 
 if (projectRoot) {
     const projectAuth = await loadProjectAuth(join(projectRoot, '.apijack'));
+
     if (projectAuth.strategy) {
         authStrategy = projectAuth.strategy;
         authResolved = true;
     }
+
     projectOnChallenge = projectAuth.onChallenge ?? null;
 }
 
 // Fall back to config-based auth type
 if (!authResolved) {
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
+
     if (env) {
         const authType = (env as Record<string, unknown>).authType as string | undefined;
+
         if (authType === 'bearer') {
-            authStrategy = new BearerTokenStrategy(async (config) => config.password);
+            authStrategy = new BearerTokenStrategy(async config => config.password);
         } else if (authType === 'apiKey') {
             const headerName = (env as Record<string, unknown>).authHeader as string ?? 'X-API-Key';
             const apiKey = (env as Record<string, unknown>).apiKey as string ?? '';
@@ -115,9 +121,11 @@ if (!authResolved) {
 let sessionAuth: SessionAuthConfig | undefined;
 {
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
+
     if (env) {
         sessionAuth = (env as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
     }
+
     if (sessionAuth && projectOnChallenge) {
         sessionAuth.onChallenge = projectOnChallenge;
     }
@@ -139,11 +147,13 @@ const cli = createCli({
 // 9. Register project-level extensions
 if (projectRoot) {
     const commands = await loadProjectCommands(join(projectRoot, '.apijack'));
+
     for (const cmd of commands) {
         cli.command(cmd.name, cmd.registrar);
     }
 
     const dispatchers = await loadProjectDispatchers(join(projectRoot, '.apijack'));
+
     for (const [name, handler] of dispatchers) {
         cli.dispatcher(name, handler);
     }

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -57,12 +57,15 @@ let authStrategy: AuthStrategy = new BasicAuthStrategy();
 let authResolved = false;
 
 // Check for project-level custom auth first
+let projectOnChallenge: SessionAuthConfig['onChallenge'] | null = null;
+
 if (projectRoot) {
     const projectAuth = await loadProjectAuth(join(projectRoot, '.apijack'));
-    if (projectAuth) {
-        authStrategy = projectAuth;
+    if (projectAuth.strategy) {
+        authStrategy = projectAuth.strategy;
         authResolved = true;
     }
+    projectOnChallenge = projectAuth.onChallenge ?? null;
 }
 
 // Fall back to config-based auth type
@@ -86,6 +89,9 @@ let sessionAuth: SessionAuthConfig | undefined;
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
     if (env) {
         sessionAuth = (env as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
+    }
+    if (sessionAuth && projectOnChallenge) {
+        sessionAuth.onChallenge = projectOnChallenge;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.6.1",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
   },
   "scripts": {
     "test": "bun test",
-    "lint": "eslint src/",
-    "lint:fix": "eslint src/ --fix",
+    "lint": "eslint src/ tests/ bin/",
+    "lint:fix": "eslint src/ tests/ bin/ --fix",
     "build:plugin": "bun run scripts/build-plugin.ts",
     "prepack": "bun run build:plugin"
   },

--- a/skills/write-routine/SKILL.md
+++ b/skills/write-routine/SKILL.md
@@ -84,6 +84,23 @@ steps:
 **Environment:**
 - `$_env(VAR)` / `$_env(VAR, default)` — read from environment. `.env` at the project root is auto-loaded at startup; real env vars take precedence.
 
+**Array lookup:**
+- `$_find($array, field, value)` — return the first element of `$array` where `element[field] == value`, or `undefined` if nothing matches. The array arg and the value arg resolve `$refs`; the field is a literal name.
+- `$_contains($array, field, value)` — returns `"true"` or `"false"`. Useful in conditions.
+
+Example — skip creation when an entity already exists:
+```yaml
+- name: list-projects
+  command: projects list
+  output: projects
+
+- name: create
+  command: projects create
+  args:
+    --name: "$name"
+  condition: "$_find($projects, name, $name) == undefined"
+```
+
 Variables can reference other variables in defaults: `run_id: "run-$_timestamp"`.
 
 Override at runtime: `<cli> routine run my-routine --set project_name=prod`.
@@ -121,7 +138,7 @@ Skip steps when a condition is false:
   condition: "$created.status == ready"
 ```
 
-Supported operators: `==`, `!=`, or bare `$ref` for truthy check.
+Supported operators: `==`, `!=`, or bare `$ref` for truthy check. The RHS may be a literal, a `$ref`, or the keyword `undefined` (for strict `=== undefined` comparison — useful with `$_find`). Function calls like `$_find(...)` are allowed on the LHS.
 
 ## Loops
 
@@ -247,6 +264,54 @@ Built-in commands available in routines:
 <cli> routine list --tree                  # Show tree structure
 ```
 
+## Custom Resolvers
+
+If the built-in `$_*` functions aren't enough, add project-specific resolvers by dropping a `.ts` file into `.apijack/resolvers/`. They show up as `$_<name>(...)` inside routines, just like the built-ins.
+
+**`.apijack/resolvers/uppercase.ts`:**
+```ts
+import type { CustomResolverHelpers } from '@apijack/core';
+
+export const name = '_uppercase';
+
+export default function uppercase(argsStr?: string, helpers?: CustomResolverHelpers): string {
+    // helpers.resolve() expands $refs and built-in functions inside the arg
+    const raw = argsStr ?? '';
+    const resolved = helpers ? String(helpers.resolve(raw)) : raw;
+
+    return resolved.toUpperCase();
+}
+```
+
+**Use it in a routine:**
+```yaml
+variables:
+  greeting: "hello-world"
+steps:
+  - name: create
+    command: resources create
+    args:
+      --title: "$_uppercase($greeting)"   # → "HELLO-WORLD"
+```
+
+**Rules:**
+- File name (or `export const name`) becomes the function name. It **must** start with `_` to match the `$_*` call syntax.
+- Built-in names (`_env`, `_find`, `_uuid`, `_random_*`, etc.) are reserved — a colliding custom resolver is skipped with a stderr warning.
+- `helpers.resolve(value)` runs the arg through the full resolver (same rules as a routine value), so `$refs`, `$_env(...)`, and other `$_*` functions inside the arg get expanded before your function sees them. Skip it to receive literal args (like `$_env` does).
+- Resolvers are sync. Return the value directly.
+
+## Project Extensions
+
+The `.apijack/` directory at a project root is auto-loaded when the CLI runs inside that project. Drop a file in one of these subdirs and it's picked up:
+
+| Directory | File exports | Used as |
+|-----------|--------------|---------|
+| `.apijack/resolvers/*.ts` | `default`: `(argsStr?, helpers?) => unknown`, optional `name` | Custom `$_*(...)` routine functions |
+| `.apijack/commands/*.ts` | `default`: `(program, ctx) => void`, optional `name` | Extra CLI subcommands |
+| `.apijack/dispatchers/*.ts` | `default`: `(args, posArgs, ctx) => Promise<unknown>`, optional `name` | Handle non-API commands invoked from routines |
+| `.apijack/auth.ts` | `default`: `AuthStrategy`, optional `onChallenge` | Project-level auth strategy |
+| `.apijack/routines/*.yaml` | Routine YAML | Available via `routine run <name>` |
+
 ## Common Patterns
 
 ### Create-then-verify
@@ -275,6 +340,26 @@ Built-in commands available in routines:
   args:
     --id: "$job.id"
     --timeout: "120"
+```
+
+### Idempotent create (skip if exists)
+
+```yaml
+- name: list-existing
+  command: projects list
+  output: projects
+
+- name: create
+  command: projects create
+  args:
+    --name: "$name"
+  condition: "$_find($projects, name, $name) == undefined"
+  output: created
+
+- name: verify
+  command: projects list
+  output: final
+  assert: "$_contains($final, name, $name) == true"
 ```
 
 ### Batch operations

--- a/skills/write-routine/SKILL.md
+++ b/skills/write-routine/SKILL.md
@@ -81,6 +81,9 @@ steps:
 - `$_random_from(a,b,c)` — pick one randomly (may repeat)
 - `$_random_distinct_from(a,b,c)` — pick one randomly, no repeats until all used (then cycles)
 
+**Environment:**
+- `$_env(VAR)` / `$_env(VAR, default)` — read from environment. `.env` at the project root is auto-loaded at startup; real env vars take precedence.
+
 Variables can reference other variables in defaults: `run_id: "run-$_timestamp"`.
 
 Override at runtime: `<cli> routine run my-routine --set project_name=prod`.

--- a/src/auth/config-merge.ts
+++ b/src/auth/config-merge.ts
@@ -9,9 +9,21 @@ export function deepMergeSessionAuth(
     base: SessionAuthConfig,
     override: Partial<SessionAuthConfig> | undefined,
 ): SessionAuthConfig {
-    if (!override) return structuredClone(base);
+    // Preserve function fields that structuredClone would strip
+    const baseFn = base.onChallenge;
+    const overrideFn = override?.onChallenge;
 
-    return deepMerge(structuredClone(base), override) as SessionAuthConfig;
+    const cloned = structuredClone({ ...base, onChallenge: undefined });
+
+    if (override) {
+        const { onChallenge: _, ...overrideData } = override;
+        deepMerge(cloned, overrideData);
+    }
+
+    const result = cloned as SessionAuthConfig;
+    result.onChallenge = overrideFn ?? baseFn;
+
+    return result;
 }
 
 function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {

--- a/src/auth/session-auth.ts
+++ b/src/auth/session-auth.ts
@@ -14,20 +14,59 @@ export class SessionAuthStrategy implements AuthStrategy {
         const baseSession = await this.base.authenticate(config);
 
         const method = this.config.session.method ?? 'GET';
-        const url = config.baseUrl + this.config.session.endpoint;
+        const baseUrl = config.baseUrl + this.config.session.endpoint;
 
-        const res = await fetch(url, {
+        let res = await fetch(baseUrl, {
             method,
             headers: baseSession.headers,
             redirect: 'manual',
         });
 
-        if (!res.ok) {
-            const body = await res.text();
-            throw new Error(`Session endpoint ${url} returned ${res.status}: ${body}`);
+        let challengeCookies: Record<string, string> | undefined;
+
+        if (!res.ok && this.config.onChallenge) {
+            let body = await res.text();
+            challengeCookies = this.collectAllCookies(res);
+            let params = await this.config.onChallenge(res.status, body);
+
+            while (params) {
+                const retryUrl = new URL(baseUrl);
+
+                for (const [k, v] of Object.entries(params)) {
+                    retryUrl.searchParams.set(k, v);
+                }
+
+                const retryHeaders: Record<string, string> = { ...baseSession.headers };
+
+                if (Object.keys(challengeCookies).length > 0) {
+                    retryHeaders.Cookie = Object.entries(challengeCookies)
+                        .map(([k, v]) => `${k}=${v}`)
+                        .join('; ');
+                }
+
+                res = await fetch(retryUrl.toString(), {
+                    method,
+                    headers: retryHeaders,
+                    redirect: 'manual',
+                });
+
+                // Accumulate cookies across retries
+                Object.assign(challengeCookies, this.collectAllCookies(res));
+
+                if (res.ok) break;
+
+                body = await res.text();
+                params = await this.config.onChallenge(res.status, body);
+            }
         }
 
-        const cookies = this.extractCookies(res);
+        if (!res.ok) {
+            const body = await res.text().catch(() => '');
+            throw new Error(`Session endpoint ${baseUrl} returned ${res.status}: ${body}`);
+        }
+
+        // Merge challenge cookies (e.g. remember_device) with extracted session cookies
+        const cookies = { ...challengeCookies, ...this.extractCookies(res) };
 
         return {
             headers: baseSession.headers,
@@ -56,6 +95,21 @@ export class SessionAuthStrategy implements AuthStrategy {
 
     async refresh(_session: AuthSession, config: ResolvedAuth): Promise<AuthSession> {
         return this.authenticate(config);
+    }
+
+    private collectAllCookies(res: Response): Record<string, string> {
+        const cookies: Record<string, string> = {};
+
+        for (const raw of res.headers.getSetCookie()) {
+            const [nameValue] = raw.split(';');
+            const eqIdx = nameValue.indexOf('=');
+
+            if (eqIdx < 0) continue;
+
+            cookies[nameValue.slice(0, eqIdx).trim()] = nameValue.slice(eqIdx + 1).trim();
+        }
+
+        return cookies;
     }
 
     private extractCookies(res: Response): Record<string, string> {

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -32,4 +32,6 @@ export interface SessionAuthConfig {
         applyTo?: string[];
     }>;
     refreshOn?: number[];
+    /** Called when the session endpoint returns a non-OK response. Return query params to retry, or null to give up. */
+    onChallenge?: (status: number, body: string) => Promise<Record<string, string> | null>;
 }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -5,6 +5,7 @@ import type {
     CommandRegistrar,
     DispatcherHandler,
     CommandDispatcher,
+    CustomResolver,
 } from './types';
 import { resolveAuth, verifyCredentials, saveEnvironment, getActiveEnvConfig } from './config';
 import { SessionManager } from './session';
@@ -29,6 +30,7 @@ import { loadPreRequestHook } from './pre-request';
 export interface Cli {
     command(name: string, registrar: CommandRegistrar): void;
     dispatcher(name: string, handler: DispatcherHandler): void;
+    resolver(name: string, handler: CustomResolver): void;
     run(): Promise<void>;
 }
 
@@ -102,6 +104,7 @@ function showCustomHelp(
 export function createCli(options: CliOptions): Cli {
     const consumerCommands: { name: string; registrar: CommandRegistrar }[] = [];
     const consumerDispatchers = new Map<string, DispatcherHandler>();
+    const consumerResolvers = new Map<string, CustomResolver>();
     const cliName = options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
     const configDir = options.configPath
@@ -117,6 +120,10 @@ export function createCli(options: CliOptions): Cli {
 
         dispatcher(name: string, handler: DispatcherHandler): void {
             consumerDispatchers.set(name, handler);
+        },
+
+        resolver(name: string, handler: CustomResolver): void {
+            consumerResolvers.set(name, handler);
         },
 
         async run(): Promise<void> {
@@ -422,11 +429,14 @@ export function createCli(options: CliOptions): Cli {
 
             let dispatch: CommandDispatcher | undefined;
 
+            const customResolvers = consumerResolvers.size > 0 ? consumerResolvers : undefined;
+
             if (ctx) {
                 dispatch = buildDispatcher({
                     commandMap,
                     client: ctx.client,
                     consumerHandlers: consumerDispatchers.size > 0 ? consumerDispatchers : undefined,
+                    customResolvers,
                     preDispatch: options.preDispatch,
                     ctx,
                     routinesDir,
@@ -437,7 +447,7 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 12. Register routine commands
-            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir);
+            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers);
 
             // 11. Handle -o routine-step
             const isRoutineStep

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
-import type { CommandDispatcher } from '../../types';
+import type { CommandDispatcher, CustomResolver } from '../../types';
 import { SessionManager } from '../../session';
 import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from '../../routine/loader';
 import { executeRoutine } from '../../routine/executor';
@@ -43,6 +43,7 @@ export function registerRoutineCommand(
     routinesDir: string,
     dispatch: CommandDispatcher | undefined,
     builtinRoutinesDir?: string,
+    customResolvers?: Map<string, CustomResolver>,
 ): void {
     const builtinsMap = builtinRoutinesDir
         ? loadBuiltinRoutines(builtinRoutinesDir)
@@ -114,6 +115,7 @@ export function registerRoutineCommand(
                     dispatch,
                     overrides,
                     dryRun: opts.dryRun,
+                    customResolvers,
                     invalidateSession: () => sessionMgr.invalidate(),
                     onStep: (step, i, total) => {
                         console.log(`\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}`);
@@ -185,6 +187,7 @@ export function registerRoutineCommand(
                     executeRoutine,
                     dispatch,
                     overrides,
+                    customResolvers,
                     routineName: name,
                     onStep: (step, i, total) => {
                         console.log(

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -1,14 +1,15 @@
-import type { CommandDispatcher } from '../../../types';
+import type { CommandDispatcher, CustomResolver } from '../../../types';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineRunDeps {
     loadRoutine: () => RoutineDefinition;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; customResolvers?: Map<string, CustomResolver>; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     dryRun?: boolean;
+    customResolvers?: Map<string, CustomResolver>;
     invalidateSession: () => void;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -26,6 +27,7 @@ export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success:
 
     const result = await deps.executeRoutine(def, deps.overrides, deps.dispatch, {
         dryRun: deps.dryRun,
+        customResolvers: deps.customResolvers,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -1,13 +1,14 @@
-import type { CommandDispatcher } from '../../../types';
+import type { CommandDispatcher, CustomResolver } from '../../../types';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineTestDeps {
     loadSpec: () => RoutineDefinition | null;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { customResolvers?: Map<string, CustomResolver>; onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
+    customResolvers?: Map<string, CustomResolver>;
     routineName?: string;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -27,6 +28,7 @@ export async function routineTestAction(deps: RoutineTestDeps): Promise<{ succes
     }
 
     return deps.executeRoutine(spec, deps.overrides, deps.dispatch, {
+        customResolvers: deps.customResolvers,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { createCli } from './cli-builder';
 export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher } from './types';
+export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver } from './types';
+export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';
 export { BearerTokenStrategy } from './auth/bearer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { createCli } from './cli-builder';
 export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver } from './types';
+export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver, CustomResolverHelpers } from './types';
 export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';

--- a/src/plugin/claude-cli.ts
+++ b/src/plugin/claude-cli.ts
@@ -1,0 +1,36 @@
+export type ClaudeRunner = (args: string[]) => Promise<void>;
+
+/** Checks that the `claude` CLI is available on PATH. Throws a helpful error if not. */
+export function ensureClaudeCli(): void {
+    let ok = false;
+
+    try {
+        const proc = Bun.spawnSync(['claude', '--version'], {
+            stdout: 'pipe',
+            stderr: 'pipe',
+        });
+
+        ok = proc.exitCode === 0;
+    } catch {
+        // Command not found — spawnSync threw
+    }
+
+    if (!ok) {
+        throw new Error(
+            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin" commands.',
+        );
+    }
+}
+
+/** Invokes the real `claude` CLI and throws on non-zero exit. stderr/stdout pass through to the parent process. */
+export async function runClaudeCli(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
+}

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,68 +1,65 @@
-import { existsSync, readFileSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
 import { join } from 'path';
+
+export type ClaudeRunner = (args: string[]) => Promise<void>;
 
 export interface InstallOptions {
     version: string;
-    claudeDir: string;
     userDataDir: string;
+    marketplaceDir: string;
     sourceDir: string;
     cliInvocation: string[];
     generatedDir: string;
+    /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
+    runClaude?: ClaudeRunner;
 }
 
 export interface InstallResult {
     success: boolean;
     marketplaceDir: string;
+    pluginDir: string;
     message: string;
 }
 
 export async function installPlugin(opts: InstallOptions): Promise<InstallResult> {
     const {
         version,
-        claudeDir,
         userDataDir,
+        marketplaceDir,
         sourceDir,
         cliInvocation,
         generatedDir,
     } = opts;
 
-    // 1. Place plugin files in local marketplace: marketplaces/local/apijack/
-    const localMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'local');
-    const pluginDir = join(localMarketplaceDir, 'apijack');
-    mkdirSync(join(localMarketplaceDir, '.claude-plugin'), { recursive: true });
+    const runClaude = opts.runClaude ?? defaultRunClaude;
+
+    if (!opts.runClaude) ensureClaudeCli();
+
+    const pluginDir = join(marketplaceDir, 'apijack');
+
+    // 1. Lay out the marketplace directory
+    mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
     mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
 
-    // Register in local marketplace.json with source: "./apijack"
-    const localMarketplacePath = join(localMarketplaceDir, '.claude-plugin', 'marketplace.json');
-    let localMarketplace: Record<string, unknown> = {
-        $schema: 'https://anthropic.com/claude-code/marketplace.schema.json',
-        name: 'local',
-        owner: { name: 'Local Plugins' },
-        plugins: [],
-    };
+    writeFileSync(
+        join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
+        JSON.stringify({
+            name: 'apijack',
+            owner: { name: 'apijack' },
+            metadata: {
+                description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
+            },
+            plugins: [
+                {
+                    name: 'apijack',
+                    description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+                    category: 'development',
+                    source: './apijack',
+                },
+            ],
+        }, null, 2) + '\n',
+    );
 
-    if (existsSync(localMarketplacePath)) {
-        try {
-            localMarketplace = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
-        } catch {}
-    }
-
-    const plugins = (localMarketplace.plugins as Array<{ name: string; [k: string]: unknown }>) || [];
-    const idx = plugins.findIndex(p => p.name === 'apijack');
-    const marketplaceEntry = {
-        name: 'apijack',
-        description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-        category: 'development',
-        source: './apijack',
-    };
-
-    if (idx >= 0) plugins[idx] = marketplaceEntry;
-    else plugins.push(marketplaceEntry);
-
-    localMarketplace.plugins = plugins;
-    writeFileSync(localMarketplacePath, JSON.stringify(localMarketplace, null, 2) + '\n');
-
-    // Write plugin.json manifest
     writeFileSync(
         join(pluginDir, '.claude-plugin', 'plugin.json'),
         JSON.stringify({
@@ -76,7 +73,6 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         }, null, 2) + '\n',
     );
 
-    // Write .mcp.json with CLAUDE_PLUGIN_ROOT reference
     writeFileSync(
         join(pluginDir, '.mcp.json'),
         JSON.stringify({
@@ -90,7 +86,7 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         }, null, 2) + '\n',
     );
 
-    // Copy bundle
+    // 2. Copy bundle
     const distDir = join(pluginDir, 'dist');
     mkdirSync(distDir, { recursive: true });
     const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
@@ -99,7 +95,7 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
     }
 
-    // Copy skills (clear first to remove stale entries from previous versions)
+    // 3. Copy skills (clear first to remove stale entries from previous versions)
     const skillsDst = join(pluginDir, 'skills');
 
     if (existsSync(skillsDst)) {
@@ -112,62 +108,46 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         cpSync(skillsSrc, skillsDst, { recursive: true });
     }
 
-    // Clean up old registrations and cache before re-registering
-    const installedPath = join(claudeDir, 'plugins', 'installed_plugins.json');
-    const settingsPath = join(claudeDir, 'settings.json');
-
-    const oldCacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
-
-    if (existsSync(oldCacheDir)) {
-        rmSync(oldCacheDir, { recursive: true, force: true });
-    }
-
-    const oldMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
-
-    if (existsSync(oldMarketplaceDir)) {
-        rmSync(oldMarketplaceDir, { recursive: true, force: true });
-    }
-
-    // 3. Register in installed_plugins.json and enable in settings.json
-    const installedPlugins = existsSync(installedPath)
-        ? JSON.parse(readFileSync(installedPath, 'utf-8'))
-        : { version: 2, plugins: {} };
-
-    if (!installedPlugins.plugins) installedPlugins.plugins = {};
-
-    delete installedPlugins.plugins['apijack@apijack'];
-    installedPlugins.plugins['apijack@local'] = [{
-        scope: 'user',
-        installPath: pluginDir,
-        version,
-        installedAt: new Date().toISOString(),
-        lastUpdated: new Date().toISOString(),
-        gitCommitSha: '',
-    }];
-    writeFileSync(installedPath, JSON.stringify(installedPlugins, null, 2) + '\n');
-
-    const settings = existsSync(settingsPath)
-        ? JSON.parse(readFileSync(settingsPath, 'utf-8'))
-        : {};
-
-    if (!settings.enabledPlugins) settings.enabledPlugins = {};
-
-    delete settings.enabledPlugins['apijack@apijack'];
-    settings.enabledPlugins['apijack@local'] = true;
-    writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-
-    // 4. Create user data directory
+    // 4. Write runtime config for the MCP entry point
     mkdirSync(join(userDataDir, 'routines'), { recursive: true });
-
-    // 5. Write plugin config for the MCP entry point
     writeFileSync(
         join(userDataDir, 'plugin.json'),
         JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
     );
 
+    // 5. Register marketplace and install via claude CLI
+    await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
+    await runClaude(['plugin', 'install', 'apijack@apijack']);
+
     return {
         success: true,
-        marketplaceDir: pluginDir,
+        marketplaceDir,
+        pluginDir,
         message: `apijack plugin v${version} installed`,
     };
+}
+
+function ensureClaudeCli(): void {
+    const proc = Bun.spawnSync(['claude', '--version'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+
+    if (proc.exitCode !== 0) {
+        throw new Error(
+            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin install".',
+        );
+    }
+}
+
+async function defaultRunClaude(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'inherit',
+        stderr: 'inherit',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
 }

--- a/src/plugin/install.ts
+++ b/src/plugin/install.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'fs';
 import { join } from 'path';
+import { type ClaudeRunner, ensureClaudeCli, runClaudeCli } from './claude-cli';
 
-export type ClaudeRunner = (args: string[]) => Promise<void>;
+export type { ClaudeRunner } from './claude-cli';
 
 export interface InstallOptions {
     version: string;
@@ -12,6 +13,8 @@ export interface InstallOptions {
     generatedDir: string;
     /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
     runClaude?: ClaudeRunner;
+    /** Overridable for tests. Defaults to checking the real `claude` CLI on PATH. */
+    checkClaudeCli?: () => void;
 }
 
 export interface InstallResult {
@@ -31,93 +34,75 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
         generatedDir,
     } = opts;
 
-    const runClaude = opts.runClaude ?? defaultRunClaude;
+    const runClaude = opts.runClaude ?? runClaudeCli;
+    const checkCli = opts.checkClaudeCli ?? ensureClaudeCli;
 
-    if (!opts.runClaude) ensureClaudeCli();
+    // Fail fast if the CLI isn't available — we don't want to lay out files we can't register
+    if (!opts.runClaude) checkCli();
 
+    const marketplaceDirExisted = existsSync(marketplaceDir);
     const pluginDir = join(marketplaceDir, 'apijack');
 
-    // 1. Lay out the marketplace directory
-    mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
-    mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
+    try {
+        // 1. Lay out the marketplace directory
+        mkdirSync(join(marketplaceDir, '.claude-plugin'), { recursive: true });
+        mkdirSync(join(pluginDir, '.claude-plugin'), { recursive: true });
 
-    writeFileSync(
-        join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
-        JSON.stringify({
-            name: 'apijack',
-            owner: { name: 'apijack' },
-            metadata: {
-                description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
-            },
-            plugins: [
-                {
-                    name: 'apijack',
-                    description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-                    category: 'development',
-                    source: './apijack',
-                },
-            ],
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(marketplaceDir, '.claude-plugin', 'marketplace.json'),
+            JSON.stringify(buildMarketplaceManifest(), null, 2) + '\n',
+        );
 
-    writeFileSync(
-        join(pluginDir, '.claude-plugin', 'plugin.json'),
-        JSON.stringify({
-            name: 'apijack',
-            description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
-            version,
-            author: { name: 'apijack' },
-            repository: 'https://github.com/normalled/apijack',
-            license: 'MIT',
-            keywords: ['openapi', 'cli', 'mcp', 'api', 'routines'],
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(pluginDir, '.claude-plugin', 'plugin.json'),
+            JSON.stringify(buildPluginManifest(version), null, 2) + '\n',
+        );
 
-    writeFileSync(
-        join(pluginDir, '.mcp.json'),
-        JSON.stringify({
-            mcpServers: {
-                apijack: {
-                    type: 'stdio',
-                    command: 'bun',
-                    args: ['run', '${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js'],
-                },
-            },
-        }, null, 2) + '\n',
-    );
+        writeFileSync(
+            join(pluginDir, '.mcp.json'),
+            JSON.stringify(buildMcpConfig(), null, 2) + '\n',
+        );
 
-    // 2. Copy bundle
-    const distDir = join(pluginDir, 'dist');
-    mkdirSync(distDir, { recursive: true });
-    const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
+        // 2. Copy bundle
+        const distDir = join(pluginDir, 'dist');
+        mkdirSync(distDir, { recursive: true });
+        const bundleSrc = join(sourceDir, 'dist', 'mcp-server.bundle.js');
 
-    if (existsSync(bundleSrc)) {
-        cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
+        if (existsSync(bundleSrc)) {
+            cpSync(bundleSrc, join(distDir, 'mcp-server.bundle.js'));
+        }
+
+        // 3. Copy skills (clear first to remove stale entries from previous versions)
+        const skillsDst = join(pluginDir, 'skills');
+
+        if (existsSync(skillsDst)) {
+            rmSync(skillsDst, { recursive: true, force: true });
+        }
+
+        const skillsSrc = join(sourceDir, 'skills');
+
+        if (existsSync(skillsSrc)) {
+            cpSync(skillsSrc, skillsDst, { recursive: true });
+        }
+
+        // 4. Write runtime config for the MCP entry point
+        mkdirSync(join(userDataDir, 'routines'), { recursive: true });
+        writeFileSync(
+            join(userDataDir, 'plugin.json'),
+            JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
+        );
+
+        // 5. Register marketplace and install via claude CLI
+        await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
+        await runClaude(['plugin', 'install', 'apijack@apijack']);
+    } catch (err) {
+        // Roll back the marketplace dir we created so the next install starts clean
+        if (!marketplaceDirExisted && existsSync(marketplaceDir)) {
+            rmSync(marketplaceDir, { recursive: true, force: true });
+        }
+
+        throw err;
     }
-
-    // 3. Copy skills (clear first to remove stale entries from previous versions)
-    const skillsDst = join(pluginDir, 'skills');
-
-    if (existsSync(skillsDst)) {
-        rmSync(skillsDst, { recursive: true, force: true });
-    }
-
-    const skillsSrc = join(sourceDir, 'skills');
-
-    if (existsSync(skillsSrc)) {
-        cpSync(skillsSrc, skillsDst, { recursive: true });
-    }
-
-    // 4. Write runtime config for the MCP entry point
-    mkdirSync(join(userDataDir, 'routines'), { recursive: true });
-    writeFileSync(
-        join(userDataDir, 'plugin.json'),
-        JSON.stringify({ cliInvocation, generatedDir }, null, 2) + '\n',
-    );
-
-    // 5. Register marketplace and install via claude CLI
-    await runClaude(['plugin', 'marketplace', 'add', marketplaceDir]);
-    await runClaude(['plugin', 'install', 'apijack@apijack']);
 
     return {
         success: true,
@@ -127,27 +112,44 @@ export async function installPlugin(opts: InstallOptions): Promise<InstallResult
     };
 }
 
-function ensureClaudeCli(): void {
-    const proc = Bun.spawnSync(['claude', '--version'], {
-        stdout: 'pipe',
-        stderr: 'pipe',
-    });
-
-    if (proc.exitCode !== 0) {
-        throw new Error(
-            'Claude Code CLI ("claude") not found on PATH. Install Claude Code before running "apijack plugin install".',
-        );
-    }
+function buildMarketplaceManifest(): Record<string, unknown> {
+    return {
+        name: 'apijack',
+        owner: { name: 'apijack' },
+        metadata: {
+            description: 'apijack plugin marketplace — MCP server, skills, and routines for Jacking into OpenAPI specs',
+        },
+        plugins: [
+            {
+                name: 'apijack',
+                description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+                category: 'development',
+                source: './apijack',
+            },
+        ],
+    };
 }
 
-async function defaultRunClaude(args: string[]): Promise<void> {
-    const proc = Bun.spawn(['claude', ...args], {
-        stdout: 'inherit',
-        stderr: 'inherit',
-    });
-    const exitCode = await proc.exited;
+function buildPluginManifest(version: string): Record<string, unknown> {
+    return {
+        name: 'apijack',
+        description: 'Jack into any OpenAPI spec — full CLI with AI-agentic workflow automation',
+        version,
+        author: { name: 'apijack' },
+        repository: 'https://github.com/normalled/apijack',
+        license: 'MIT',
+        keywords: ['openapi', 'cli', 'mcp', 'api', 'routines'],
+    };
+}
 
-    if (exitCode !== 0) {
-        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
-    }
+function buildMcpConfig(): Record<string, unknown> {
+    return {
+        mcpServers: {
+            apijack: {
+                type: 'stdio',
+                command: 'bun',
+                args: ['run', '${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js'],
+            },
+        },
+    };
 }

--- a/src/plugin/paths.ts
+++ b/src/plugin/paths.ts
@@ -2,23 +2,17 @@ import { homedir } from 'os';
 import { join, resolve } from 'path';
 
 export interface PluginPaths {
-    claudeDir: string;
-    installedPluginsFile: string;
-    settingsFile: string;
     userDataDir: string;
+    marketplaceDir: string;
     sourceDir: string;
 }
 
 export function getPluginPaths(_version: string): PluginPaths {
-    const home = homedir();
-    const claudeDir = join(home, '.claude');
-    const pluginsDir = join(claudeDir, 'plugins');
+    const userDataDir = join(homedir(), '.apijack');
 
     return {
-        claudeDir,
-        installedPluginsFile: join(pluginsDir, 'installed_plugins.json'),
-        settingsFile: join(claudeDir, 'settings.json'),
-        userDataDir: join(home, '.apijack'),
+        userDataDir,
+        marketplaceDir: join(userDataDir, 'plugin-marketplace'),
         sourceDir: resolve(import.meta.dir, '../..'),
     };
 }

--- a/src/plugin/register.ts
+++ b/src/plugin/register.ts
@@ -44,27 +44,20 @@ export function registerPluginCommand(
 
             const result = await installPlugin({
                 version,
-                claudeDir: paths.claudeDir,
                 userDataDir: paths.userDataDir,
+                marketplaceDir: paths.marketplaceDir,
                 sourceDir: paths.sourceDir,
                 cliInvocation,
                 generatedDir: opts.generatedDir ?? 'src/generated',
             });
 
             if (result.success) {
-                console.log(result.message);
-                console.log(`\n  Plugin dir:    ${result.marketplaceDir}`);
+                console.log(`\n${result.message}`);
+                console.log(`\n  Marketplace:   ${result.marketplaceDir}`);
+                console.log(`  Plugin dir:    ${result.pluginDir}`);
                 console.log(`  User data:     ${paths.userDataDir}`);
                 console.log(`  CLI invocation: ${cliInvocation.join(' ')}`);
-                console.log('\n── Next steps ──────────────────────────────────────');
-                console.log('1. In Claude Code, run:  /reload-plugins');
-                console.log('2. Then try a prompt like:');
-                console.log('');
-                console.log('   "Use /setup-api to connect apijack to my todo list');
-                console.log('    API at http://localhost:8080, then use /write-routine');
-                console.log('    to automate an e2e test: create 10 todos and then');
-                console.log('    delete them all."');
-                console.log('');
+                console.log('\nIn Claude Code, run /reload-plugins to activate.');
             }
         });
 
@@ -73,7 +66,7 @@ export function registerPluginCommand(
         .description('Remove Claude Code plugin registration')
         .action(async () => {
             const paths = getPluginPaths(version);
-            const result = await uninstallPlugin({ claudeDir: paths.claudeDir });
+            const result = await uninstallPlugin({ marketplaceDir: paths.marketplaceDir });
             console.log(result.message);
         });
 

--- a/src/plugin/uninstall.ts
+++ b/src/plugin/uninstall.ts
@@ -1,6 +1,7 @@
 import { existsSync, rmSync } from 'fs';
+import { type ClaudeRunner, runClaudeCli } from './claude-cli';
 
-export type ClaudeRunner = (args: string[]) => Promise<void>;
+export type { ClaudeRunner } from './claude-cli';
 
 export interface UninstallOptions {
     marketplaceDir: string;
@@ -11,34 +12,39 @@ export interface UninstallOptions {
 export interface UninstallResult {
     success: boolean;
     message: string;
+    warnings: string[];
 }
 
 export async function uninstallPlugin(opts: UninstallOptions): Promise<UninstallResult> {
     const { marketplaceDir } = opts;
-    const runClaude = opts.runClaude ?? defaultRunClaude;
+    const runClaude = opts.runClaude ?? runClaudeCli;
+    const warnings: string[] = [];
 
-    // Best-effort unregister via claude CLI — ignore failures so cleanup continues
-    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch(() => {});
-    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch(() => {});
+    // Unregister via claude CLI. Failures are surfaced as warnings so filesystem cleanup
+    // still runs even if the CLI is unavailable or the plugin is already gone.
+    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch((err) => {
+        warnings.push(`claude plugin uninstall apijack@apijack: ${formatError(err)}`);
+    });
+    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch((err) => {
+        warnings.push(`claude plugin marketplace remove apijack: ${formatError(err)}`);
+    });
 
     if (existsSync(marketplaceDir)) {
         rmSync(marketplaceDir, { recursive: true, force: true });
     }
 
+    const baseMessage = 'apijack plugin uninstalled. User data preserved at ~/.apijack/';
+    const message = warnings.length > 0
+        ? `${baseMessage}\nWarnings:\n  - ${warnings.join('\n  - ')}`
+        : baseMessage;
+
     return {
         success: true,
-        message: 'apijack plugin uninstalled. User data preserved at ~/.apijack/',
+        message,
+        warnings,
     };
 }
 
-async function defaultRunClaude(args: string[]): Promise<void> {
-    const proc = Bun.spawn(['claude', ...args], {
-        stdout: 'ignore',
-        stderr: 'ignore',
-    });
-    const exitCode = await proc.exited;
-
-    if (exitCode !== 0) {
-        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
-    }
+function formatError(err: unknown): string {
+    return err instanceof Error ? err.message : String(err);
 }

--- a/src/plugin/uninstall.ts
+++ b/src/plugin/uninstall.ts
@@ -1,8 +1,11 @@
-import { existsSync, readFileSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { existsSync, rmSync } from 'fs';
+
+export type ClaudeRunner = (args: string[]) => Promise<void>;
 
 export interface UninstallOptions {
-    claudeDir: string;
+    marketplaceDir: string;
+    /** Overridable for tests. Defaults to spawning the real `claude` CLI. */
+    runClaude?: ClaudeRunner;
 }
 
 export interface UninstallResult {
@@ -11,71 +14,31 @@ export interface UninstallResult {
 }
 
 export async function uninstallPlugin(opts: UninstallOptions): Promise<UninstallResult> {
-    const { claudeDir } = opts;
+    const { marketplaceDir } = opts;
+    const runClaude = opts.runClaude ?? defaultRunClaude;
 
-    // 1. Remove plugin directory from local marketplace
-    const pluginDir = join(claudeDir, 'plugins', 'marketplaces', 'local', 'apijack');
+    // Best-effort unregister via claude CLI — ignore failures so cleanup continues
+    await runClaude(['plugin', 'uninstall', 'apijack@apijack']).catch(() => {});
+    await runClaude(['plugin', 'marketplace', 'remove', 'apijack']).catch(() => {});
 
-    if (existsSync(pluginDir)) {
-        rmSync(pluginDir, { recursive: true, force: true });
+    if (existsSync(marketplaceDir)) {
+        rmSync(marketplaceDir, { recursive: true, force: true });
     }
-
-    // Remove legacy separate marketplace directory
-    const legacyMarketplaceDir = join(claudeDir, 'plugins', 'marketplaces', 'apijack');
-
-    if (existsSync(legacyMarketplaceDir)) {
-        rmSync(legacyMarketplaceDir, { recursive: true, force: true });
-    }
-
-    // 2. Remove apijack entry from local marketplace.json
-    const localMarketplacePath = join(claudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json');
-
-    if (existsSync(localMarketplacePath)) {
-        try {
-            const local = JSON.parse(readFileSync(localMarketplacePath, 'utf-8'));
-            local.plugins = (local.plugins || []).filter((p: { name: string }) => p.name !== 'apijack');
-            writeFileSync(localMarketplacePath, JSON.stringify(local, null, 2) + '\n');
-        } catch {}
-    }
-
-    // 3. Clean up registrations (current + legacy)
-    const installedPath = join(claudeDir, 'plugins', 'installed_plugins.json');
-
-    if (existsSync(installedPath)) {
-        try {
-            const installed = JSON.parse(readFileSync(installedPath, 'utf-8'));
-            delete installed.plugins['apijack@apijack'];
-            delete installed.plugins['apijack@local'];
-            writeFileSync(installedPath, JSON.stringify(installed, null, 2) + '\n');
-        } catch {}
-    }
-
-    const settingsPath = join(claudeDir, 'settings.json');
-
-    if (existsSync(settingsPath)) {
-        try {
-            const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-            if (settings.enabledPlugins) {
-                delete settings.enabledPlugins['apijack@apijack'];
-                delete settings.enabledPlugins['apijack@local'];
-            }
-
-            writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
-        } catch {}
-    }
-
-    // 4. Remove old plugin cache
-    const cacheDir = join(claudeDir, 'plugins', 'cache', 'local', 'apijack');
-
-    if (existsSync(cacheDir)) {
-        rmSync(cacheDir, { recursive: true, force: true });
-    }
-
-    // NOTE: User data at ~/.apijack/ is intentionally preserved
 
     return {
         success: true,
         message: 'apijack plugin uninstalled. User data preserved at ~/.apijack/',
     };
+}
+
+async function defaultRunClaude(args: string[]): Promise<void> {
+    const proc = Bun.spawn(['claude', ...args], {
+        stdout: 'ignore',
+        stderr: 'ignore',
+    });
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+        throw new Error(`claude ${args.join(' ')} exited ${exitCode}`);
+    }
 }

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -1,7 +1,15 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import type { AuthStrategy, SessionAuthConfig } from './auth/types';
-import type { CommandRegistrar, DispatcherHandler } from './types';
+import type { CommandRegistrar, DispatcherHandler, CustomResolver } from './types';
+
+const BUILTIN_RESOLVER_NAMES = new Set([
+    '_random_hex_color',
+    '_uuid',
+    '_random_int',
+    '_random_from',
+    '_random_distinct_from',
+]);
 
 export interface ProjectAuth {
     strategy: AuthStrategy | null;
@@ -84,4 +92,45 @@ export async function loadProjectDispatchers(
     }
 
     return dispatchers;
+}
+
+export async function loadProjectResolvers(
+    apijackDir: string,
+): Promise<Map<string, CustomResolver>> {
+    const resDir = join(apijackDir, 'resolvers');
+
+    if (!existsSync(resDir)) return new Map();
+
+    const resolvers = new Map<string, CustomResolver>();
+    const files = readdirSync(resDir).filter(f => f.endsWith('.ts'));
+
+    for (const file of files) {
+        try {
+            const mod = await import(join(resDir, file));
+            const name = mod.name ?? basename(file, '.ts');
+            const resolver = mod.default as CustomResolver;
+
+            if (typeof resolver !== 'function') continue;
+
+            if (typeof name !== 'string' || !name.startsWith('_')) {
+                process.stderr.write(
+                    `Warning: skipping resolver "${file}" — name "${name}" must start with "_" (e.g. "_my_fn")\n`,
+                );
+                continue;
+            }
+
+            if (BUILTIN_RESOLVER_NAMES.has(name)) {
+                process.stderr.write(
+                    `Warning: skipping resolver "${file}" — name "${name}" collides with a built-in\n`,
+                );
+                continue;
+            }
+
+            resolvers.set(name, resolver);
+        } catch {
+            // Skip files that fail to import
+        }
+    }
+
+    return resolvers;
 }

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -1,21 +1,29 @@
 import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
-import type { AuthStrategy } from './auth/types';
+import type { AuthStrategy, SessionAuthConfig } from './auth/types';
 import type { CommandRegistrar, DispatcherHandler } from './types';
+
+export interface ProjectAuth {
+    strategy: AuthStrategy | null;
+    onChallenge: SessionAuthConfig['onChallenge'] | null;
+}
 
 export async function loadProjectAuth(
     apijackDir: string,
-): Promise<AuthStrategy | null> {
+): Promise<ProjectAuth> {
     const authPath = join(apijackDir, 'auth.ts');
 
-    if (!existsSync(authPath)) return null;
+    if (!existsSync(authPath)) return { strategy: null, onChallenge: null };
 
     try {
         const mod = await import(authPath);
 
-        return (mod.default ?? mod) as AuthStrategy;
+        const strategy = (mod.default ?? null) as AuthStrategy | null;
+        const onChallenge = (mod.onChallenge ?? null) as SessionAuthConfig['onChallenge'] | null;
+
+        return { strategy, onChallenge };
     } catch {
-        return null;
+        return { strategy: null, onChallenge: null };
     }
 }
 

--- a/src/routine/condition.ts
+++ b/src/routine/condition.ts
@@ -1,5 +1,25 @@
 import type { RoutineContext } from './types';
-import { resolveRef } from './resolver';
+import { resolveRef, resolveValue } from './resolver';
+
+// LHS captures a $ref or a $_func(...) built-in call
+const LHS_PATTERN = '\\$[a-zA-Z_][a-zA-Z0-9_.\\-]*(?:\\([^)]*\\))?';
+
+function resolveLhs(lhs: string, ctx: RoutineContext): unknown {
+    return lhs.includes('(') ? resolveValue(lhs, ctx) : resolveRef(lhs.slice(1), ctx);
+}
+
+function resolveRhs(rhs: string, ctx: RoutineContext): { value: unknown; isUndefined: boolean } {
+    if (rhs === 'undefined') return { value: undefined, isUndefined: true };
+
+    if (rhs.startsWith('$')) return { value: resolveValue(rhs, ctx), isUndefined: false };
+
+    // Strip surrounding quotes on literal RHS (e.g., == "true")
+    if ((rhs.startsWith('"') && rhs.endsWith('"')) || (rhs.startsWith("'") && rhs.endsWith("'"))) {
+        return { value: rhs.slice(1, -1), isUndefined: false };
+    }
+
+    return { value: rhs, isUndefined: false };
+}
 
 export function evaluateCondition(expr: string | undefined, ctx: RoutineContext): boolean {
     if (expr === undefined || expr === null) return true;
@@ -8,26 +28,28 @@ export function evaluateCondition(expr: string | undefined, ctx: RoutineContext)
 
     if (expr === 'false') return false;
 
-    // Equality: $ref == value (RHS can also be a $ref)
-    const eqMatch = expr.match(/^(\$[a-zA-Z_][a-zA-Z0-9_.\-]*)\s*==\s*(.+)$/);
+    // Equality: <lhs> == value (RHS can also be a $ref or "undefined")
+    const eqMatch = expr.match(new RegExp(`^(${LHS_PATTERN})\\s*==\\s*(.+)$`));
 
     if (eqMatch) {
-        const resolved = resolveRef(eqMatch[1]!.slice(1), ctx);
-        const rhs = eqMatch[2]!.trim();
-        const rhsValue = rhs.startsWith('$') ? String(resolveRef(rhs.slice(1), ctx)) : rhs;
+        const resolved = resolveLhs(eqMatch[1]!, ctx);
+        const rhs = resolveRhs(eqMatch[2]!.trim(), ctx);
 
-        return String(resolved) === rhsValue;
+        if (rhs.isUndefined) return resolved === undefined;
+
+        return String(resolved) === String(rhs.value);
     }
 
-    // Inequality: $ref != value (RHS can also be a $ref)
-    const neqMatch = expr.match(/^(\$[a-zA-Z_][a-zA-Z0-9_.\-]*)\s*!=\s*(.+)$/);
+    // Inequality: <lhs> != value (RHS can also be a $ref or "undefined")
+    const neqMatch = expr.match(new RegExp(`^(${LHS_PATTERN})\\s*!=\\s*(.+)$`));
 
     if (neqMatch) {
-        const resolved = resolveRef(neqMatch[1]!.slice(1), ctx);
-        const rhs = neqMatch[2]!.trim();
-        const rhsValue = rhs.startsWith('$') ? String(resolveRef(rhs.slice(1), ctx)) : rhs;
+        const resolved = resolveLhs(neqMatch[1]!, ctx);
+        const rhs = resolveRhs(neqMatch[2]!.trim(), ctx);
 
-        return String(resolved) !== rhsValue;
+        if (rhs.isUndefined) return resolved !== undefined;
+
+        return String(resolved) !== String(rhs.value);
     }
 
     // Truthy check: $ref

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -1,4 +1,4 @@
-import type { CliContext, DispatcherHandler, CommandDispatcher } from '../types';
+import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../types';
 import { loadRoutineFile, validateRoutine } from './loader';
 import { executeRoutine } from './executor';
 
@@ -12,6 +12,7 @@ export interface DispatcherConfig {
     }>;
     client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
+    customResolvers?: Map<string, CustomResolver>;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     ctx: CliContext;
     routinesDir: string;
@@ -175,7 +176,9 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                 if (k.startsWith('--set-')) subOverrides[k.slice(6)] = v;
             }
 
-            const result = await _execute(subDef, subOverrides, dispatch);
+            const result = await _execute(subDef, subOverrides, dispatch, {
+                customResolvers: config.customResolvers,
+            });
 
             if (!result.success) throw new Error(`Sub-routine "${routineName}" failed`);
 

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -3,7 +3,13 @@ import { loadRoutineFile, validateRoutine } from './loader';
 import { executeRoutine } from './executor';
 
 export interface DispatcherConfig {
-    commandMap?: Record<string, { operationId: string; pathParams: string[]; queryParams: string[]; hasBody: boolean }>;
+    commandMap?: Record<string, {
+        operationId: string;
+        pathParams: string[];
+        queryParams: string[];
+        hasBody: boolean;
+        bodyFields?: Array<{ name: string; type: string; required: boolean; description?: string }>;
+    }>;
     client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
@@ -52,19 +58,18 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
             // Body from args
             if (mapping.hasBody) {
                 const body: Record<string, unknown> = {};
+                const bodyFieldNames = new Set(mapping.bodyFields?.map(f => f.name) ?? []);
 
                 for (const [key, val] of Object.entries(args)) {
                     if (key.startsWith('--')) {
-                        // Skip path params and query params — they're handled separately
-                        const isPathParam = mapping.pathParams.some(
-                            (p: string) => `--${p}` === key,
-                        );
-                        const isQueryParam = mapping.queryParams.some(
-                            (p: string) => `--${p}` === key,
-                        );
+                        const propName = key.slice(2);
+                        const isBodyField = bodyFieldNames.has(propName);
+                        // A field that's declared as a body field stays in the body
+                        // even if its name collides with a path or query param.
+                        const isPathParam = mapping.pathParams.includes(propName);
+                        const isQueryParam = mapping.queryParams.includes(propName);
 
-                        if (!isPathParam && !isQueryParam) {
-                            const propName = key.slice(2);
+                        if (isBodyField || (!isPathParam && !isQueryParam)) {
                             body[propName] = val;
                         }
                     }

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -12,7 +12,7 @@ import {
     shuffle,
 } from './resolver';
 import { evaluateCondition } from './condition';
-import type { CommandDispatcher } from '../types';
+import type { CommandDispatcher, CustomResolver } from '../types';
 
 export interface RoutineResult {
     success: boolean;
@@ -24,6 +24,7 @@ export interface RoutineResult {
 
 interface ExecutorOptions {
     dryRun?: boolean;
+    customResolvers?: Map<string, CustomResolver>;
     onStep?: (step: RoutineStep, index: number, total: number) => void;
     onIteration?: (
         step: RoutineStep,
@@ -71,6 +72,7 @@ class RoutineExecutor {
         const ctx: RoutineContext = {
             variables: rawVars,
             stepOutputs: new Map(),
+            customResolvers: this.options?.customResolvers,
         };
 
         const ok = await this.runSteps(routine.steps, ctx);

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -83,6 +83,7 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
             const value = process.env[varName];
 
             if (value !== undefined) return value;
+
             if (defaultVal !== undefined) return defaultVal;
 
             process.stderr.write(`Warning: env var ${varName} is not set\n`);

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -4,7 +4,7 @@ const REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*
 // No-arg built-in functions (match without parentheses)
 const NOARG_FUNC_PATTERN = /\$(_random_hex_color|_uuid)/g;
 // Parameterized built-in functions (require parentheses)
-const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)/g;
+const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)/g;
 
 // ── Built-in functions ─────────────────────────────────────────────
 
@@ -27,7 +27,7 @@ export function resetDistinctPools(): void {
     distinctPools.clear();
 }
 
-function evalBuiltinFunc(name: string, argsStr?: string): unknown {
+function evalBuiltinFunc(name: string, argsStr?: string, ctx?: RoutineContext): unknown {
     switch (name) {
         case '_random_hex_color': {
             const hex = Math.floor(Math.random() * 0xFFFFFF).toString(16).padStart(6, '0');
@@ -90,9 +90,45 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
 
             return '';
         }
+        case '_find': {
+            if (!argsStr || !ctx) return undefined;
+
+            const parts = argsStr.split(',').map(s => s.trim());
+
+            if (parts.length < 3) {
+                process.stderr.write(`Warning: $_find requires (array, field, value), got (${argsStr})\n`);
+
+                return undefined;
+            }
+
+            const arr = resolveValue(parts[0]!, ctx);
+            const field = stripQuotes(parts[1]!);
+            const value = resolveValue(parts.slice(2).join(',').trim(), ctx);
+
+            if (!Array.isArray(arr)) return undefined;
+
+            return arr.find(el =>
+                el != null
+                && typeof el === 'object'
+                && String((el as Record<string, unknown>)[field]) === String(value),
+            );
+        }
+        case '_contains': {
+            const found = evalBuiltinFunc('_find', argsStr, ctx);
+
+            return found !== undefined ? 'true' : 'false';
+        }
         default:
             return undefined;
     }
+}
+
+function stripQuotes(s: string): string {
+    if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+        return s.slice(1, -1);
+    }
+
+    return s;
 }
 
 function getByDotPath(obj: unknown, path: string[]): unknown {
@@ -147,14 +183,14 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
     const funcExact = value.match(/^\$(_random_hex_color|_uuid)$/);
 
     if (funcExact) {
-        return evalBuiltinFunc(funcExact[1]!);
+        return evalBuiltinFunc(funcExact[1]!, undefined, ctx);
     }
 
     // Exact match: built-in function with args
-    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)$/);
+    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)$/);
 
     if (funcCall) {
-        return evalBuiltinFunc(funcCall[1]!, funcCall[2]);
+        return evalBuiltinFunc(funcCall[1]!, funcCall[2], ctx);
     }
 
     // Exact match: entire value is a single $ref — resolve to native type
@@ -171,13 +207,13 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
 export function resolveString(str: string, ctx: RoutineContext): string {
     // First resolve parameterized built-in functions (require parens)
     let result = str.replace(PARAM_FUNC_PATTERN, (_match, name: string, argsStr: string) => {
-        const resolved = evalBuiltinFunc(name, argsStr);
+        const resolved = evalBuiltinFunc(name, argsStr, ctx);
 
         return resolved !== undefined ? String(resolved) : _match;
     });
     // Then no-arg built-in functions
     result = result.replace(NOARG_FUNC_PATTERN, (_match, name: string) => {
-        const resolved = evalBuiltinFunc(name);
+        const resolved = evalBuiltinFunc(name, undefined, ctx);
 
         return resolved !== undefined ? String(resolved) : _match;
     });

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -1,10 +1,13 @@
 import type { RoutineContext } from './types';
 
 const REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*)*)/g;
-// No-arg built-in functions (match without parentheses)
-const NOARG_FUNC_PATTERN = /\$(_random_hex_color|_uuid)/g;
-// Parameterized built-in functions (require parentheses)
-const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)/g;
+// Parameterized built-in / custom functions (require parentheses). Run first in resolveString.
+const PARAM_FUNC_PATTERN = /\$(_[a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)/g;
+// No-arg built-in / custom functions. Run after PARAM_FUNC_PATTERN so only unparenned names remain.
+const NOARG_FUNC_PATTERN = /\$(_[a-zA-Z_][a-zA-Z0-9_]*)/g;
+// Exact-match equivalents for single-value resolution (resolveValue)
+const EXACT_PARAM_FUNC_PATTERN = /^\$(_[a-zA-Z_][a-zA-Z0-9_]*)\(([^)]*)\)$/;
+const EXACT_NOARG_FUNC_PATTERN = /^\$(_[a-zA-Z_][a-zA-Z0-9_]*)$/;
 
 // ── Built-in functions ─────────────────────────────────────────────
 
@@ -118,8 +121,13 @@ function evalBuiltinFunc(name: string, argsStr?: string, ctx?: RoutineContext): 
 
             return found !== undefined ? 'true' : 'false';
         }
-        default:
+        default: {
+            const custom = ctx?.customResolvers?.get(name);
+
+            if (custom) return custom(argsStr);
+
             return undefined;
+        }
     }
 }
 
@@ -179,18 +187,21 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
 
     if (!value.includes('$')) return value;
 
-    // Exact match: built-in function (no args)
-    const funcExact = value.match(/^\$(_random_hex_color|_uuid)$/);
-
-    if (funcExact) {
-        return evalBuiltinFunc(funcExact[1]!, undefined, ctx);
-    }
-
-    // Exact match: built-in function with args
-    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env|_find|_contains)\(([^)]*)\)$/);
+    // Exact match: function call with args (check before no-arg so foo() isn't captured as no-arg)
+    const funcCall = value.match(EXACT_PARAM_FUNC_PATTERN);
 
     if (funcCall) {
         return evalBuiltinFunc(funcCall[1]!, funcCall[2], ctx);
+    }
+
+    // Exact match: function without args. Only dispatch to evalBuiltinFunc if it actually
+    // resolves — otherwise fall through to ref resolution (so e.g. `$_timestamp` variables work).
+    const funcExact = value.match(EXACT_NOARG_FUNC_PATTERN);
+
+    if (funcExact) {
+        const result = evalBuiltinFunc(funcExact[1]!, undefined, ctx);
+
+        if (result !== undefined) return result;
     }
 
     // Exact match: entire value is a single $ref — resolve to native type

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -122,11 +122,13 @@ function evalBuiltinFunc(name: string, argsStr?: string, ctx?: RoutineContext): 
             return found !== undefined ? 'true' : 'false';
         }
         default: {
-            const custom = ctx?.customResolvers?.get(name);
+            if (!ctx) return undefined;
 
-            if (custom) return custom(argsStr);
+            const custom = ctx.customResolvers?.get(name);
 
-            return undefined;
+            if (!custom) return undefined;
+
+            return custom(argsStr, { resolve: v => resolveValue(v, ctx) });
         }
     }
 }

--- a/src/routine/resolver.ts
+++ b/src/routine/resolver.ts
@@ -4,7 +4,7 @@ const REF_PATTERN = /\$([a-zA-Z_][a-zA-Z0-9_\-]*(?:\.[a-zA-Z0-9_][a-zA-Z0-9_\-]*
 // No-arg built-in functions (match without parentheses)
 const NOARG_FUNC_PATTERN = /\$(_random_hex_color|_uuid)/g;
 // Parameterized built-in functions (require parentheses)
-const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from)\(([^)]*)\)/g;
+const PARAM_FUNC_PATTERN = /\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)/g;
 
 // ── Built-in functions ─────────────────────────────────────────────
 
@@ -73,6 +73,22 @@ function evalBuiltinFunc(name: string, argsStr?: string): unknown {
 
             return pool.pop()!;
         }
+        case '_env': {
+            if (!argsStr) return '';
+
+            const firstComma = argsStr.indexOf(',');
+            const varName = (firstComma === -1 ? argsStr : argsStr.slice(0, firstComma)).trim();
+            const defaultVal = firstComma === -1 ? undefined : argsStr.slice(firstComma + 1).trim();
+
+            const value = process.env[varName];
+
+            if (value !== undefined) return value;
+            if (defaultVal !== undefined) return defaultVal;
+
+            process.stderr.write(`Warning: env var ${varName} is not set\n`);
+
+            return '';
+        }
         default:
             return undefined;
     }
@@ -134,7 +150,7 @@ export function resolveValue(value: unknown, ctx: RoutineContext): unknown {
     }
 
     // Exact match: built-in function with args
-    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from)\(([^)]*)\)$/);
+    const funcCall = value.match(/^\$(_random_int|_random_from|_random_distinct_from|_env)\(([^)]*)\)$/);
 
     if (funcCall) {
         return evalBuiltinFunc(funcCall[1]!, funcCall[2]);

--- a/src/routine/types.ts
+++ b/src/routine/types.ts
@@ -29,8 +29,11 @@ export interface StepResult {
     error?: string;
 }
 
+import type { CustomResolver } from '../types';
+
 export interface RoutineContext {
     variables: Record<string, unknown>;
     stepOutputs: Map<string, StepResult>;
     forEachItem?: { name: string; value: unknown };
+    customResolvers?: Map<string, CustomResolver>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,12 @@ export type DispatcherHandler = (
     ctx: CliContext,
 ) => Promise<unknown>;
 
-export type CustomResolver = (argsStr?: string) => unknown;
+export interface CustomResolverHelpers {
+    /** Resolve `$refs` and built-in functions inside a string against the current routine context. */
+    resolve: (value: string) => unknown;
+}
+
+export type CustomResolver = (argsStr?: string, helpers?: CustomResolverHelpers) => unknown;
 
 export type CommandDispatcher = (
     command: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,8 @@ export type DispatcherHandler = (
     ctx: CliContext,
 ) => Promise<unknown>;
 
+export type CustomResolver = (argsStr?: string) => unknown;
+
 export type CommandDispatcher = (
     command: string,
     args: Record<string, unknown>,

--- a/tests/auth/api-key.test.ts
+++ b/tests/auth/api-key.test.ts
@@ -1,37 +1,37 @@
-import { describe, test, expect } from "bun:test";
-import { ApiKeyStrategy } from "../../src/auth/api-key";
-import type { ResolvedAuth, AuthSession } from "../../src/auth/types";
+import { describe, test, expect } from 'bun:test';
+import { ApiKeyStrategy } from '../../src/auth/api-key';
+import type { ResolvedAuth, AuthSession } from '../../src/auth/types';
 
-describe("ApiKeyStrategy", () => {
-  const config: ResolvedAuth = {
-    baseUrl: "https://api.example.com",
-    username: "admin",
-    password: "secret",
-  };
-
-  test("constructor takes header name and key value", () => {
-    const strategy = new ApiKeyStrategy("X-API-Key", "my-secret-key");
-    expect(strategy).toBeDefined();
-  });
-
-  test("authenticate() returns session with the specified header", async () => {
-    const strategy = new ApiKeyStrategy("X-API-Key", "my-secret-key");
-    const session = await strategy.authenticate(config);
-    expect(session.headers["X-API-Key"]).toBe("my-secret-key");
-  });
-
-  test("authenticate() works with custom header names", async () => {
-    const strategy = new ApiKeyStrategy("Authorization", "ApiKey sk-12345");
-    const session = await strategy.authenticate(config);
-    expect(session.headers.Authorization).toBe("ApiKey sk-12345");
-  });
-
-  test("restore() always returns the cached session (stateless)", async () => {
-    const strategy = new ApiKeyStrategy("X-API-Key", "my-secret-key");
-    const cached: AuthSession = {
-      headers: { "X-API-Key": "my-secret-key" },
+describe('ApiKeyStrategy', () => {
+    const config: ResolvedAuth = {
+        baseUrl: 'https://api.example.com',
+        username: 'admin',
+        password: 'secret',
     };
-    const result = await strategy.restore(cached, config);
-    expect(result).toBe(cached);
-  });
+
+    test('constructor takes header name and key value', () => {
+        const strategy = new ApiKeyStrategy('X-API-Key', 'my-secret-key');
+        expect(strategy).toBeDefined();
+    });
+
+    test('authenticate() returns session with the specified header', async () => {
+        const strategy = new ApiKeyStrategy('X-API-Key', 'my-secret-key');
+        const session = await strategy.authenticate(config);
+        expect(session.headers['X-API-Key']).toBe('my-secret-key');
+    });
+
+    test('authenticate() works with custom header names', async () => {
+        const strategy = new ApiKeyStrategy('Authorization', 'ApiKey sk-12345');
+        const session = await strategy.authenticate(config);
+        expect(session.headers.Authorization).toBe('ApiKey sk-12345');
+    });
+
+    test('restore() always returns the cached session (stateless)', async () => {
+        const strategy = new ApiKeyStrategy('X-API-Key', 'my-secret-key');
+        const cached: AuthSession = {
+            headers: { 'X-API-Key': 'my-secret-key' },
+        };
+        const result = await strategy.restore(cached, config);
+        expect(result).toBe(cached);
+    });
 });

--- a/tests/auth/basic.test.ts
+++ b/tests/auth/basic.test.ts
@@ -1,32 +1,32 @@
-import { describe, test, expect } from "bun:test";
-import { BasicAuthStrategy } from "../../src/auth/basic";
-import type { ResolvedAuth, AuthSession } from "../../src/auth/types";
+import { describe, test, expect } from 'bun:test';
+import { BasicAuthStrategy } from '../../src/auth/basic';
+import type { ResolvedAuth, AuthSession } from '../../src/auth/types';
 
-describe("BasicAuthStrategy", () => {
-  const config: ResolvedAuth = {
-    baseUrl: "https://api.example.com",
-    username: "admin",
-    password: "secret",
-  };
-
-  const strategy = new BasicAuthStrategy();
-
-  test("authenticate() returns session with Authorization Basic header", async () => {
-    const session = await strategy.authenticate(config);
-    const expected = "Basic " + btoa("admin:secret");
-    expect(session.headers.Authorization).toBe(expected);
-  });
-
-  test("authenticate() does not set expiresAt", async () => {
-    const session = await strategy.authenticate(config);
-    expect(session.expiresAt).toBeUndefined();
-  });
-
-  test("restore() always returns the cached session (stateless)", async () => {
-    const cached: AuthSession = {
-      headers: { Authorization: "Basic dGVzdDp0ZXN0" },
+describe('BasicAuthStrategy', () => {
+    const config: ResolvedAuth = {
+        baseUrl: 'https://api.example.com',
+        username: 'admin',
+        password: 'secret',
     };
-    const result = await strategy.restore(cached, config);
-    expect(result).toBe(cached);
-  });
+
+    const strategy = new BasicAuthStrategy();
+
+    test('authenticate() returns session with Authorization Basic header', async () => {
+        const session = await strategy.authenticate(config);
+        const expected = 'Basic ' + btoa('admin:secret');
+        expect(session.headers.Authorization).toBe(expected);
+    });
+
+    test('authenticate() does not set expiresAt', async () => {
+        const session = await strategy.authenticate(config);
+        expect(session.expiresAt).toBeUndefined();
+    });
+
+    test('restore() always returns the cached session (stateless)', async () => {
+        const cached: AuthSession = {
+            headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
+        };
+        const result = await strategy.restore(cached, config);
+        expect(result).toBe(cached);
+    });
 });

--- a/tests/auth/bearer.test.ts
+++ b/tests/auth/bearer.test.ts
@@ -1,77 +1,78 @@
-import { describe, test, expect, mock } from "bun:test";
-import { BearerTokenStrategy } from "../../src/auth/bearer";
-import type { ResolvedAuth, AuthSession } from "../../src/auth/types";
+import { describe, test, expect, mock } from 'bun:test';
+import { BearerTokenStrategy } from '../../src/auth/bearer';
+import type { ResolvedAuth, AuthSession } from '../../src/auth/types';
 
-describe("BearerTokenStrategy", () => {
-  const config: ResolvedAuth = {
-    baseUrl: "https://api.example.com",
-    username: "admin",
-    password: "secret",
-  };
+describe('BearerTokenStrategy', () => {
+    const config: ResolvedAuth = {
+        baseUrl: 'https://api.example.com',
+        username: 'admin',
+        password: 'secret',
+    };
 
-  test("constructor takes a getToken function", () => {
-    const getToken = mock(async () => "tok_abc123");
-    const strategy = new BearerTokenStrategy(getToken);
-    expect(strategy).toBeDefined();
-  });
-
-  test("authenticate() calls getToken() and returns Bearer header", async () => {
-    const getToken = mock(async () => "tok_abc123");
-    const strategy = new BearerTokenStrategy(getToken);
-
-    const session = await strategy.authenticate(config);
-    expect(getToken).toHaveBeenCalledWith(config);
-    expect(session.headers.Authorization).toBe("Bearer tok_abc123");
-  });
-
-  test("refresh() calls getToken() again and returns new session", async () => {
-    let callCount = 0;
-    const getToken = mock(async () => {
-      callCount++;
-      return `tok_${callCount}`;
+    test('constructor takes a getToken function', () => {
+        const getToken = mock(async () => 'tok_abc123');
+        const strategy = new BearerTokenStrategy(getToken);
+        expect(strategy).toBeDefined();
     });
-    const strategy = new BearerTokenStrategy(getToken);
 
-    const session1 = await strategy.authenticate(config);
-    expect(session1.headers.Authorization).toBe("Bearer tok_1");
+    test('authenticate() calls getToken() and returns Bearer header', async () => {
+        const getToken = mock(async () => 'tok_abc123');
+        const strategy = new BearerTokenStrategy(getToken);
 
-    const session2 = await strategy.refresh!(session1, config);
-    expect(session2.headers.Authorization).toBe("Bearer tok_2");
-    expect(getToken).toHaveBeenCalledTimes(2);
-  });
+        const session = await strategy.authenticate(config);
+        expect(getToken).toHaveBeenCalledWith(config);
+        expect(session.headers.Authorization).toBe('Bearer tok_abc123');
+    });
 
-  test("restore() returns cached session if not expired", async () => {
-    const getToken = mock(async () => "tok_abc123");
-    const strategy = new BearerTokenStrategy(getToken);
+    test('refresh() calls getToken() again and returns new session', async () => {
+        let callCount = 0;
+        const getToken = mock(async () => {
+            callCount++;
 
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer tok_abc123" },
-      expiresAt: Date.now() + 60_000, // 1 minute in the future
-    };
-    const result = await strategy.restore(cached, config);
-    expect(result).toBe(cached);
-  });
+            return `tok_${callCount}`;
+        });
+        const strategy = new BearerTokenStrategy(getToken);
 
-  test("restore() returns null if session is expired", async () => {
-    const getToken = mock(async () => "tok_abc123");
-    const strategy = new BearerTokenStrategy(getToken);
+        const session1 = await strategy.authenticate(config);
+        expect(session1.headers.Authorization).toBe('Bearer tok_1');
 
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer tok_abc123" },
-      expiresAt: Date.now() - 1000, // 1 second in the past
-    };
-    const result = await strategy.restore(cached, config);
-    expect(result).toBeNull();
-  });
+        const session2 = await strategy.refresh!(session1, config);
+        expect(session2.headers.Authorization).toBe('Bearer tok_2');
+        expect(getToken).toHaveBeenCalledTimes(2);
+    });
 
-  test("restore() returns cached session if no expiresAt set", async () => {
-    const getToken = mock(async () => "tok_abc123");
-    const strategy = new BearerTokenStrategy(getToken);
+    test('restore() returns cached session if not expired', async () => {
+        const getToken = mock(async () => 'tok_abc123');
+        const strategy = new BearerTokenStrategy(getToken);
 
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer tok_abc123" },
-    };
-    const result = await strategy.restore(cached, config);
-    expect(result).toBe(cached);
-  });
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer tok_abc123' },
+            expiresAt: Date.now() + 60_000, // 1 minute in the future
+        };
+        const result = await strategy.restore(cached, config);
+        expect(result).toBe(cached);
+    });
+
+    test('restore() returns null if session is expired', async () => {
+        const getToken = mock(async () => 'tok_abc123');
+        const strategy = new BearerTokenStrategy(getToken);
+
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer tok_abc123' },
+            expiresAt: Date.now() - 1000, // 1 second in the past
+        };
+        const result = await strategy.restore(cached, config);
+        expect(result).toBeNull();
+    });
+
+    test('restore() returns cached session if no expiresAt set', async () => {
+        const getToken = mock(async () => 'tok_abc123');
+        const strategy = new BearerTokenStrategy(getToken);
+
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer tok_abc123' },
+        };
+        const result = await strategy.restore(cached, config);
+        expect(result).toBe(cached);
+    });
 });

--- a/tests/auth/config-merge.test.ts
+++ b/tests/auth/config-merge.test.ts
@@ -1,72 +1,72 @@
-import { describe, test, expect } from "bun:test";
-import { deepMergeSessionAuth } from "../../src/auth/config-merge";
-import type { SessionAuthConfig } from "../../src/auth/types";
+import { describe, test, expect } from 'bun:test';
+import { deepMergeSessionAuth } from '../../src/auth/config-merge';
+import type { SessionAuthConfig } from '../../src/auth/types';
 
 const base: SessionAuthConfig = {
-  session: { endpoint: "/session", method: "GET" },
-  cookies: {
-    extract: ["SESSION", "XSRF-TOKEN"],
-    applyTo: ["POST", "PUT", "DELETE", "PATCH"],
-  },
-  headerMirror: [
-    { fromCookie: "XSRF-TOKEN", toHeader: "X-XSRF-TOKEN" },
-  ],
-  refreshOn: [401, 403],
+    session: { endpoint: '/session', method: 'GET' },
+    cookies: {
+        extract: ['SESSION', 'XSRF-TOKEN'],
+        applyTo: ['POST', 'PUT', 'DELETE', 'PATCH'],
+    },
+    headerMirror: [
+        { fromCookie: 'XSRF-TOKEN', toHeader: 'X-XSRF-TOKEN' },
+    ],
+    refreshOn: [401, 403],
 };
 
-describe("deepMergeSessionAuth", () => {
-  test("returns base when override is undefined", () => {
-    const result = deepMergeSessionAuth(base, undefined);
-    expect(result).toEqual(base);
-  });
+describe('deepMergeSessionAuth', () => {
+    test('returns base when override is undefined', () => {
+        const result = deepMergeSessionAuth(base, undefined);
+        expect(result).toEqual(base);
+    });
 
-  test("returns base when override is null-ish", () => {
-    const result = deepMergeSessionAuth(base, undefined);
-    expect(result.session.endpoint).toBe("/session");
-  });
+    test('returns base when override is null-ish', () => {
+        const result = deepMergeSessionAuth(base, undefined);
+        expect(result.session.endpoint).toBe('/session');
+    });
 
-  test("overrides scalar fields", () => {
-    const override = { session: { endpoint: "/auth/session" } };
-    const result = deepMergeSessionAuth(base, override);
-    expect(result.session.endpoint).toBe("/auth/session");
-    expect(result.session.method).toBe("GET");
-  });
+    test('overrides scalar fields', () => {
+        const override = { session: { endpoint: '/auth/session' } };
+        const result = deepMergeSessionAuth(base, override);
+        expect(result.session.endpoint).toBe('/auth/session');
+        expect(result.session.method).toBe('GET');
+    });
 
-  test("replaces arrays entirely (does not concat)", () => {
-    const override = { cookies: { applyTo: ["*"] } };
-    const result = deepMergeSessionAuth(base, override);
-    expect(result.cookies.applyTo).toEqual(["*"]);
-    expect(result.cookies.extract).toEqual(["SESSION", "XSRF-TOKEN"]);
-  });
+    test('replaces arrays entirely (does not concat)', () => {
+        const override = { cookies: { applyTo: ['*'] } };
+        const result = deepMergeSessionAuth(base, override);
+        expect(result.cookies.applyTo).toEqual(['*']);
+        expect(result.cookies.extract).toEqual(['SESSION', 'XSRF-TOKEN']);
+    });
 
-  test("overrides refreshOn array", () => {
-    const override = { refreshOn: [401] };
-    const result = deepMergeSessionAuth(base, override);
-    expect(result.refreshOn).toEqual([401]);
-  });
+    test('overrides refreshOn array', () => {
+        const override = { refreshOn: [401] };
+        const result = deepMergeSessionAuth(base, override);
+        expect(result.refreshOn).toEqual([401]);
+    });
 
-  test("overrides headerMirror array", () => {
-    const override = {
-      headerMirror: [
-        { fromCookie: "CSRF", toHeader: "X-CSRF" },
-      ],
-    };
-    const result = deepMergeSessionAuth(base, override);
-    expect(result.headerMirror).toEqual([
-      { fromCookie: "CSRF", toHeader: "X-CSRF" },
-    ]);
-  });
+    test('overrides headerMirror array', () => {
+        const override = {
+            headerMirror: [
+                { fromCookie: 'CSRF', toHeader: 'X-CSRF' },
+            ],
+        };
+        const result = deepMergeSessionAuth(base, override);
+        expect(result.headerMirror).toEqual([
+            { fromCookie: 'CSRF', toHeader: 'X-CSRF' },
+        ]);
+    });
 
-  test("does not mutate base config", () => {
-    const baseCopy = JSON.parse(JSON.stringify(base));
-    deepMergeSessionAuth(base, { cookies: { applyTo: ["*"] } });
-    expect(base).toEqual(baseCopy);
-  });
+    test('does not mutate base config', () => {
+        const baseCopy = JSON.parse(JSON.stringify(base));
+        deepMergeSessionAuth(base, { cookies: { applyTo: ['*'] } });
+        expect(base).toEqual(baseCopy);
+    });
 
-  test("deeply merges nested objects", () => {
-    const override = { cookies: { extract: ["TOKEN"] } };
-    const result = deepMergeSessionAuth(base, override);
-    expect(result.cookies.extract).toEqual(["TOKEN"]);
-    expect(result.cookies.applyTo).toEqual(["POST", "PUT", "DELETE", "PATCH"]);
-  });
+    test('deeply merges nested objects', () => {
+        const override = { cookies: { extract: ['TOKEN'] } };
+        const result = deepMergeSessionAuth(base, override);
+        expect(result.cookies.extract).toEqual(['TOKEN']);
+        expect(result.cookies.applyTo).toEqual(['POST', 'PUT', 'DELETE', 'PATCH']);
+    });
 });

--- a/tests/auth/resolve-headers.test.ts
+++ b/tests/auth/resolve-headers.test.ts
@@ -1,131 +1,131 @@
-import { describe, test, expect } from "bun:test";
-import { resolveRequestHeaders } from "../../src/auth/resolve-headers";
-import type { AuthSession, SessionAuthConfig } from "../../src/auth/types";
+import { describe, test, expect } from 'bun:test';
+import { resolveRequestHeaders } from '../../src/auth/resolve-headers';
+import type { AuthSession, SessionAuthConfig } from '../../src/auth/types';
 
 const baseSession: AuthSession = {
-  headers: { Authorization: "Basic dGVzdDp0ZXN0" },
+    headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
 };
 
 const sessionWithCookies: AuthSession = {
-  headers: { Authorization: "Basic dGVzdDp0ZXN0" },
-  cookies: { SESSION: "abc123", "XSRF-TOKEN": "xyz789" },
+    headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
+    cookies: { 'SESSION': 'abc123', 'XSRF-TOKEN': 'xyz789' },
 };
 
 const config: SessionAuthConfig = {
-  session: { endpoint: "/session" },
-  cookies: {
-    extract: ["SESSION", "XSRF-TOKEN"],
-    applyTo: ["POST", "PUT", "DELETE", "PATCH"],
-  },
-  headerMirror: [
-    { fromCookie: "XSRF-TOKEN", toHeader: "X-XSRF-TOKEN" },
-  ],
-  refreshOn: [401, 403],
+    session: { endpoint: '/session' },
+    cookies: {
+        extract: ['SESSION', 'XSRF-TOKEN'],
+        applyTo: ['POST', 'PUT', 'DELETE', 'PATCH'],
+    },
+    headerMirror: [
+        { fromCookie: 'XSRF-TOKEN', toHeader: 'X-XSRF-TOKEN' },
+    ],
+    refreshOn: [401, 403],
 };
 
-describe("resolveRequestHeaders", () => {
-  test("returns only base headers when no config", () => {
-    const result = resolveRequestHeaders(baseSession, undefined, "GET");
-    expect(result).toEqual({ Authorization: "Basic dGVzdDp0ZXN0" });
-  });
+describe('resolveRequestHeaders', () => {
+    test('returns only base headers when no config', () => {
+        const result = resolveRequestHeaders(baseSession, undefined, 'GET');
+        expect(result).toEqual({ Authorization: 'Basic dGVzdDp0ZXN0' });
+    });
 
-  test("returns only base headers when session has no cookies", () => {
-    const result = resolveRequestHeaders(baseSession, config, "POST");
-    expect(result).toEqual({ Authorization: "Basic dGVzdDp0ZXN0" });
-  });
+    test('returns only base headers when session has no cookies', () => {
+        const result = resolveRequestHeaders(baseSession, config, 'POST');
+        expect(result).toEqual({ Authorization: 'Basic dGVzdDp0ZXN0' });
+    });
 
-  test("returns only base headers for GET (not in applyTo)", () => {
-    const result = resolveRequestHeaders(sessionWithCookies, config, "GET");
-    expect(result).toEqual({ Authorization: "Basic dGVzdDp0ZXN0" });
-    expect(result.Cookie).toBeUndefined();
-    expect(result["X-XSRF-TOKEN"]).toBeUndefined();
-  });
+    test('returns only base headers for GET (not in applyTo)', () => {
+        const result = resolveRequestHeaders(sessionWithCookies, config, 'GET');
+        expect(result).toEqual({ Authorization: 'Basic dGVzdDp0ZXN0' });
+        expect(result.Cookie).toBeUndefined();
+        expect(result['X-XSRF-TOKEN']).toBeUndefined();
+    });
 
-  test("assembles Cookie header and mirrors for POST", () => {
-    const result = resolveRequestHeaders(sessionWithCookies, config, "POST");
-    expect(result.Authorization).toBe("Basic dGVzdDp0ZXN0");
-    expect(result.Cookie).toBe("SESSION=abc123; XSRF-TOKEN=xyz789");
-    expect(result["X-XSRF-TOKEN"]).toBe("xyz789");
-  });
+    test('assembles Cookie header and mirrors for POST', () => {
+        const result = resolveRequestHeaders(sessionWithCookies, config, 'POST');
+        expect(result.Authorization).toBe('Basic dGVzdDp0ZXN0');
+        expect(result.Cookie).toBe('SESSION=abc123; XSRF-TOKEN=xyz789');
+        expect(result['X-XSRF-TOKEN']).toBe('xyz789');
+    });
 
-  test("assembles Cookie header and mirrors for DELETE", () => {
-    const result = resolveRequestHeaders(sessionWithCookies, config, "DELETE");
-    expect(result.Cookie).toBe("SESSION=abc123; XSRF-TOKEN=xyz789");
-    expect(result["X-XSRF-TOKEN"]).toBe("xyz789");
-  });
+    test('assembles Cookie header and mirrors for DELETE', () => {
+        const result = resolveRequestHeaders(sessionWithCookies, config, 'DELETE');
+        expect(result.Cookie).toBe('SESSION=abc123; XSRF-TOKEN=xyz789');
+        expect(result['X-XSRF-TOKEN']).toBe('xyz789');
+    });
 
-  test("method matching is case-insensitive", () => {
-    const result = resolveRequestHeaders(sessionWithCookies, config, "post");
-    expect(result.Cookie).toBe("SESSION=abc123; XSRF-TOKEN=xyz789");
-  });
+    test('method matching is case-insensitive', () => {
+        const result = resolveRequestHeaders(sessionWithCookies, config, 'post');
+        expect(result.Cookie).toBe('SESSION=abc123; XSRF-TOKEN=xyz789');
+    });
 
-  test("wildcard applyTo matches all methods", () => {
-    const wildcardConfig: SessionAuthConfig = {
-      ...config,
-      cookies: { extract: ["SESSION"], applyTo: ["*"] },
-    };
-    const result = resolveRequestHeaders(sessionWithCookies, wildcardConfig, "GET");
-    expect(result.Cookie).toBe("SESSION=abc123; XSRF-TOKEN=xyz789");
-  });
+    test('wildcard applyTo matches all methods', () => {
+        const wildcardConfig: SessionAuthConfig = {
+            ...config,
+            cookies: { extract: ['SESSION'], applyTo: ['*'] },
+        };
+        const result = resolveRequestHeaders(sessionWithCookies, wildcardConfig, 'GET');
+        expect(result.Cookie).toBe('SESSION=abc123; XSRF-TOKEN=xyz789');
+    });
 
-  test("omitted applyTo defaults to all methods", () => {
-    const noScopeConfig: SessionAuthConfig = {
-      ...config,
-      cookies: { extract: ["SESSION"] },
-    };
-    const result = resolveRequestHeaders(sessionWithCookies, noScopeConfig, "GET");
-    expect(result.Cookie).toBeDefined();
-  });
+    test('omitted applyTo defaults to all methods', () => {
+        const noScopeConfig: SessionAuthConfig = {
+            ...config,
+            cookies: { extract: ['SESSION'] },
+        };
+        const result = resolveRequestHeaders(sessionWithCookies, noScopeConfig, 'GET');
+        expect(result.Cookie).toBeDefined();
+    });
 
-  test("headerMirror with narrower applyTo than cookies", () => {
-    const narrowMirrorConfig: SessionAuthConfig = {
-      ...config,
-      cookies: {
-        extract: ["SESSION", "XSRF-TOKEN"],
-        applyTo: ["POST", "PUT", "DELETE"],
-      },
-      headerMirror: [
-        { fromCookie: "XSRF-TOKEN", toHeader: "X-XSRF-TOKEN", applyTo: ["POST"] },
-      ],
-    };
-    const deleteResult = resolveRequestHeaders(sessionWithCookies, narrowMirrorConfig, "DELETE");
-    expect(deleteResult.Cookie).toBeDefined();
-    expect(deleteResult["X-XSRF-TOKEN"]).toBeUndefined();
+    test('headerMirror with narrower applyTo than cookies', () => {
+        const narrowMirrorConfig: SessionAuthConfig = {
+            ...config,
+            cookies: {
+                extract: ['SESSION', 'XSRF-TOKEN'],
+                applyTo: ['POST', 'PUT', 'DELETE'],
+            },
+            headerMirror: [
+                { fromCookie: 'XSRF-TOKEN', toHeader: 'X-XSRF-TOKEN', applyTo: ['POST'] },
+            ],
+        };
+        const deleteResult = resolveRequestHeaders(sessionWithCookies, narrowMirrorConfig, 'DELETE');
+        expect(deleteResult.Cookie).toBeDefined();
+        expect(deleteResult['X-XSRF-TOKEN']).toBeUndefined();
 
-    const postResult = resolveRequestHeaders(sessionWithCookies, narrowMirrorConfig, "POST");
-    expect(postResult.Cookie).toBeDefined();
-    expect(postResult["X-XSRF-TOKEN"]).toBe("xyz789");
-  });
+        const postResult = resolveRequestHeaders(sessionWithCookies, narrowMirrorConfig, 'POST');
+        expect(postResult.Cookie).toBeDefined();
+        expect(postResult['X-XSRF-TOKEN']).toBe('xyz789');
+    });
 
-  test("mirror cannot widen beyond cookie scope", () => {
-    const widenAttemptConfig: SessionAuthConfig = {
-      ...config,
-      cookies: {
-        extract: ["SESSION", "XSRF-TOKEN"],
-        applyTo: ["POST"],
-      },
-      headerMirror: [
-        { fromCookie: "XSRF-TOKEN", toHeader: "X-XSRF-TOKEN", applyTo: ["GET", "POST"] },
-      ],
-    };
-    const result = resolveRequestHeaders(sessionWithCookies, widenAttemptConfig, "GET");
-    expect(result["X-XSRF-TOKEN"]).toBeUndefined();
-    expect(result.Cookie).toBeUndefined();
-  });
+    test('mirror cannot widen beyond cookie scope', () => {
+        const widenAttemptConfig: SessionAuthConfig = {
+            ...config,
+            cookies: {
+                extract: ['SESSION', 'XSRF-TOKEN'],
+                applyTo: ['POST'],
+            },
+            headerMirror: [
+                { fromCookie: 'XSRF-TOKEN', toHeader: 'X-XSRF-TOKEN', applyTo: ['GET', 'POST'] },
+            ],
+        };
+        const result = resolveRequestHeaders(sessionWithCookies, widenAttemptConfig, 'GET');
+        expect(result['X-XSRF-TOKEN']).toBeUndefined();
+        expect(result.Cookie).toBeUndefined();
+    });
 
-  test("empty cookies map produces no Cookie header", () => {
-    const emptySession: AuthSession = {
-      headers: { Authorization: "Basic dGVzdDp0ZXN0" },
-      cookies: {},
-    };
-    const result = resolveRequestHeaders(emptySession, config, "POST");
-    expect(result.Cookie).toBeUndefined();
-    expect(result.Authorization).toBe("Basic dGVzdDp0ZXN0");
-  });
+    test('empty cookies map produces no Cookie header', () => {
+        const emptySession: AuthSession = {
+            headers: { Authorization: 'Basic dGVzdDp0ZXN0' },
+            cookies: {},
+        };
+        const result = resolveRequestHeaders(emptySession, config, 'POST');
+        expect(result.Cookie).toBeUndefined();
+        expect(result.Authorization).toBe('Basic dGVzdDp0ZXN0');
+    });
 
-  test("does not mutate the original session headers", () => {
-    const original = { ...sessionWithCookies.headers };
-    resolveRequestHeaders(sessionWithCookies, config, "POST");
-    expect(sessionWithCookies.headers).toEqual(original);
-  });
+    test('does not mutate the original session headers', () => {
+        const original = { ...sessionWithCookies.headers };
+        resolveRequestHeaders(sessionWithCookies, config, 'POST');
+        expect(sessionWithCookies.headers).toEqual(original);
+    });
 });

--- a/tests/auth/session-auth.test.ts
+++ b/tests/auth/session-auth.test.ts
@@ -1,192 +1,200 @@
-import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
-import { SessionAuthStrategy } from "../../src/auth/session-auth";
-import type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from "../../src/auth/types";
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { SessionAuthStrategy } from '../../src/auth/session-auth';
+import type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from '../../src/auth/types';
 
 const resolvedAuth: ResolvedAuth = {
-  baseUrl: "https://api.example.com",
-  username: "admin",
-  password: "secret",
+    baseUrl: 'https://api.example.com',
+    username: 'admin',
+    password: 'secret',
 };
 
 const sessionConfig: SessionAuthConfig = {
-  session: { endpoint: "/session" },
-  cookies: {
-    extract: ["SESSION", "XSRF-TOKEN"],
-    applyTo: ["POST", "PUT", "DELETE"],
-  },
-  headerMirror: [
-    { fromCookie: "XSRF-TOKEN", toHeader: "X-XSRF-TOKEN" },
-  ],
-  refreshOn: [401, 403],
+    session: { endpoint: '/session' },
+    cookies: {
+        extract: ['SESSION', 'XSRF-TOKEN'],
+        applyTo: ['POST', 'PUT', 'DELETE'],
+    },
+    headerMirror: [
+        { fromCookie: 'XSRF-TOKEN', toHeader: 'X-XSRF-TOKEN' },
+    ],
+    refreshOn: [401, 403],
 };
 
 const baseSession: AuthSession = {
-  headers: { Authorization: "Basic YWRtaW46c2VjcmV0" },
+    headers: { Authorization: 'Basic YWRtaW46c2VjcmV0' },
 };
 
 function makeBaseStrategy(session: AuthSession = baseSession): AuthStrategy {
-  return {
-    authenticate: mock(async () => ({ ...session })),
-    restore: mock(async (cached: AuthSession) => cached),
-  };
+    return {
+        authenticate: mock(async () => ({ ...session })),
+        restore: mock(async (cached: AuthSession) => cached),
+    };
 }
 
 function mockSessionFetch() {
-  const originalFetch = globalThis.fetch;
-  const mockFn = mock(async (url: string | URL | Request, init?: RequestInit) => {
-    const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
-    if (urlStr.endsWith("/session")) {
-      return new Response("{}", {
-        status: 200,
-        headers: [
-          ["Set-Cookie", "SESSION=sess123; Path=/; HttpOnly"],
-          ["Set-Cookie", "XSRF-TOKEN=xsrf456; Path=/"],
-        ],
-      });
-    }
-    return originalFetch(url, init);
-  });
-  globalThis.fetch = mockFn as typeof fetch;
-  return { mockFn, restore: () => { globalThis.fetch = originalFetch; } };
+    const originalFetch = globalThis.fetch;
+    const mockFn = mock(async (url: string | URL | Request, init?: RequestInit) => {
+        const urlStr = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+
+        if (urlStr.endsWith('/session')) {
+            return new Response('{}', {
+                status: 200,
+                headers: [
+                    ['Set-Cookie', 'SESSION=sess123; Path=/; HttpOnly'],
+                    ['Set-Cookie', 'XSRF-TOKEN=xsrf456; Path=/'],
+                ],
+            });
+        }
+
+        return originalFetch(url, init);
+    });
+    globalThis.fetch = mockFn as typeof fetch;
+
+    return {
+        mockFn,
+        restore: () => {
+            globalThis.fetch = originalFetch;
+        },
+    };
 }
 
-describe("SessionAuthStrategy", () => {
-  let fetchMock: ReturnType<typeof mockSessionFetch>;
+describe('SessionAuthStrategy', () => {
+    let fetchMock: ReturnType<typeof mockSessionFetch>;
 
-  beforeEach(() => {
-    fetchMock = mockSessionFetch();
-  });
+    beforeEach(() => {
+        fetchMock = mockSessionFetch();
+    });
 
-  afterEach(() => {
-    fetchMock.restore();
-  });
+    afterEach(() => {
+        fetchMock.restore();
+    });
 
-  test("authenticate() calls base strategy then hits session endpoint", async () => {
-    const base = makeBaseStrategy();
-    await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    expect(base.authenticate).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mockFn).toHaveBeenCalledTimes(1);
-    const fetchUrl = (fetchMock.mockFn as any).mock.calls[0][0] as string;
-    expect(fetchUrl).toBe("https://api.example.com/session");
-  });
+    test('authenticate() calls base strategy then hits session endpoint', async () => {
+        const base = makeBaseStrategy();
+        await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        expect(base.authenticate).toHaveBeenCalledTimes(1);
+        expect(fetchMock.mockFn).toHaveBeenCalledTimes(1);
+        const fetchUrl = (fetchMock.mockFn as any).mock.calls[0][0] as string;
+        expect(fetchUrl).toBe('https://api.example.com/session');
+    });
 
-  test("authenticate() extracts named cookies from Set-Cookie", async () => {
-    const base = makeBaseStrategy();
-    const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    expect(session.cookies).toBeDefined();
-    expect(session.cookies!.SESSION).toBe("sess123");
-    expect(session.cookies!["XSRF-TOKEN"]).toBe("xsrf456");
-  });
+    test('authenticate() extracts named cookies from Set-Cookie', async () => {
+        const base = makeBaseStrategy();
+        const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        expect(session.cookies).toBeDefined();
+        expect(session.cookies!.SESSION).toBe('sess123');
+        expect(session.cookies!['XSRF-TOKEN']).toBe('xsrf456');
+    });
 
-  test("authenticate() excludes cookies not in extract list", async () => {
-    globalThis.fetch = mock(async () => new Response("{}", {
-      status: 200,
-      headers: [
-        ["Set-Cookie", "SESSION=sess123; Path=/"],
-        ["Set-Cookie", "XSRF-TOKEN=xsrf456; Path=/"],
-        ["Set-Cookie", "JSESSIONID=unwanted; Path=/"],
-      ],
-    })) as typeof fetch;
+    test('authenticate() excludes cookies not in extract list', async () => {
+        globalThis.fetch = mock(async () => new Response('{}', {
+            status: 200,
+            headers: [
+                ['Set-Cookie', 'SESSION=sess123; Path=/'],
+                ['Set-Cookie', 'XSRF-TOKEN=xsrf456; Path=/'],
+                ['Set-Cookie', 'JSESSIONID=unwanted; Path=/'],
+            ],
+        })) as typeof fetch;
 
-    const base = makeBaseStrategy();
-    const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    expect(session.cookies!.SESSION).toBe("sess123");
-    expect(session.cookies!["XSRF-TOKEN"]).toBe("xsrf456");
-    expect(session.cookies!["JSESSIONID"]).toBeUndefined();
-  });
+        const base = makeBaseStrategy();
+        const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        expect(session.cookies!.SESSION).toBe('sess123');
+        expect(session.cookies!['XSRF-TOKEN']).toBe('xsrf456');
+        expect(session.cookies!['JSESSIONID']).toBeUndefined();
+    });
 
-  test("authenticate() preserves base headers", async () => {
-    const base = makeBaseStrategy();
-    const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    expect(session.headers.Authorization).toBe("Basic YWRtaW46c2VjcmV0");
-  });
+    test('authenticate() preserves base headers', async () => {
+        const base = makeBaseStrategy();
+        const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        expect(session.headers.Authorization).toBe('Basic YWRtaW46c2VjcmV0');
+    });
 
-  test("authenticate() sends base headers in session endpoint request", async () => {
-    const base = makeBaseStrategy();
-    await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
-    expect(fetchInit.headers).toEqual({ Authorization: "Basic YWRtaW46c2VjcmV0" });
-  });
+    test('authenticate() sends base headers in session endpoint request', async () => {
+        const base = makeBaseStrategy();
+        await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
+        expect(fetchInit.headers).toEqual({ Authorization: 'Basic YWRtaW46c2VjcmV0' });
+    });
 
-  test("authenticate() uses configured HTTP method", async () => {
-    const base = makeBaseStrategy();
-    const postConfig = { ...sessionConfig, session: { endpoint: "/session", method: "POST" } };
-    await new SessionAuthStrategy(base, postConfig).authenticate(resolvedAuth);
-    const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
-    expect(fetchInit.method).toBe("POST");
-  });
+    test('authenticate() uses configured HTTP method', async () => {
+        const base = makeBaseStrategy();
+        const postConfig = { ...sessionConfig, session: { endpoint: '/session', method: 'POST' } };
+        await new SessionAuthStrategy(base, postConfig).authenticate(resolvedAuth);
+        const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
+        expect(fetchInit.method).toBe('POST');
+    });
 
-  test("authenticate() defaults to GET method", async () => {
-    const base = makeBaseStrategy();
-    await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
-    expect(fetchInit.method).toBe("GET");
-  });
+    test('authenticate() defaults to GET method', async () => {
+        const base = makeBaseStrategy();
+        await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
+        expect(fetchInit.method).toBe('GET');
+    });
 
-  test("authenticate() handles cookie values containing '=' characters", async () => {
-    globalThis.fetch = mock(async () => new Response("{}", {
-      status: 200,
-      headers: [
-        ["Set-Cookie", "SESSION=dGVzdD10ZXN0==; Path=/; HttpOnly"],
-        ["Set-Cookie", "XSRF-TOKEN=abc=def=ghi; Path=/"],
-      ],
-    })) as typeof fetch;
+    test("authenticate() handles cookie values containing '=' characters", async () => {
+        globalThis.fetch = mock(async () => new Response('{}', {
+            status: 200,
+            headers: [
+                ['Set-Cookie', 'SESSION=dGVzdD10ZXN0==; Path=/; HttpOnly'],
+                ['Set-Cookie', 'XSRF-TOKEN=abc=def=ghi; Path=/'],
+            ],
+        })) as typeof fetch;
 
-    const base = makeBaseStrategy();
-    const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    expect(session.cookies!.SESSION).toBe("dGVzdD10ZXN0==");
-    expect(session.cookies!["XSRF-TOKEN"]).toBe("abc=def=ghi");
-  });
+        const base = makeBaseStrategy();
+        const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        expect(session.cookies!.SESSION).toBe('dGVzdD10ZXN0==');
+        expect(session.cookies!['XSRF-TOKEN']).toBe('abc=def=ghi');
+    });
 
-  test("authenticate() uses redirect: manual to preserve Set-Cookie headers", async () => {
-    const base = makeBaseStrategy();
-    await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
-    const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
-    expect(fetchInit.redirect).toBe("manual");
-  });
+    test('authenticate() uses redirect: manual to preserve Set-Cookie headers', async () => {
+        const base = makeBaseStrategy();
+        await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+        const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
+        expect(fetchInit.redirect).toBe('manual');
+    });
 
-  test("authenticate() throws when session endpoint returns error", async () => {
-    globalThis.fetch = mock(async () => new Response("Unauthorized", { status: 401 })) as typeof fetch;
-    const base = makeBaseStrategy();
-    await expect(new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth)).rejects.toThrow();
-  });
+    test('authenticate() throws when session endpoint returns error', async () => {
+        globalThis.fetch = mock(async () => new Response('Unauthorized', { status: 401 })) as typeof fetch;
+        const base = makeBaseStrategy();
+        await expect(new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth)).rejects.toThrow();
+    });
 
-  test("restore() returns null when base.restore() returns null", async () => {
-    const base = makeBaseStrategy();
-    (base.restore as any).mockImplementation(async () => null);
-    const cached: AuthSession = { headers: { Authorization: "Basic old" }, cookies: { SESSION: "old" } };
-    const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
-    expect(result).toBeNull();
-  });
+    test('restore() returns null when base.restore() returns null', async () => {
+        const base = makeBaseStrategy();
+        (base.restore as any).mockImplementation(async () => null);
+        const cached: AuthSession = { headers: { Authorization: 'Basic old' }, cookies: { SESSION: 'old' } };
+        const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
+        expect(result).toBeNull();
+    });
 
-  test("restore() returns cached session with cookies when base succeeds", async () => {
-    const base = makeBaseStrategy();
-    const cached: AuthSession = {
-      headers: { Authorization: "Basic cached" },
-      cookies: { SESSION: "cached_sess", "XSRF-TOKEN": "cached_xsrf" },
-    };
-    const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
-    expect(result).not.toBeNull();
-    expect(result!.cookies!.SESSION).toBe("cached_sess");
-  });
+    test('restore() returns cached session with cookies when base succeeds', async () => {
+        const base = makeBaseStrategy();
+        const cached: AuthSession = {
+            headers: { Authorization: 'Basic cached' },
+            cookies: { 'SESSION': 'cached_sess', 'XSRF-TOKEN': 'cached_xsrf' },
+        };
+        const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
+        expect(result).not.toBeNull();
+        expect(result!.cookies!.SESSION).toBe('cached_sess');
+    });
 
-  test("restore() returns null when session is expired", async () => {
-    const base = makeBaseStrategy();
-    const cached: AuthSession = {
-      headers: { Authorization: "Basic cached" },
-      cookies: { SESSION: "expired" },
-      expiresAt: Date.now() - 1000,
-    };
-    const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
-    expect(result).toBeNull();
-  });
+    test('restore() returns null when session is expired', async () => {
+        const base = makeBaseStrategy();
+        const cached: AuthSession = {
+            headers: { Authorization: 'Basic cached' },
+            cookies: { SESSION: 'expired' },
+            expiresAt: Date.now() - 1000,
+        };
+        const result = await new SessionAuthStrategy(base, sessionConfig).restore(cached, resolvedAuth);
+        expect(result).toBeNull();
+    });
 
-  test("refresh() re-authenticates by hitting session endpoint", async () => {
-    const base = makeBaseStrategy();
-    const strategy = new SessionAuthStrategy(base, sessionConfig);
-    const oldSession: AuthSession = { headers: { Authorization: "Basic old" }, cookies: { SESSION: "old_sess" } };
-    const refreshed = await strategy.refresh!(oldSession, resolvedAuth);
-    expect(refreshed.cookies!.SESSION).toBe("sess123");
-    expect(fetchMock.mockFn).toHaveBeenCalledTimes(1);
-  });
+    test('refresh() re-authenticates by hitting session endpoint', async () => {
+        const base = makeBaseStrategy();
+        const strategy = new SessionAuthStrategy(base, sessionConfig);
+        const oldSession: AuthSession = { headers: { Authorization: 'Basic old' }, cookies: { SESSION: 'old_sess' } };
+        const refreshed = await strategy.refresh!(oldSession, resolvedAuth);
+        expect(refreshed.cookies!.SESSION).toBe('sess123');
+        expect(fetchMock.mockFn).toHaveBeenCalledTimes(1);
+    });
 });

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -1,19 +1,19 @@
-import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
-import { Command } from "commander";
-import { createCli, type Cli } from "../src/cli-builder";
-import type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler } from "../src/types";
-import { BasicAuthStrategy } from "../src/auth/basic";
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { Command } from 'commander';
+import { createCli, type Cli } from '../src/cli-builder';
+import type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler } from '../src/types';
+import { BasicAuthStrategy } from '../src/auth/basic';
 
 function makeOptions(overrides: Partial<CliOptions> = {}): CliOptions {
-  return {
-    name: "testcli",
-    description: "A test CLI",
-    version: "1.0.0",
-    specPath: "/v3/api-docs",
-    auth: new BasicAuthStrategy(),
-    outputModes: ["json", "table", "quiet"],
-    ...overrides,
-  };
+    return {
+        name: 'testcli',
+        description: 'A test CLI',
+        version: '1.0.0',
+        specPath: '/v3/api-docs',
+        auth: new BasicAuthStrategy(),
+        outputModes: ['json', 'table', 'quiet'],
+        ...overrides,
+    };
 }
 
 /**
@@ -21,53 +21,54 @@ function makeOptions(overrides: Partial<CliOptions> = {}): CliOptions {
  * during an async callback. Commander's --help writes directly to stdout.
  */
 async function captureOutput(fn: () => Promise<void>): Promise<string> {
-  const logs: string[] = [];
-  const origLog = console.log;
-  const origErr = console.error;
-  const origWrite = process.stdout.write;
+    const logs: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    const origWrite = process.stdout.write;
 
-  console.log = (...args: unknown[]) => logs.push(args.join(" "));
-  console.error = (...args: unknown[]) => logs.push(args.join(" "));
-  process.stdout.write = (chunk: any, ...rest: any[]) => {
-    logs.push(typeof chunk === "string" ? chunk : chunk.toString());
-    return true;
-  };
+    console.log = (...args: unknown[]) => logs.push(args.join(' '));
+    console.error = (...args: unknown[]) => logs.push(args.join(' '));
+    process.stdout.write = (chunk: any, ...rest: any[]) => {
+        logs.push(typeof chunk === 'string' ? chunk : chunk.toString());
 
-  try {
-    await fn();
-  } catch {
+        return true;
+    };
+
+    try {
+        await fn();
+    } catch {
     // Expected: process.exit calls
-  } finally {
-    console.log = origLog;
-    console.error = origErr;
-    process.stdout.write = origWrite;
-  }
+    } finally {
+        console.log = origLog;
+        console.error = origErr;
+        process.stdout.write = origWrite;
+    }
 
-  return logs.join("\n");
+    return logs.join('\n');
 }
 
-describe("createCli()", () => {
-  test("returns object with command(), dispatcher(), run() methods", () => {
-    const cli = createCli(makeOptions());
-    expect(typeof cli.command).toBe("function");
-    expect(typeof cli.dispatcher).toBe("function");
-    expect(typeof cli.run).toBe("function");
-  });
+describe('createCli()', () => {
+    test('returns object with command(), dispatcher(), run() methods', () => {
+        const cli = createCli(makeOptions());
+        expect(typeof cli.command).toBe('function');
+        expect(typeof cli.dispatcher).toBe('function');
+        expect(typeof cli.run).toBe('function');
+    });
 
-  test("command() stores registrar for later invocation", () => {
-    const cli = createCli(makeOptions());
-    const registrar: CommandRegistrar = (_program, _ctx) => {};
-    // Should not throw
-    cli.command("my-cmd", registrar);
+    test('command() stores registrar for later invocation', () => {
+        const cli = createCli(makeOptions());
+        const registrar: CommandRegistrar = (_program, _ctx) => {};
+        // Should not throw
+        cli.command('my-cmd', registrar);
     // We verify this is wired correctly in integration-style tests below
-  });
+    });
 
-  test("dispatcher() stores handler for the composed dispatcher", () => {
-    const cli = createCli(makeOptions());
-    const handler: DispatcherHandler = async (_args, _pos, _ctx) => ({});
-    // Should not throw
-    cli.dispatcher("my-dispatch", handler);
-  });
+    test('dispatcher() stores handler for the composed dispatcher', () => {
+        const cli = createCli(makeOptions());
+        const handler: DispatcherHandler = async (_args, _pos, _ctx) => ({});
+        // Should not throw
+        cli.dispatcher('my-dispatch', handler);
+    });
 });
 
 /**
@@ -75,305 +76,305 @@ describe("createCli()", () => {
  * we construct the CLI and inspect the Commander program that would be built.
  * We do this by mocking process.argv and intercepting parseAsync.
  */
-describe("built-in commands", () => {
-  let originalArgv: string[];
-  let originalExit: typeof process.exit;
-  let exitCode: number | undefined;
+describe('built-in commands', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let exitCode: number | undefined;
 
-  beforeEach(() => {
-    originalArgv = process.argv;
-    originalExit = process.exit;
-    exitCode = undefined;
-    // Mock process.exit to prevent test runner from dying
-    (process as any).exit = (code?: number) => {
-      exitCode = code ?? 0;
-      throw new Error(`process.exit(${code})`);
-    };
-  });
-
-  afterEach(() => {
-    process.argv = originalArgv;
-    (process as any).exit = originalExit;
-  });
-
-  test("setup, login, config (list, switch), generate, and routine commands are registered", async () => {
-    // Use --help with a non-existent command to force Commander to parse and build the tree
-    const cli = createCli(makeOptions());
-
-    // We can build a program internally by running with --help, which will call showCustomHelp and exit
-    // Instead, let's test the structure by hooking into run() at the parse stage
-    process.argv = ["node", "testcli", "--help"];
-
-    // Capture console output
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected: process.exit(0) from showCustomHelp
-    }
-
-    console.log = origLog;
-    const output = logs.join("\n");
-
-    // Verify core commands appear in help
-    expect(output).toContain("setup");
-    expect(output).toContain("login");
-    expect(output).toContain("config");
-    expect(output).toContain("generate");
-    expect(output).toContain("routine");
-  });
-
-  test("knownSites option registers config import and config update-password", async () => {
-    const cli = createCli(
-      makeOptions({
-        knownSites: {
-          staging: { url: "https://staging.example.com", description: "Staging" },
-        },
-      }),
-    );
-
-    process.argv = ["node", "testcli", "config", "--help"];
-
-    const output = await captureOutput(() => cli.run());
-
-    // config import and update-password should be registered as subcommands
-    expect(output).toContain("import");
-    expect(output).toContain("update-password");
-  });
-
-  test("config import is NOT registered when knownSites is not provided", async () => {
-    const cli = createCli(makeOptions({ knownSites: undefined }));
-
-    process.argv = ["node", "testcli", "config", "--help"];
-
-    const output = await captureOutput(() => cli.run());
-
-    // config import should NOT be present
-    expect(output).not.toContain("import");
-    expect(output).not.toContain("update-password");
-  });
-
-  test("output mode flags are registered (--table, --quiet, -o)", async () => {
-    const cli = createCli(makeOptions());
-
-    process.argv = ["node", "testcli", "--help"];
-
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
-
-    console.log = origLog;
-    const output = logs.join("\n");
-
-    expect(output).toContain("--table");
-    expect(output).toContain("--quiet");
-    expect(output).toContain("-o <format>");
-  });
-
-  test("output mode flags respect outputModes option", async () => {
-    // Only json mode (no table or quiet)
-    const cli = createCli(makeOptions({ outputModes: ["json"] }));
-
-    process.argv = ["node", "testcli", "--help"];
-
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
-
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
-
-    console.log = origLog;
-    const output = logs.join("\n");
-
-    // --table and --quiet should NOT be registered since not in outputModes
-    expect(output).not.toContain("--table");
-    expect(output).not.toContain("--quiet");
-    // -o should still be registered
-    expect(output).toContain("-o <format>");
-  });
-
-  test("custom help separates core commands from API commands", async () => {
-    const cli = createCli(makeOptions());
-
-    process.argv = ["node", "testcli", "--help"];
-
-    const output = await captureOutput(() => cli.run());
-
-    // Should show "Commands:" section with core commands
-    expect(output).toContain("Commands:");
-    // Should show usage and description
-    expect(output).toContain("Usage: testcli");
-    expect(output).toContain("A test CLI");
-  });
-
-  test("custom commands appear in their own section, visible without --help", async () => {
-    const cli = createCli(makeOptions());
-    cli.command("my-tool", (program) => {
-      program.command("my-tool").description("A custom tool");
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+        exitCode = undefined;
+        // Mock process.exit to prevent test runner from dying
+        (process as any).exit = (code?: number) => {
+            exitCode = code ?? 0;
+            throw new Error(`process.exit(${code})`);
+        };
     });
 
-    // No --help flag — just bare invocation
-    process.argv = ["node", "testcli"];
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as any).exit = originalExit;
+    });
 
-    const output = await captureOutput(() => cli.run());
+    test('setup, login, config (list, switch), generate, and routine commands are registered', async () => {
+    // Use --help with a non-existent command to force Commander to parse and build the tree
+        const cli = createCli(makeOptions());
 
-    expect(output).toContain("Custom Commands:");
-    expect(output).toContain("my-tool");
-    expect(output).toContain("A custom tool");
-  });
+        // We can build a program internally by running with --help, which will call showCustomHelp and exit
+        // Instead, let's test the structure by hooking into run() at the parse stage
+        process.argv = ['node', 'testcli', '--help'];
 
-  test("custom commands section is hidden when there are none", async () => {
-    const cli = createCli(makeOptions());
+        // Capture console output
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
 
-    process.argv = ["node", "testcli"];
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected: process.exit(0) from showCustomHelp
+        }
 
-    const output = await captureOutput(() => cli.run());
+        console.log = origLog;
+        const output = logs.join('\n');
 
-    expect(output).not.toContain("Custom Commands:");
-  });
+        // Verify core commands appear in help
+        expect(output).toContain('setup');
+        expect(output).toContain('login');
+        expect(output).toContain('config');
+        expect(output).toContain('generate');
+        expect(output).toContain('routine');
+    });
 
-  test("routine subcommands are registered (list, run, validate, test, init)", async () => {
-    const cli = createCli(makeOptions());
+    test('knownSites option registers config import and config update-password', async () => {
+        const cli = createCli(
+            makeOptions({
+                knownSites: {
+                    staging: { url: 'https://staging.example.com', description: 'Staging' },
+                },
+            }),
+        );
 
-    process.argv = ["node", "testcli", "routine", "--help"];
+        process.argv = ['node', 'testcli', 'config', '--help'];
 
-    const output = await captureOutput(() => cli.run());
+        const output = await captureOutput(() => cli.run());
 
-    expect(output).toContain("list");
-    expect(output).toContain("run");
-    expect(output).toContain("validate");
-    expect(output).toContain("test");
-    expect(output).toContain("init");
-  });
+        // config import and update-password should be registered as subcommands
+        expect(output).toContain('import');
+        expect(output).toContain('update-password');
+    });
 
-  test("env var prefix is derived from cliName uppercased", async () => {
+    test('config import is NOT registered when knownSites is not provided', async () => {
+        const cli = createCli(makeOptions({ knownSites: undefined }));
+
+        process.argv = ['node', 'testcli', 'config', '--help'];
+
+        const output = await captureOutput(() => cli.run());
+
+        // config import should NOT be present
+        expect(output).not.toContain('import');
+        expect(output).not.toContain('update-password');
+    });
+
+    test('output mode flags are registered (--table, --quiet, -o)', async () => {
+        const cli = createCli(makeOptions());
+
+        process.argv = ['node', 'testcli', '--help'];
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected
+        }
+
+        console.log = origLog;
+        const output = logs.join('\n');
+
+        expect(output).toContain('--table');
+        expect(output).toContain('--quiet');
+        expect(output).toContain('-o <format>');
+    });
+
+    test('output mode flags respect outputModes option', async () => {
+    // Only json mode (no table or quiet)
+        const cli = createCli(makeOptions({ outputModes: ['json'] }));
+
+        process.argv = ['node', 'testcli', '--help'];
+
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
+
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected
+        }
+
+        console.log = origLog;
+        const output = logs.join('\n');
+
+        // --table and --quiet should NOT be registered since not in outputModes
+        expect(output).not.toContain('--table');
+        expect(output).not.toContain('--quiet');
+        // -o should still be registered
+        expect(output).toContain('-o <format>');
+    });
+
+    test('custom help separates core commands from API commands', async () => {
+        const cli = createCli(makeOptions());
+
+        process.argv = ['node', 'testcli', '--help'];
+
+        const output = await captureOutput(() => cli.run());
+
+        // Should show "Commands:" section with core commands
+        expect(output).toContain('Commands:');
+        // Should show usage and description
+        expect(output).toContain('Usage: testcli');
+        expect(output).toContain('A test CLI');
+    });
+
+    test('custom commands appear in their own section, visible without --help', async () => {
+        const cli = createCli(makeOptions());
+        cli.command('my-tool', (program) => {
+            program.command('my-tool').description('A custom tool');
+        });
+
+        // No --help flag — just bare invocation
+        process.argv = ['node', 'testcli'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('Custom Commands:');
+        expect(output).toContain('my-tool');
+        expect(output).toContain('A custom tool');
+    });
+
+    test('custom commands section is hidden when there are none', async () => {
+        const cli = createCli(makeOptions());
+
+        process.argv = ['node', 'testcli'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).not.toContain('Custom Commands:');
+    });
+
+    test('routine subcommands are registered (list, run, validate, test, init)', async () => {
+        const cli = createCli(makeOptions());
+
+        process.argv = ['node', 'testcli', 'routine', '--help'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('list');
+        expect(output).toContain('run');
+        expect(output).toContain('validate');
+        expect(output).toContain('test');
+        expect(output).toContain('init');
+    });
+
+    test('env var prefix is derived from cliName uppercased', async () => {
     // Set env vars matching the test CLI name
-    process.env.TESTCLI_URL = "https://env.example.com";
-    process.env.TESTCLI_USER = "envuser";
-    process.env.TESTCLI_PASS = "envpass";
+        process.env.TESTCLI_URL = 'https://env.example.com';
+        process.env.TESTCLI_USER = 'envuser';
+        process.env.TESTCLI_PASS = 'envpass';
 
-    const cli = createCli(makeOptions({ name: "testcli" }));
+        const cli = createCli(makeOptions({ name: 'testcli' }));
 
-    // Run with a non-existent command that won't match — we just want to verify auth resolution
-    process.argv = ["node", "testcli", "--help"];
+        // Run with a non-existent command that won't match — we just want to verify auth resolution
+        process.argv = ['node', 'testcli', '--help'];
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
 
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected: process.exit from help
-    }
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected: process.exit from help
+        }
 
-    console.log = origLog;
+        console.log = origLog;
 
-    // Clean up
-    delete process.env.TESTCLI_URL;
-    delete process.env.TESTCLI_USER;
-    delete process.env.TESTCLI_PASS;
+        // Clean up
+        delete process.env.TESTCLI_URL;
+        delete process.env.TESTCLI_USER;
+        delete process.env.TESTCLI_PASS;
 
-    // If we got this far without error, env var resolution worked
-    expect(exitCode).toBe(0);
-  });
+        // If we got this far without error, env var resolution worked
+        expect(exitCode).toBe(0);
+    });
 
-  test("program name and version are set correctly", async () => {
-    const cli = createCli(
-      makeOptions({
-        name: "mycli",
-        description: "My custom CLI tool",
-        version: "2.5.0",
-      }),
-    );
+    test('program name and version are set correctly', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'mycli',
+                description: 'My custom CLI tool',
+                version: '2.5.0',
+            }),
+        );
 
-    process.argv = ["node", "mycli", "--help"];
+        process.argv = ['node', 'mycli', '--help'];
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
 
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected
+        }
 
-    console.log = origLog;
-    const output = logs.join("\n");
+        console.log = origLog;
+        const output = logs.join('\n');
 
-    expect(output).toContain("Usage: mycli");
-    expect(output).toContain("My custom CLI tool");
-  });
+        expect(output).toContain('Usage: mycli');
+        expect(output).toContain('My custom CLI tool');
+    });
 
-  test("--dry-run flag is registered", async () => {
-    const cli = createCli(makeOptions());
+    test('--dry-run flag is registered', async () => {
+        const cli = createCli(makeOptions());
 
-    process.argv = ["node", "testcli", "--help"];
+        process.argv = ['node', 'testcli', '--help'];
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
 
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected
+        }
 
-    console.log = origLog;
-    const output = logs.join("\n");
+        console.log = origLog;
+        const output = logs.join('\n');
 
-    expect(output).toContain("--dry-run");
-  });
+        expect(output).toContain('--dry-run');
+    });
 
-  test("-o help text includes curl and curl-with-creds formats", async () => {
-    const cli = createCli(makeOptions());
+    test('-o help text includes curl and curl-with-creds formats', async () => {
+        const cli = createCli(makeOptions());
 
-    process.argv = ["node", "testcli", "--help"];
+        process.argv = ['node', 'testcli', '--help'];
 
-    const logs: string[] = [];
-    const origLog = console.log;
-    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+        const logs: string[] = [];
+        const origLog = console.log;
+        console.log = (...args: unknown[]) => logs.push(args.join(' '));
 
-    try {
-      await cli.run();
-    } catch (e: any) {
-      // Expected
-    }
+        try {
+            await cli.run();
+        } catch (e: any) {
+            // Expected
+        }
 
-    console.log = origLog;
-    const output = logs.join("\n");
+        console.log = origLog;
+        const output = logs.join('\n');
 
-    expect(output).toContain("curl");
-    expect(output).toContain("curl-with-creds");
-  });
+        expect(output).toContain('curl');
+        expect(output).toContain('curl-with-creds');
+    });
 });
 
-describe("index exports", () => {
-  test("all expected exports are available", async () => {
-    const indexModule = await import("../src/index");
+describe('index exports', () => {
+    test('all expected exports are available', async () => {
+        const indexModule = await import('../src/index');
 
-    // Functions
-    expect(typeof indexModule.createCli).toBe("function");
-    expect(typeof indexModule.BasicAuthStrategy).toBe("function");
-    expect(typeof indexModule.BearerTokenStrategy).toBe("function");
-    expect(typeof indexModule.ApiKeyStrategy).toBe("function");
-    expect(typeof indexModule.formatOutput).toBe("function");
-    expect(typeof indexModule.updateEnvironmentField).toBe("function");
-    expect(typeof indexModule.verifyCredentials).toBe("function");
-  });
+        // Functions
+        expect(typeof indexModule.createCli).toBe('function');
+        expect(typeof indexModule.BasicAuthStrategy).toBe('function');
+        expect(typeof indexModule.BearerTokenStrategy).toBe('function');
+        expect(typeof indexModule.ApiKeyStrategy).toBe('function');
+        expect(typeof indexModule.formatOutput).toBe('function');
+        expect(typeof indexModule.updateEnvironmentField).toBe('function');
+        expect(typeof indexModule.verifyCredentials).toBe('function');
+    });
 });

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -48,10 +48,11 @@ async function captureOutput(fn: () => Promise<void>): Promise<string> {
 }
 
 describe('createCli()', () => {
-    test('returns object with command(), dispatcher(), run() methods', () => {
+    test('returns object with command(), dispatcher(), resolver(), run() methods', () => {
         const cli = createCli(makeOptions());
         expect(typeof cli.command).toBe('function');
         expect(typeof cli.dispatcher).toBe('function');
+        expect(typeof cli.resolver).toBe('function');
         expect(typeof cli.run).toBe('function');
     });
 
@@ -68,6 +69,12 @@ describe('createCli()', () => {
         const handler: DispatcherHandler = async (_args, _pos, _ctx) => ({});
         // Should not throw
         cli.dispatcher('my-dispatch', handler);
+    });
+
+    test('resolver() stores handler for the composed dispatcher', () => {
+        const cli = createCli(makeOptions());
+        // Should not throw
+        cli.resolver('_my_fn', _argsStr => 'ok');
     });
 });
 

--- a/tests/codegen/client.test.ts
+++ b/tests/codegen/client.test.ts
@@ -1,331 +1,332 @@
-import { describe, expect, it, beforeAll, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
-import { join } from "path";
-import { generateClient } from "../../src/codegen/client";
-import type { OpenApiOperation } from "../../src/codegen/openapi-types";
-import fixture from "../fixtures/petstore.json";
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { generateClient } from '../../src/codegen/client';
+import type { OpenApiOperation } from '../../src/codegen/openapi-types';
+import fixture from '../fixtures/petstore.json';
 
 const schemas = fixture.components.schemas as Record<string, any>;
 
-describe("generateClient — unit tests", () => {
-  it("generates the generic ApiClient class", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {};
-    const output = generateClient(paths);
-    expect(output).toContain("export class ApiClient {");
-  });
+describe('generateClient — unit tests', () => {
+    it('generates the generic ApiClient class', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {};
+        const output = generateClient(paths);
+        expect(output).toContain('export class ApiClient {');
+    });
 
-  it("generates method with path params for GET endpoint", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        get: {
-          operationId: "getItem",
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateClient(paths);
-    expect(output).toContain("async getItem(id: number)");
-    // Path template uses backtick interpolation for path params
-    expect(output).toContain("return this.request(\"GET\", `/items/${id}`");
-  });
-
-  it("generates method with body param for POST endpoint", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        post: {
-          operationId: "createItem",
-          requestBody: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateItemDto" },
-              },
+    it('generates method with path params for GET endpoint', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                get: {
+                    operationId: 'getItem',
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
             },
-          },
-        },
-      },
-    };
-    const output = generateClient(paths);
-    expect(output).toContain(
-      "async createItem(body: CreateItemDto)",
-    );
-    expect(output).toContain(", { body }");
-  });
+        };
+        const output = generateClient(paths);
+        expect(output).toContain('async getItem(id: number)');
+        // Path template uses backtick interpolation for path params
+        expect(output).toContain('return this.request("GET", `/items/${id}`');
+    });
 
-  it("passes query params through", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          parameters: [
-            { name: "page", in: "query", schema: { type: "integer" } },
-            { name: "size", in: "query", schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateClient(paths);
-    expect(output).toContain("params?: { page?: number; size?: number }");
-    expect(output).toContain(", { params }");
-  });
-
-  it("handles endpoint with path params, body, and query params", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        put: {
-          operationId: "updateItem",
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-            { name: "notify", in: "query", schema: { type: "boolean" } },
-          ],
-          requestBody: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/UpdateItemDto" },
-              },
+    it('generates method with body param for POST endpoint', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/CreateItemDto' },
+                            },
+                        },
+                    },
+                },
             },
-          },
-        },
-      },
-    };
-    const output = generateClient(paths);
-    expect(output).toContain(
-      "async updateItem(id: number, body: UpdateItemDto, params?: { notify?: boolean })",
-    );
-    expect(output).toContain(", { params, body }");
-  });
+        };
+        const output = generateClient(paths);
+        expect(output).toContain(
+            'async createItem(body: CreateItemDto)',
+        );
+        expect(output).toContain(', { body }');
+    });
 
-  it("includes auto-generated header", () => {
-    const output = generateClient({});
-    expect(output).toContain("// Auto-generated");
-  });
+    it('passes query params through', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    parameters: [
+                        { name: 'page', in: 'query', schema: { type: 'integer' } },
+                        { name: 'size', in: 'query', schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateClient(paths);
+        expect(output).toContain('params?: { page?: number; size?: number }');
+        expect(output).toContain(', { params }');
+    });
 
-  it("includes request method with fetch logic", () => {
-    const output = generateClient({});
-    expect(output).toContain("private async request(");
-    expect(output).toContain("fetch(");
-    expect(output).toContain("JSON.stringify");
-  });
+    it('handles endpoint with path params, body, and query params', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                put: {
+                    operationId: 'updateItem',
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                        { name: 'notify', in: 'query', schema: { type: 'boolean' } },
+                    ],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/UpdateItemDto' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const output = generateClient(paths);
+        expect(output).toContain(
+            'async updateItem(id: number, body: UpdateItemDto, params?: { notify?: boolean })',
+        );
+        expect(output).toContain(', { params, body }');
+    });
 
-  it("skips operations without operationId", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          tags: ["items"],
-          // no operationId
-        },
-      },
-    };
-    const output = generateClient(paths);
-    // Should only have the class shell, no methods beyond request
-    expect(output).not.toContain("async list");
-  });
+    it('includes auto-generated header', () => {
+        const output = generateClient({});
+        expect(output).toContain('// Auto-generated');
+    });
 
-  it("generates correct path template for endpoint without path params", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-        },
-      },
-    };
-    const output = generateClient(paths);
-    expect(output).toContain('return this.request("GET", "/items")');
-  });
+    it('includes request method with fetch logic', () => {
+        const output = generateClient({});
+        expect(output).toContain('private async request(');
+        expect(output).toContain('fetch(');
+        expect(output).toContain('JSON.stringify');
+    });
 
-  it("exports PreRequestHook type", () => {
-    const output = generateClient({});
-    expect(output).toContain(
-      "export type PreRequestHook = (req: { method: string; url: string; body?: unknown }) => void;",
-    );
-  });
+    it('skips operations without operationId', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    tags: ['items'],
+                    // no operationId
+                },
+            },
+        };
+        const output = generateClient(paths);
+        // Should only have the class shell, no methods beyond request
+        expect(output).not.toContain('async list');
+    });
 
-  it("exports RequestInterceptor type", () => {
-    const output = generateClient({});
-    expect(output).toContain(
-      "export type RequestInterceptor = (req: { method: string; url: string; body?: unknown }) => unknown | undefined;",
-    );
-  });
+    it('generates correct path template for endpoint without path params', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                },
+            },
+        };
+        const output = generateClient(paths);
+        expect(output).toContain('return this.request("GET", "/items")');
+    });
 
-  it("exports HeadersProvider type", () => {
-    const output = generateClient({});
-    expect(output).toContain(
-      "export type HeadersProvider = (method: string) => Record<string, string>;",
-    );
-  });
+    it('exports PreRequestHook type', () => {
+        const output = generateClient({});
+        expect(output).toContain(
+            'export type PreRequestHook = (req: { method: string; url: string; body?: unknown }) => void;',
+        );
+    });
 
-  it("generates preRequest hook property", () => {
-    const output = generateClient({});
-    expect(output).toContain("preRequest?: PreRequestHook");
-  });
+    it('exports RequestInterceptor type', () => {
+        const output = generateClient({});
+        expect(output).toContain(
+            'export type RequestInterceptor = (req: { method: string; url: string; body?: unknown }) => unknown | undefined;',
+        );
+    });
 
-  it("generates interceptRequest hook property", () => {
-    const output = generateClient({});
-    expect(output).toContain("interceptRequest?: RequestInterceptor");
-  });
+    it('exports HeadersProvider type', () => {
+        const output = generateClient({});
+        expect(output).toContain(
+            'export type HeadersProvider = (method: string) => Record<string, string>;',
+        );
+    });
 
-  it("generates ensureReady hook property", () => {
-    const output = generateClient({});
-    expect(output).toContain("ensureReady?: () => Promise<void>");
-  });
+    it('generates preRequest hook property', () => {
+        const output = generateClient({});
+        expect(output).toContain('preRequest?: PreRequestHook');
+    });
 
-  it("does not generate dryRun property", () => {
-    const output = generateClient({});
-    expect(output).not.toContain("dryRun");
-  });
+    it('generates interceptRequest hook property', () => {
+        const output = generateClient({});
+        expect(output).toContain('interceptRequest?: RequestInterceptor');
+    });
 
-  it("does not generate CapturedRequest interface", () => {
-    const output = generateClient({});
-    expect(output).not.toContain("export interface CapturedRequest");
-  });
+    it('generates ensureReady hook property', () => {
+        const output = generateClient({});
+        expect(output).toContain('ensureReady?: () => Promise<void>');
+    });
+
+    it('does not generate dryRun property', () => {
+        const output = generateClient({});
+        expect(output).not.toContain('dryRun');
+    });
+
+    it('does not generate CapturedRequest interface', () => {
+        const output = generateClient({});
+        expect(output).not.toContain('export interface CapturedRequest');
+    });
 });
 
-describe("generateClient — petstore fixture", () => {
-  const output = generateClient(fixture.paths as any, schemas);
+describe('generateClient — petstore fixture', () => {
+    const output = generateClient(fixture.paths as any, schemas);
 
-  it("generates class with method per operationId", () => {
-    expect(output).toContain("export class ApiClient {");
-    expect(output).toContain("async adminGetMatters(");
-    expect(output).toContain("async adminCreateMatter(");
-    expect(output).toContain("async adminGetMatter(");
-    expect(output).toContain("async adminDeleteMatter(");
-    expect(output).toContain("async getUsers(");
-  });
+    it('generates class with method per operationId', () => {
+        expect(output).toContain('export class ApiClient {');
+        expect(output).toContain('async adminGetMatters(');
+        expect(output).toContain('async adminCreateMatter(');
+        expect(output).toContain('async adminGetMatter(');
+        expect(output).toContain('async adminDeleteMatter(');
+        expect(output).toContain('async getUsers(');
+    });
 
-  it("path params become method parameters", () => {
-    expect(output).toContain("matterId: number");
-  });
+    it('path params become method parameters', () => {
+        expect(output).toContain('matterId: number');
+    });
 
-  it("query params become optional params object", () => {
-    expect(output).toContain("params?: { status?: string }");
-  });
+    it('query params become optional params object', () => {
+        expect(output).toContain('params?: { status?: string }');
+    });
 
-  it("request body becomes body parameter", () => {
-    expect(output).toContain("body: CreateMatterRequest");
-  });
+    it('request body becomes body parameter', () => {
+        expect(output).toContain('body: CreateMatterRequest');
+    });
 
-  it("generates correct HTTP method in request call", () => {
-    expect(output).toContain(`this.request("GET", "/admin/matters"`);
-    expect(output).toContain(`this.request("POST", "/admin/matters"`);
-    expect(output).toContain(`this.request("DELETE", \`/admin/matters/\${matterId}\``);
-  });
+    it('generates correct HTTP method in request call', () => {
+        expect(output).toContain('this.request("GET", "/admin/matters"');
+        expect(output).toContain('this.request("POST", "/admin/matters"');
+        expect(output).toContain('this.request("DELETE", `/admin/matters/${matterId}`');
+    });
 
-  // Response types
-  it("typed return for $ref response", () => {
-    expect(output).toMatch(/async adminGetMatter\(.*\): Promise<MatterDto>/);
-  });
+    // Response types
+    it('typed return for $ref response', () => {
+        expect(output).toMatch(/async adminGetMatter\(.*\): Promise<MatterDto>/);
+    });
 
-  it("typed return for array response", () => {
-    expect(output).toMatch(/async adminGetMatters\(.*\): Promise<MatterDto\[\]>/);
-  });
+    it('typed return for array response', () => {
+        expect(output).toMatch(/async adminGetMatters\(.*\): Promise<MatterDto\[\]>/);
+    });
 
-  it("void return for no-body response", () => {
-    expect(output).toMatch(/async adminDeleteMatter\(.*\): Promise<void>/);
-  });
+    it('void return for no-body response', () => {
+        expect(output).toMatch(/async adminDeleteMatter\(.*\): Promise<void>/);
+    });
 
-  it("typed return for 201 response", () => {
-    expect(output).toMatch(/async createItem\(.*\): Promise<DescribedDto>/);
-  });
+    it('typed return for 201 response', () => {
+        expect(output).toMatch(/async createItem\(.*\): Promise<DescribedDto>/);
+    });
 
-  // Type imports
-  it("generates import statement for referenced types", () => {
-    expect(output).toContain('import type {');
-    expect(output).toContain("MatterDto");
-    expect(output).toContain("CreateMatterRequest");
-    expect(output).toContain("DescribedDto");
-    expect(output).toContain('} from "./types";');
-  });
+    // Type imports
+    it('generates import statement for referenced types', () => {
+        expect(output).toContain('import type {');
+        expect(output).toContain('MatterDto');
+        expect(output).toContain('CreateMatterRequest');
+        expect(output).toContain('DescribedDto');
+        expect(output).toContain('} from "./types";');
+    });
 
-  // Operation JSDoc
-  it("emits operation summary as JSDoc", () => {
-    expect(output).toContain("/** List all items");
-  });
+    // Operation JSDoc
+    it('emits operation summary as JSDoc', () => {
+        expect(output).toContain('/** List all items');
+    });
 
-  it("emits operation description in JSDoc body", () => {
-    expect(output).toContain("Returns a paginated list of items matching the filter criteria");
-  });
+    it('emits operation description in JSDoc body', () => {
+        expect(output).toContain('Returns a paginated list of items matching the filter criteria');
+    });
 
-  it("emits HTTP method and path in JSDoc", () => {
-    expect(output).toContain("GET /described/items");
-    expect(output).toContain("POST /described/items");
-  });
+    it('emits HTTP method and path in JSDoc', () => {
+        expect(output).toContain('GET /described/items');
+        expect(output).toContain('POST /described/items');
+    });
 
-  it("emits @param tags with descriptions", () => {
-    expect(output).toContain("@param itemId");
-    expect(output).toContain("The unique item identifier");
-  });
+    it('emits @param tags with descriptions', () => {
+        expect(output).toContain('@param itemId');
+        expect(output).toContain('The unique item identifier');
+    });
 
-  it("emits @param for body with description", () => {
-    expect(output).toContain("@param body");
-  });
+    it('emits @param for body with description', () => {
+        expect(output).toContain('@param body');
+    });
 
-  // Deprecated
-  it("deprecated operation emits @deprecated JSDoc", () => {
-    expect(output).toContain("@deprecated");
-    expect(output).toContain("Delete an item");
-  });
+    // Deprecated
+    it('deprecated operation emits @deprecated JSDoc', () => {
+        expect(output).toContain('@deprecated');
+        expect(output).toContain('Delete an item');
+    });
 });
 
-describe("generateClient — behavioral tests (ensureReady)", () => {
-  const tmpDir = join(import.meta.dir, ".tmp-client-behavioral");
-  let ApiClient: new (...args: unknown[]) => Record<string, unknown>;
+describe('generateClient — behavioral tests (ensureReady)', () => {
+    const tmpDir = join(import.meta.dir, '.tmp-client-behavioral');
+    let ApiClient: new (...args: unknown[]) => Record<string, unknown>;
 
-  beforeAll(async () => {
-    mkdirSync(tmpDir, { recursive: true });
-    const source = generateClient({
-      "/items": {
-        get: { operationId: "listItems" },
-      },
-    } as Record<string, Record<string, OpenApiOperation>>);
-    writeFileSync(join(tmpDir, "client.ts"), source);
-    const mod = await import(join(tmpDir, "client.ts"));
-    ApiClient = mod.ApiClient;
-  });
+    beforeAll(async () => {
+        mkdirSync(tmpDir, { recursive: true });
+        const source = generateClient({
+            '/items': {
+                get: { operationId: 'listItems' },
+            },
+        } as Record<string, Record<string, OpenApiOperation>>);
+        writeFileSync(join(tmpDir, 'client.ts'), source);
+        const mod = await import(join(tmpDir, 'client.ts'));
+        ApiClient = mod.ApiClient;
+    });
 
-  afterAll(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
-  });
+    afterAll(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
 
-  it("rejected ensureReady clears promise cache, allowing retry", async () => {
-    let callCount = 0;
-    const client = new ApiClient("http://example.com", () => ({}));
-    client.ensureReady = async () => {
-      callCount++;
-      if (callCount === 1) throw new Error("transient failure");
-    };
+    it('rejected ensureReady clears promise cache, allowing retry', async () => {
+        let callCount = 0;
+        const client = new ApiClient('http://example.com', () => ({}));
+        client.ensureReady = async () => {
+            callCount++;
 
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("{}", { status: 200 })) as typeof fetch;
+            if (callCount === 1) throw new Error('transient failure');
+        };
 
-    try {
-      // First call — ensureReady rejects
-      await expect((client as any).listItems()).rejects.toThrow("transient failure");
+        const origFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('{}', { status: 200 })) as typeof fetch;
 
-      // Second call — ensureReady succeeds (cache was cleared on rejection)
-      await (client as any).listItems();
-      expect(callCount).toBe(2);
-    } finally {
-      globalThis.fetch = origFetch;
-    }
-  });
+        try {
+            // First call — ensureReady rejects
+            await expect((client as any).listItems()).rejects.toThrow('transient failure');
 
-  it("concurrent requests share the same ensureReady promise", async () => {
-    let callCount = 0;
-    const client = new ApiClient("http://example.com", () => ({}));
-    client.ensureReady = async () => {
-      callCount++;
-      await new Promise(r => setTimeout(r, 10));
-    };
+            // Second call — ensureReady succeeds (cache was cleared on rejection)
+            await (client as any).listItems();
+            expect(callCount).toBe(2);
+        } finally {
+            globalThis.fetch = origFetch;
+        }
+    });
 
-    const origFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("[]", { status: 200 })) as typeof fetch;
+    it('concurrent requests share the same ensureReady promise', async () => {
+        let callCount = 0;
+        const client = new ApiClient('http://example.com', () => ({}));
+        client.ensureReady = async () => {
+            callCount++;
+            await new Promise(r => setTimeout(r, 10));
+        };
 
-    try {
-      await Promise.all([(client as any).listItems(), (client as any).listItems()]);
-      expect(callCount).toBe(1);
-    } finally {
-      globalThis.fetch = origFetch;
-    }
-  });
+        const origFetch = globalThis.fetch;
+        globalThis.fetch = (async () => new Response('[]', { status: 200 })) as typeof fetch;
+
+        try {
+            await Promise.all([(client as any).listItems(), (client as any).listItems()]);
+            expect(callCount).toBe(1);
+        } finally {
+            globalThis.fetch = origFetch;
+        }
+    });
 });

--- a/tests/codegen/command-map.test.ts
+++ b/tests/codegen/command-map.test.ts
@@ -1,198 +1,198 @@
-import { describe, expect, it } from "bun:test";
-import { generateCommandMap } from "../../src/codegen/command-map";
+import { describe, expect, it } from 'bun:test';
+import { generateCommandMap } from '../../src/codegen/command-map';
 import type {
-  OpenApiOperation,
-  OpenApiSchema,
-} from "../../src/codegen/openapi-types";
-import fixture from "../fixtures/petstore.json";
+    OpenApiOperation,
+    OpenApiSchema,
+} from '../../src/codegen/openapi-types';
+import fixture from '../fixtures/petstore.json';
 
 const schemas = fixture.components.schemas as Record<string, any>;
 
-describe("generateCommandMap — unit tests", () => {
-  it("generates correct command path to operationId mapping", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-      "/items/{id}": {
-        get: {
-          operationId: "getItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('"items list"');
-    expect(output).toContain('operationId: "listItems"');
-    expect(output).toContain('"items get"');
-    expect(output).toContain('operationId: "getItem"');
-  });
-
-  it("detects path params correctly", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        get: {
-          operationId: "getItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('pathParams: ["id"]');
-  });
-
-  it("detects query params correctly", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-          parameters: [
-            { name: "page", in: "query", schema: { type: "integer" } },
-            { name: "size", in: "query", schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('queryParams: ["page", "size"]');
-  });
-
-  it("detects hasBody correctly", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        post: {
-          operationId: "createItem",
-          tags: ["items"],
-          requestBody: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateItemDto" },
-              },
+describe('generateCommandMap — unit tests', () => {
+    it('generates correct command path to operationId mapping', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
             },
-          },
-        },
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('"items create": { operationId: "createItem"');
-    expect(output).toContain("hasBody: true");
-    expect(output).toContain('"items list": { operationId: "listItems"');
-    expect(output).toContain("hasBody: false");
-  });
+            '/items/{id}': {
+                get: {
+                    operationId: 'getItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('"items list"');
+        expect(output).toContain('operationId: "listItems"');
+        expect(output).toContain('"items get"');
+        expect(output).toContain('operationId: "getItem"');
+    });
 
-  it("verb deduplication matches command generation", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-      "/items/search": {
-        get: {
-          operationId: "searchItems",
-          tags: ["items"],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('"items list-items"');
-    expect(output).toContain('"items search-items"');
-  });
+    it('detects path params correctly', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                get: {
+                    operationId: 'getItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('pathParams: ["id"]');
+    });
 
-  it("handles multi-level tag grouping", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/admin/users": {
-        get: {
-          operationId: "listAdminUsers",
-          tags: ["Admin : Users"],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain('"admin users list"');
-  });
+    it('detects query params correctly', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'page', in: 'query', schema: { type: 'integer' } },
+                        { name: 'size', in: 'query', schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('queryParams: ["page", "size"]');
+    });
 
-  it("includes CommandMapping interface", () => {
-    const output = generateCommandMap({});
-    expect(output).toContain("export interface CommandMapping");
-    expect(output).toContain("operationId: string;");
-    expect(output).toContain("pathParams: string[];");
-    expect(output).toContain("queryParams: string[];");
-    expect(output).toContain("hasBody: boolean;");
-  });
+    it('detects hasBody correctly', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    tags: ['items'],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/CreateItemDto' },
+                            },
+                        },
+                    },
+                },
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('"items create": { operationId: "createItem"');
+        expect(output).toContain('hasBody: true');
+        expect(output).toContain('"items list": { operationId: "listItems"');
+        expect(output).toContain('hasBody: false');
+    });
 
-  it("exports commandMap as Record<string, CommandMapping>", () => {
-    const output = generateCommandMap({});
-    expect(output).toContain(
-      "export const commandMap: Record<string, CommandMapping>",
-    );
-  });
+    it('verb deduplication matches command generation', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
+            },
+            '/items/search': {
+                get: {
+                    operationId: 'searchItems',
+                    tags: ['items'],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('"items list-items"');
+        expect(output).toContain('"items search-items"');
+    });
 
-  it("includes auto-generated header", () => {
-    const output = generateCommandMap({});
-    expect(output).toContain("// Auto-generated");
-  });
+    it('handles multi-level tag grouping', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/admin/users': {
+                get: {
+                    operationId: 'listAdminUsers',
+                    tags: ['Admin : Users'],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('"admin users list"');
+    });
 
-  it("handles empty path params and query params", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-    };
-    const output = generateCommandMap(paths);
-    expect(output).toContain("pathParams: []");
-    expect(output).toContain("queryParams: []");
-  });
+    it('includes CommandMapping interface', () => {
+        const output = generateCommandMap({});
+        expect(output).toContain('export interface CommandMapping');
+        expect(output).toContain('operationId: string;');
+        expect(output).toContain('pathParams: string[];');
+        expect(output).toContain('queryParams: string[];');
+        expect(output).toContain('hasBody: boolean;');
+    });
+
+    it('exports commandMap as Record<string, CommandMapping>', () => {
+        const output = generateCommandMap({});
+        expect(output).toContain(
+            'export const commandMap: Record<string, CommandMapping>',
+        );
+    });
+
+    it('includes auto-generated header', () => {
+        const output = generateCommandMap({});
+        expect(output).toContain('// Auto-generated');
+    });
+
+    it('handles empty path params and query params', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
+            },
+        };
+        const output = generateCommandMap(paths);
+        expect(output).toContain('pathParams: []');
+        expect(output).toContain('queryParams: []');
+    });
 });
 
-describe("generateCommandMap — petstore fixture", () => {
-  const output = generateCommandMap(fixture.paths as any, schemas);
+describe('generateCommandMap — petstore fixture', () => {
+    const output = generateCommandMap(fixture.paths as any, schemas);
 
-  it("exports a commandMap object", () => {
-    expect(output).toContain("export const commandMap");
-  });
+    it('exports a commandMap object', () => {
+        expect(output).toContain('export const commandMap');
+    });
 
-  it("maps command path to operationId", () => {
-    expect(output).toContain("adminGetMatters");
-  });
+    it('maps command path to operationId', () => {
+        expect(output).toContain('adminGetMatters');
+    });
 
-  it("includes pathParams list", () => {
-    expect(output).toContain('"matterId"');
-  });
+    it('includes pathParams list', () => {
+        expect(output).toContain('"matterId"');
+    });
 
-  it("includes hasBody flag", () => {
-    expect(output).toContain("hasBody: true");
-    expect(output).toContain("hasBody: false");
-  });
+    it('includes hasBody flag', () => {
+        expect(output).toContain('hasBody: true');
+        expect(output).toContain('hasBody: false');
+    });
 
-  it("CommandMapping interface includes description field", () => {
-    expect(output).toContain("description?: string;");
-  });
+    it('CommandMapping interface includes description field', () => {
+        expect(output).toContain('description?: string;');
+    });
 
-  it("includes operation summary as description", () => {
-    expect(output).toContain('description: "List all items"');
-  });
+    it('includes operation summary as description', () => {
+        expect(output).toContain('description: "List all items"');
+    });
 
-  it("omits description when operation has no summary", () => {
-    const adminLine = output.split("\n").find((l) => l.includes("adminGetMatters"));
-    expect(adminLine).not.toContain("description:");
-  });
+    it('omits description when operation has no summary', () => {
+        const adminLine = output.split('\n').find(l => l.includes('adminGetMatters'));
+        expect(adminLine).not.toContain('description:');
+    });
 });

--- a/tests/codegen/commands.test.ts
+++ b/tests/codegen/commands.test.ts
@@ -1,320 +1,320 @@
-import { describe, expect, it } from "bun:test";
-import { generateCommands } from "../../src/codegen/commands";
+import { describe, expect, it } from 'bun:test';
+import { generateCommands } from '../../src/codegen/commands';
 import type {
-  OpenApiOperation,
-  OpenApiSchema,
-} from "../../src/codegen/openapi-types";
-import fixture from "../fixtures/petstore.json";
+    OpenApiOperation,
+    OpenApiSchema,
+} from '../../src/codegen/openapi-types';
+import fixture from '../fixtures/petstore.json';
 
 const schemas = fixture.components.schemas as Record<string, any>;
 
-describe("generateCommands — unit tests", () => {
-  it("groups commands by normalized tags", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/admin/users": {
-        get: {
-          operationId: "listUsers",
-          tags: ["Admin : Users"],
-        },
-      },
-      "/admin/roles": {
-        get: {
-          operationId: "listRoles",
-          tags: ["Admin : Roles"],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("admin")');
-    expect(output).toContain('.command("users")');
-    expect(output).toContain('.command("roles")');
-  });
-
-  it("GET without path params produces list verb", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("list")');
-  });
-
-  it("GET with path params produces get verb", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        get: {
-          operationId: "getItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("get <id>")');
-  });
-
-  it("POST produces create verb", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        post: {
-          operationId: "createItem",
-          tags: ["items"],
-          requestBody: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateItemDto" },
-              },
+describe('generateCommands — unit tests', () => {
+    it('groups commands by normalized tags', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/admin/users': {
+                get: {
+                    operationId: 'listUsers',
+                    tags: ['Admin : Users'],
+                },
             },
-          },
-        },
-      },
-    };
-    const schemas: Record<string, OpenApiSchema> = {
-      CreateItemDto: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-        },
-      },
-    };
-    const output = generateCommands(paths, schemas);
-    expect(output).toContain('.command("create")');
-  });
-
-  it("PUT produces update verb", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        put: {
-          operationId: "updateItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("update <id>")');
-  });
-
-  it("DELETE produces delete verb", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        delete: {
-          operationId: "deleteItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("delete <id>")');
-  });
-
-  it("verb deduplication falls back to operationId kebab-case", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-        },
-      },
-      "/items/search": {
-        get: {
-          operationId: "searchItems",
-          tags: ["items"],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("list-items")');
-    expect(output).toContain('.command("search-items")');
-  });
-
-  it("resolves body props to individual CLI flags", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        post: {
-          operationId: "createItem",
-          tags: ["items"],
-          requestBody: {
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateItemDto" },
-              },
+            '/admin/roles': {
+                get: {
+                    operationId: 'listRoles',
+                    tags: ['Admin : Roles'],
+                },
             },
-          },
-        },
-      },
-    };
-    const schemas: Record<string, OpenApiSchema> = {
-      CreateItemDto: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-          description: { type: "string" },
-          itemCount: { type: "integer" },
-        },
-      },
-    };
-    const output = generateCommands(paths, schemas);
-    expect(output).toContain('--name <value>');
-    expect(output).toContain('--description <value>');
-    expect(output).toContain('--itemCount <value>');
-  });
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("admin")');
+        expect(output).toContain('.command("users")');
+        expect(output).toContain('.command("roles")');
+    });
 
-  it("imports the generic ApiClient class", () => {
-    const output = generateCommands({});
-    expect(output).toContain("ApiClient");
-  });
-
-  it("includes auto-generated header", () => {
-    const output = generateCommands({});
-    expect(output).toContain("// Auto-generated");
-  });
-
-  it("generates query param options", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-          tags: ["items"],
-          parameters: [
-            { name: "page", in: "query", schema: { type: "integer" } },
-            {
-              name: "sort",
-              in: "query",
-              schema: { type: "string", enum: ["asc", "desc"] },
+    it('GET without path params produces list verb', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
             },
-          ],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('--page <page>');
-    expect(output).toContain('--sort <sort>');
-    expect(output).toContain("[asc, desc]");
-  });
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("list")');
+    });
 
-  it("uses default tag when no tags specified", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items": {
-        get: {
-          operationId: "listItems",
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain('.command("default")');
-  });
+    it('GET with path params produces get verb', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                get: {
+                    operationId: 'getItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("get <id>")');
+    });
 
-  it("calls client method with correct arguments in action", () => {
-    const paths: Record<string, Record<string, OpenApiOperation>> = {
-      "/items/{id}": {
-        get: {
-          operationId: "getItem",
-          tags: ["items"],
-          parameters: [
-            { name: "id", in: "path", required: true, schema: { type: "integer" } },
-          ],
-        },
-      },
-    };
-    const output = generateCommands(paths);
-    expect(output).toContain("client.getItem(id)");
-    expect(output).toContain("onResult(result)");
-  });
+    it('POST produces create verb', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    tags: ['items'],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/CreateItemDto' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const schemas: Record<string, OpenApiSchema> = {
+            CreateItemDto: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                },
+            },
+        };
+        const output = generateCommands(paths, schemas);
+        expect(output).toContain('.command("create")');
+    });
+
+    it('PUT produces update verb', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                put: {
+                    operationId: 'updateItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("update <id>")');
+    });
+
+    it('DELETE produces delete verb', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                delete: {
+                    operationId: 'deleteItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("delete <id>")');
+    });
+
+    it('verb deduplication falls back to operationId kebab-case', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                },
+            },
+            '/items/search': {
+                get: {
+                    operationId: 'searchItems',
+                    tags: ['items'],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("list-items")');
+        expect(output).toContain('.command("search-items")');
+    });
+
+    it('resolves body props to individual CLI flags', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    tags: ['items'],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/CreateItemDto' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const schemas: Record<string, OpenApiSchema> = {
+            CreateItemDto: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    description: { type: 'string' },
+                    itemCount: { type: 'integer' },
+                },
+            },
+        };
+        const output = generateCommands(paths, schemas);
+        expect(output).toContain('--name <value>');
+        expect(output).toContain('--description <value>');
+        expect(output).toContain('--itemCount <value>');
+    });
+
+    it('imports the generic ApiClient class', () => {
+        const output = generateCommands({});
+        expect(output).toContain('ApiClient');
+    });
+
+    it('includes auto-generated header', () => {
+        const output = generateCommands({});
+        expect(output).toContain('// Auto-generated');
+    });
+
+    it('generates query param options', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'page', in: 'query', schema: { type: 'integer' } },
+                        {
+                            name: 'sort',
+                            in: 'query',
+                            schema: { type: 'string', enum: ['asc', 'desc'] },
+                        },
+                    ],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('--page <page>');
+        expect(output).toContain('--sort <sort>');
+        expect(output).toContain('[asc, desc]');
+    });
+
+    it('uses default tag when no tags specified', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                get: {
+                    operationId: 'listItems',
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('.command("default")');
+    });
+
+    it('calls client method with correct arguments in action', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items/{id}': {
+                get: {
+                    operationId: 'getItem',
+                    tags: ['items'],
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const output = generateCommands(paths);
+        expect(output).toContain('client.getItem(id)');
+        expect(output).toContain('onResult(result)');
+    });
 });
 
-describe("generateCommands — petstore fixture", () => {
-  const output = generateCommands(fixture.paths as any, schemas);
+describe('generateCommands — petstore fixture', () => {
+    const output = generateCommands(fixture.paths as any, schemas);
 
-  it("accepts onResult callback parameter", () => {
-    expect(output).toContain("onResult: OutputHandler");
-  });
+    it('accepts onResult callback parameter', () => {
+        expect(output).toContain('onResult: OutputHandler');
+    });
 
-  it("creates tag-based subcommand groups", () => {
-    expect(output).toContain('.command("admin")');
-    expect(output).toContain('.command("matters")');
-    expect(output).toContain('.command("users")');
-  });
+    it('creates tag-based subcommand groups', () => {
+        expect(output).toContain('.command("admin")');
+        expect(output).toContain('.command("matters")');
+        expect(output).toContain('.command("users")');
+    });
 
-  it("maps GET collection to list verb", () => {
-    expect(output).toContain('.command("list")');
-  });
+    it('maps GET collection to list verb', () => {
+        expect(output).toContain('.command("list")');
+    });
 
-  it("maps GET with path param to get verb", () => {
-    expect(output).toContain('.command("get');
-  });
+    it('maps GET with path param to get verb', () => {
+        expect(output).toContain('.command("get');
+    });
 
-  it("maps POST to create verb", () => {
-    expect(output).toContain('.command("create")');
-  });
+    it('maps POST to create verb', () => {
+        expect(output).toContain('.command("create")');
+    });
 
-  it("maps DELETE to delete verb", () => {
-    expect(output).toContain('.command("delete');
-  });
+    it('maps DELETE to delete verb', () => {
+        expect(output).toContain('.command("delete');
+    });
 
-  it("adds path params as required arguments", () => {
-    expect(output).toContain("<matterId>");
-  });
+    it('adds path params as required arguments', () => {
+        expect(output).toContain('<matterId>');
+    });
 
-  it("adds query params as options", () => {
-    expect(output).toContain("--status");
-  });
+    it('adds query params as options', () => {
+        expect(output).toContain('--status');
+    });
 
-  // Operation descriptions
-  it("uses operation summary in command description", () => {
-    expect(output).toContain("List all items");
-  });
+    // Operation descriptions
+    it('uses operation summary in command description', () => {
+        expect(output).toContain('List all items');
+    });
 
-  it("includes HTTP method and path in description", () => {
-    expect(output).toContain("GET /described/items");
-  });
+    it('includes HTTP method and path in description', () => {
+        expect(output).toContain('GET /described/items');
+    });
 
-  // Property descriptions on options
-  it("uses property description in option help text", () => {
-    expect(output).toContain("Display name of the item");
-  });
+    // Property descriptions on options
+    it('uses property description in option help text', () => {
+        expect(output).toContain('Display name of the item');
+    });
 
-  // Required flags
-  it("uses requiredOption for required body properties", () => {
-    expect(output).toContain(".requiredOption(");
-    expect(output).toContain("(required)");
-  });
+    // Required flags
+    it('uses requiredOption for required body properties', () => {
+        expect(output).toContain('.requiredOption(');
+        expect(output).toContain('(required)');
+    });
 
-  // readOnly exclusion
-  it("excludes readOnly properties from CLI flags", () => {
-    const describedCreateBlock = output.split('"createItem"')[1]?.split(".action(")[0] || "";
-    expect(describedCreateBlock).not.toContain("--id ");
-    expect(describedCreateBlock).not.toContain("--created-on");
-  });
+    // readOnly exclusion
+    it('excludes readOnly properties from CLI flags', () => {
+        const describedCreateBlock = output.split('"createItem"')[1]?.split('.action(')[0] || '';
+        expect(describedCreateBlock).not.toContain('--id ');
+        expect(describedCreateBlock).not.toContain('--created-on');
+    });
 
-  // Format hints
-  it("includes format hint in option description", () => {
-    expect(output).toContain("(email)");
-  });
+    // Format hints
+    it('includes format hint in option description', () => {
+        expect(output).toContain('(email)');
+    });
 
-  // Default values
-  it("includes default value in option description", () => {
-    expect(output).toContain("(default: 0)");
-  });
+    // Default values
+    it('includes default value in option description', () => {
+        expect(output).toContain('(default: 0)');
+    });
 
-  // Deprecated
-  it("marks deprecated operations in description", () => {
-    expect(output).toContain("[DEPRECATED]");
-  });
+    // Deprecated
+    it('marks deprecated operations in description', () => {
+        expect(output).toContain('[DEPRECATED]');
+    });
 
-  // Query param descriptions
-  it("uses query parameter description in option help", () => {
-    expect(output).toContain("Page number to retrieve");
-  });
+    // Query param descriptions
+    it('uses query parameter description in option help', () => {
+        expect(output).toContain('Page number to retrieve');
+    });
 });

--- a/tests/codegen/edge-cases.test.ts
+++ b/tests/codegen/edge-cases.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from "bun:test";
-import { generateTypes } from "../../src/codegen/types";
-import { generateClient } from "../../src/codegen/client";
-import { generateCommands } from "../../src/codegen/commands";
-import { generateCommandMap } from "../../src/codegen/command-map";
-import fixture from "../fixtures/edge-cases.json";
+import { describe, it, expect } from 'bun:test';
+import { generateTypes } from '../../src/codegen/types';
+import { generateClient } from '../../src/codegen/client';
+import { generateCommands } from '../../src/codegen/commands';
+import { generateCommandMap } from '../../src/codegen/command-map';
+import fixture from '../fixtures/edge-cases.json';
 
 const schemas = fixture.components.schemas as Record<string, any>;
 const paths = fixture.paths as Record<string, any>;
@@ -15,290 +15,291 @@ const commandMapOutput = generateCommandMap(paths, schemas);
 
 // -- 1. Recursive/Circular Structures --
 
-describe("edge cases: recursive/circular structures", () => {
-  it("self-referencing schema resolves to type name", () => {
-    expect(typesOutput).toContain("export interface TreeNode {");
-    expect(typesOutput).toMatch(/children\??: TreeNode\[\]/);
-  });
+describe('edge cases: recursive/circular structures', () => {
+    it('self-referencing schema resolves to type name', () => {
+        expect(typesOutput).toContain('export interface TreeNode {');
+        expect(typesOutput).toMatch(/children\??: TreeNode\[\]/);
+    });
 
-  it("indirect cycle resolves to type names", () => {
-    expect(typesOutput).toContain("export interface CycleA {");
-    expect(typesOutput).toContain("export interface CycleB {");
-    expect(typesOutput).toMatch(/b\??: CycleB/);
-    expect(typesOutput).toMatch(/a\??: CycleA/);
-  });
+    it('indirect cycle resolves to type names', () => {
+        expect(typesOutput).toContain('export interface CycleA {');
+        expect(typesOutput).toContain('export interface CycleB {');
+        expect(typesOutput).toMatch(/b\??: CycleB/);
+        expect(typesOutput).toMatch(/a\??: CycleA/);
+    });
 
-  it("multi-hop ref chain resolves correctly", () => {
-    expect(typesOutput).toMatch(/next\??: ChainB/);
-    expect(typesOutput).toMatch(/next\??: ChainC/);
-    expect(typesOutput).toContain("export interface ChainC {");
-  });
+    it('multi-hop ref chain resolves correctly', () => {
+        expect(typesOutput).toMatch(/next\??: ChainB/);
+        expect(typesOutput).toMatch(/next\??: ChainC/);
+        expect(typesOutput).toContain('export interface ChainC {');
+    });
 
-  it("generators do not crash on recursive schemas", () => {
-    expect(typesOutput).toBeTruthy();
-    expect(clientOutput).toBeTruthy();
-    expect(commandsOutput).toBeTruthy();
-    expect(commandMapOutput).toBeTruthy();
-  });
+    it('generators do not crash on recursive schemas', () => {
+        expect(typesOutput).toBeTruthy();
+        expect(clientOutput).toBeTruthy();
+        expect(commandsOutput).toBeTruthy();
+        expect(commandMapOutput).toBeTruthy();
+    });
 });
 
 // -- 2. Composition Edge Cases --
 
-describe("edge cases: composition", () => {
-  it("allOf with 3 parts including inline schema", () => {
-    expect(typesOutput).toContain("export type TripleAllOf =");
-    expect(typesOutput).toContain("ChainA");
-    expect(typesOutput).toContain("ChainB");
-    expect(typesOutput).toMatch(/extra: string/);
-  });
+describe('edge cases: composition', () => {
+    it('allOf with 3 parts including inline schema', () => {
+        expect(typesOutput).toContain('export type TripleAllOf =');
+        expect(typesOutput).toContain('ChainA');
+        expect(typesOutput).toContain('ChainB');
+        expect(typesOutput).toMatch(/extra: string/);
+    });
 
-  it("allOf where one part is an enum", () => {
-    expect(typesOutput).toContain("export type AllOfWithEnum =");
-    expect(typesOutput).toContain("LargeEnum");
-  });
+    it('allOf where one part is an enum', () => {
+        expect(typesOutput).toContain('export type AllOfWithEnum =');
+        expect(typesOutput).toContain('LargeEnum');
+    });
 
-  it("oneOf with single variant unwraps or produces single-element union", () => {
-    expect(typesOutput).toContain("SingleVariantOneOf");
-    expect(typesOutput).toContain("TreeNode");
-  });
+    it('oneOf with single variant unwraps or produces single-element union', () => {
+        expect(typesOutput).toContain('SingleVariantOneOf');
+        expect(typesOutput).toContain('TreeNode');
+    });
 
-  it("anyOf produces union type same as oneOf", () => {
-    expect(typesOutput).toContain("export type AnyOfExample =");
-    expect(typesOutput).toContain("ChainA");
-    expect(typesOutput).toContain("ChainB");
-  });
+    it('anyOf produces union type same as oneOf', () => {
+        expect(typesOutput).toContain('export type AnyOfExample =');
+        expect(typesOutput).toContain('ChainA');
+        expect(typesOutput).toContain('ChainB');
+    });
 
-  it("oneOf with inline schemas resolves inline variants", () => {
-    const block = typesOutput.split("InlineOneOf")[1]?.split("\n\n")[0] || "";
-    expect(block).toContain("alphaField");
-    expect(block).toContain("betaField");
-  });
+    it('oneOf with inline schemas resolves inline variants', () => {
+        const block = typesOutput.split('InlineOneOf')[1]?.split('\n\n')[0] || '';
+        expect(block).toContain('alphaField');
+        expect(block).toContain('betaField');
+    });
 
-  it("discriminator without mapping derives values from schema names", () => {
-    expect(typesOutput).toContain("DiscriminatorNoMapping");
-    expect(typesOutput).toContain("nodeType");
-    expect(typesOutput).toContain("ChainA");
-    expect(typesOutput).toContain("ChainB");
-  });
+    it('discriminator without mapping derives values from schema names', () => {
+        expect(typesOutput).toContain('DiscriminatorNoMapping');
+        expect(typesOutput).toContain('nodeType');
+        expect(typesOutput).toContain('ChainA');
+        expect(typesOutput).toContain('ChainB');
+    });
 
-  it("nested composition — property with allOf type", () => {
-    expect(typesOutput).toContain("export interface NestedComposition {");
-    const block = typesOutput.split("export interface NestedComposition")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("nested");
-    expect(block).toContain("TreeNode");
-  });
+    it('nested composition — property with allOf type', () => {
+        expect(typesOutput).toContain('export interface NestedComposition {');
+        const block = typesOutput.split('export interface NestedComposition')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('nested');
+        expect(block).toContain('TreeNode');
+    });
 });
 
 // -- 3. Inline/Anonymous Schemas --
 
-describe("edge cases: inline/anonymous schemas", () => {
-  it("deeply nested objects hit depth cap", () => {
-    const block = typesOutput.split("export interface DeeplyNested")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("level1");
-    expect(block).toContain("level2");
-    expect(block).toContain("level3");
-    expect(block).toContain("Record<string, unknown>");
-  });
+describe('edge cases: inline/anonymous schemas', () => {
+    it('deeply nested objects hit depth cap', () => {
+        const block = typesOutput.split('export interface DeeplyNested')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('level1');
+        expect(block).toContain('level2');
+        expect(block).toContain('level3');
+        expect(block).toContain('Record<string, unknown>');
+    });
 
-  it("array items with inline object schema", () => {
-    const block = typesOutput.split("export interface InlineArrayItems")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("id");
-    expect(block).toContain("name");
-  });
+    it('array items with inline object schema', () => {
+        const block = typesOutput.split('export interface InlineArrayItems')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('id');
+        expect(block).toContain('name');
+    });
 
-  it("additionalProperties only — no named properties", () => {
-    expect(typesOutput).toContain("export interface AdditionalPropsOnly {");
-    expect(typesOutput).toContain("[key: string]:");
-  });
+    it('additionalProperties only — no named properties', () => {
+        expect(typesOutput).toContain('export interface AdditionalPropsOnly {');
+        expect(typesOutput).toContain('[key: string]:');
+    });
 
-  it("additionalProperties: true", () => {
-    const block = typesOutput.split("export interface AdditionalPropsTrue")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("name?: string");
-    expect(block).toContain("[key: string]: unknown");
-  });
+    it('additionalProperties: true', () => {
+        const block = typesOutput.split('export interface AdditionalPropsTrue')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('name?: string');
+        expect(block).toContain('[key: string]: unknown');
+    });
 
-  it("additionalProperties: false — no index signature", () => {
-    const block = typesOutput.split("export interface AdditionalPropsFalse")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("name?: string");
-    expect(block).not.toContain("[key: string]");
-  });
+    it('additionalProperties: false — no index signature', () => {
+        const block = typesOutput.split('export interface AdditionalPropsFalse')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('name?: string');
+        expect(block).not.toContain('[key: string]');
+    });
 
-  it("additionalProperties type conflict does not crash", () => {
-    const block = typesOutput.split("export interface AdditionalPropsConflict")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("name");
-    expect(block).toContain("count");
-  });
+    it('additionalProperties type conflict does not crash', () => {
+        const block = typesOutput.split('export interface AdditionalPropsConflict')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('name');
+        expect(block).toContain('count');
+    });
 });
 
 // -- 4. Metadata Stress --
 
-describe("edge cases: metadata stress", () => {
-  it("all constraints in one JSDoc block", () => {
-    expect(typesOutput).toContain("@format double");
-    expect(typesOutput).toContain("@minimum 0");
-    expect(typesOutput).toContain("@maximum 100");
-    expect(typesOutput).toContain("@exclusiveMinimum 0");
-    expect(typesOutput).toContain("@exclusiveMaximum 100");
-    expect(typesOutput).toContain("@default 50");
-    expect(typesOutput).toContain("@example 42.5");
-  });
+describe('edge cases: metadata stress', () => {
+    it('all constraints in one JSDoc block', () => {
+        expect(typesOutput).toContain('@format double');
+        expect(typesOutput).toContain('@minimum 0');
+        expect(typesOutput).toContain('@maximum 100');
+        expect(typesOutput).toContain('@exclusiveMinimum 0');
+        expect(typesOutput).toContain('@exclusiveMaximum 100');
+        expect(typesOutput).toContain('@default 50');
+        expect(typesOutput).toContain('@example 42.5');
+    });
 
-  it("description with */ does not break JSDoc", () => {
-    expect(typesOutput).toContain("*\\/");
-  });
+    it('description with */ does not break JSDoc', () => {
+        expect(typesOutput).toContain('*\\/');
+    });
 
-  it("description with quotes survives in output", () => {
-    expect(typesOutput).toContain("quotes");
-  });
+    it('description with quotes survives in output', () => {
+        expect(typesOutput).toContain('quotes');
+    });
 
-  it("HTML in description passes through", () => {
-    expect(typesOutput).toContain("<b>HTML</b>");
-  });
+    it('HTML in description passes through', () => {
+        expect(typesOutput).toContain('<b>HTML</b>');
+    });
 
-  it("multiline description splits into multi-line JSDoc", () => {
-    expect(typesOutput).toContain("Line one");
-    expect(typesOutput).toContain("Line two");
-    expect(typesOutput).toContain("Line three");
-  });
+    it('multiline description splits into multi-line JSDoc', () => {
+        expect(typesOutput).toContain('Line one');
+        expect(typesOutput).toContain('Line two');
+        expect(typesOutput).toContain('Line three');
+    });
 
-  it("uniqueItems emits @uniqueItems tag", () => {
-    expect(typesOutput).toContain("@uniqueItems");
-  });
+    it('uniqueItems emits @uniqueItems tag', () => {
+        expect(typesOutput).toContain('@uniqueItems');
+    });
 
-  it("object default value serialized as JSON", () => {
-    expect(typesOutput).toMatch(/@default.*key.*value/);
-  });
+    it('object default value serialized as JSON', () => {
+        expect(typesOutput).toMatch(/@default.*key.*value/);
+    });
 
-  it("boolean exclusiveMinimum (OAS 3.0 style)", () => {
-    expect(typesOutput).toContain("@exclusiveMinimum true");
-  });
+    it('boolean exclusiveMinimum (OAS 3.0 style)', () => {
+        expect(typesOutput).toContain('@exclusiveMinimum true');
+    });
 
-  it("large enum generates all 50 values", () => {
-    expect(typesOutput).toContain('export type LargeEnum =');
-    expect(typesOutput).toContain('"V01"');
-    expect(typesOutput).toContain('"V50"');
-    const enumLine = typesOutput.split("export type LargeEnum =")[1]?.split(";")[0] || "";
-    const valueCount = (enumLine.match(/"/g) || []).length / 2;
-    expect(valueCount).toBe(50);
-  });
+    it('large enum generates all 50 values', () => {
+        expect(typesOutput).toContain('export type LargeEnum =');
+        expect(typesOutput).toContain('"V01"');
+        expect(typesOutput).toContain('"V50"');
+        const enumLine = typesOutput.split('export type LargeEnum =')[1]?.split(';')[0] || '';
+        const valueCount = (enumLine.match(/"/g) || []).length / 2;
+        expect(valueCount).toBe(50);
+    });
 
-  it("empty schema does not crash", () => {
-    expect(typesOutput).toBeTruthy();
-  });
+    it('empty schema does not crash', () => {
+        expect(typesOutput).toBeTruthy();
+    });
 });
 
 // -- 5. Naming/Dedup --
 
-describe("edge cases: naming/dedup", () => {
-  it("duplicate CLI flags are deduplicated", () => {
-    expect(commandsOutput).toBeTruthy();
-  });
+describe('edge cases: naming/dedup', () => {
+    it('duplicate CLI flags are deduplicated', () => {
+        expect(commandsOutput).toBeTruthy();
+    });
 
-  it("reserved word properties are valid in TypeScript interfaces", () => {
-    const block = typesOutput.split("export interface ReservedWord")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("type?: string");
-    expect(block).toContain("function?: string");
-    expect(block).toContain("class?: string");
-  });
+    it('reserved word properties are valid in TypeScript interfaces', () => {
+        const block = typesOutput.split('export interface ReservedWord')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('type?: string');
+        expect(block).toContain('function?: string');
+        expect(block).toContain('class?: string');
+    });
 });
 
 // -- 6. Operations --
 
-describe("edge cases: operations", () => {
-  it("operation without operationId is skipped in client", () => {
-    expect(clientOutput).not.toContain("async undefined(");
-  });
+describe('edge cases: operations', () => {
+    it('operation without operationId is skipped in client', () => {
+        expect(clientOutput).not.toContain('async undefined(');
+    });
 
-  it("operation without operationId is skipped in command map", () => {
-    expect(commandMapOutput).not.toContain("no-operation-id");
-  });
+    it('operation without operationId is skipped in command map', () => {
+        expect(commandMapOutput).not.toContain('no-operation-id');
+    });
 
-  it("operation without tags goes into default group", () => {
-    expect(commandsOutput).toContain("noTagsOp");
-    expect(commandsOutput).toContain('"default"');
-  });
+    it('operation without tags goes into default group', () => {
+        expect(commandsOutput).toContain('noTagsOp');
+        expect(commandsOutput).toContain('"default"');
+    });
 
-  it("operation with multiple tags uses first tag", () => {
-    expect(commandsOutput).toContain("multiTagOp");
-    expect(commandMapOutput).toContain("multiTagOp");
-  });
+    it('operation with multiple tags uses first tag', () => {
+        expect(commandsOutput).toContain('multiTagOp');
+        expect(commandMapOutput).toContain('multiTagOp');
+    });
 
-  it("multiple response codes — 200 preferred over 201", () => {
-    expect(clientOutput).toMatch(/multiResponseOp.*Promise<ChainA>/);
-  });
+    it('multiple response codes — 200 preferred over 201', () => {
+        expect(clientOutput).toMatch(/multiResponseOp.*Promise<ChainA>/);
+    });
 
-  it("empty responses returns void", () => {
-    expect(clientOutput).toMatch(/noResponseOp.*Promise<void>/);
-  });
+    it('empty responses returns void', () => {
+        expect(clientOutput).toMatch(/noResponseOp.*Promise<void>/);
+    });
 
-  it("primitive body produces -B flag", () => {
-    expect(clientOutput).toContain("primitiveBodyOp");
-    expect(commandsOutput).toContain('.option("-B <value>", "Body value (string)")');
-    expect(commandsOutput).toContain("opts.B");
-  });
+    it('primitive body produces -B flag', () => {
+        expect(clientOutput).toContain('primitiveBodyOp');
+        expect(commandsOutput).toContain('.option("-B <value>", "Body value (string)")');
+        expect(commandsOutput).toContain('opts.B');
+    });
 
-  it("primitive array body produces -B flag for comma-separated values", () => {
-    expect(clientOutput).toContain("primitiveArrayBodyOp");
-    expect(commandsOutput).toContain('.option("-B <values>", "Comma-separated string values")');
-    expect(commandsOutput).toContain("(opts.B as string).split");
-  });
+    it('primitive array body produces -B flag for comma-separated values', () => {
+        expect(clientOutput).toContain('primitiveArrayBodyOp');
+        expect(commandsOutput).toContain('.option("-B <values>", "Comma-separated string values")');
+        expect(commandsOutput).toContain('(opts.B as string).split');
+    });
 
-  it("array body produces array parameter", () => {
-    expect(clientOutput).toContain("arrayBodyOp");
-    expect(commandsOutput).toContain("array");
-  });
+    it('array body produces array parameter', () => {
+        expect(clientOutput).toContain('arrayBodyOp');
+        expect(commandsOutput).toContain('array');
+    });
 
-  it("all-readOnly body produces zero body prop flags", () => {
-    const idx = commandsOutput.indexOf("client.allReadonlyBodyOp");
-    const preceding = commandsOutput.lastIndexOf('.command("', idx);
-    const block = commandsOutput.substring(preceding, idx);
-    expect(block).not.toContain("--body");
-    expect(block).not.toContain("--body-file");
-    expect(block).not.toContain('"--id ');
-    expect(block).not.toContain("--created-at");
-  });
+    it('all-readOnly body produces zero body prop flags', () => {
+        const idx = commandsOutput.indexOf('client.allReadonlyBodyOp');
+        const preceding = commandsOutput.lastIndexOf('.command("', idx);
+        const block = commandsOutput.substring(preceding, idx);
+        expect(block).not.toContain('--body');
+        expect(block).not.toContain('--body-file');
+        expect(block).not.toContain('"--id ');
+        expect(block).not.toContain('--created-at');
+    });
 
-  it("inline response type is handled", () => {
-    expect(clientOutput).toContain("inlineResponseOp");
-  });
+    it('inline response type is handled', () => {
+        expect(clientOutput).toContain('inlineResponseOp');
+    });
 
-  it("inline body type is handled", () => {
-    expect(clientOutput).toContain("inlineBodyOp");
-    expect(commandsOutput).toContain("inlineBodyOp");
-  });
+    it('inline body type is handled', () => {
+        expect(clientOutput).toContain('inlineBodyOp');
+        expect(commandsOutput).toContain('inlineBodyOp');
+    });
 
-  it("union response type imports constituent types", () => {
-    expect(clientOutput).toContain("unionResponseOp");
-    const importLine = clientOutput.split("\n").find((l: string) => l.startsWith("import type"));
-    if (importLine) {
-      expect(importLine).toContain("ChainA");
-      expect(importLine).toContain("ChainB");
-    }
-  });
+    it('union response type imports constituent types', () => {
+        expect(clientOutput).toContain('unionResponseOp');
+        const importLine = clientOutput.split('\n').find((l: string) => l.startsWith('import type'));
 
-  it("shared path parameters are inherited by operations", () => {
-    expect(clientOutput).toContain("sharedParamGet");
-    expect(clientOutput).toContain("sharedParamDelete");
-  });
+        if (importLine) {
+            expect(importLine).toContain('ChainA');
+            expect(importLine).toContain('ChainB');
+        }
+    });
 
-  it("rich query param has description, enum, default, and format", () => {
-    const idx = commandsOutput.indexOf("client.richQueryOp");
-    const preceding = commandsOutput.lastIndexOf('.command("', idx);
-    const block = commandsOutput.substring(preceding, idx);
-    expect(block).toContain("Filter by status");
-    expect(block).toContain("active");
-    expect(block).toContain("inactive");
-    expect(block).toContain("pending");
-    expect(block).toContain("default: active");
-    expect(block).toContain("custom-status");
-  });
+    it('shared path parameters are inherited by operations', () => {
+        expect(clientOutput).toContain('sharedParamGet');
+        expect(clientOutput).toContain('sharedParamDelete');
+    });
 
-  it("dangerous summary with quotes is escaped in commands", () => {
-    expect(commandsOutput).toContain("dangerousSummaryOp");
-    expect(commandsOutput).toContain("quotes");
-  });
+    it('rich query param has description, enum, default, and format', () => {
+        const idx = commandsOutput.indexOf('client.richQueryOp');
+        const preceding = commandsOutput.lastIndexOf('.command("', idx);
+        const block = commandsOutput.substring(preceding, idx);
+        expect(block).toContain('Filter by status');
+        expect(block).toContain('active');
+        expect(block).toContain('inactive');
+        expect(block).toContain('pending');
+        expect(block).toContain('default: active');
+        expect(block).toContain('custom-status');
+    });
 
-  it("command map has description for operations with summary", () => {
-    expect(commandMapOutput).toContain('description: "Query param with everything"');
-  });
+    it('dangerous summary with quotes is escaped in commands', () => {
+        expect(commandsOutput).toContain('dangerousSummaryOp');
+        expect(commandsOutput).toContain('quotes');
+    });
+
+    it('command map has description for operations with summary', () => {
+        expect(commandMapOutput).toContain('description: "Query param with everything"');
+    });
 });

--- a/tests/codegen/generate.test.ts
+++ b/tests/codegen/generate.test.ts
@@ -1,195 +1,195 @@
-import { describe, expect, it, beforeEach, afterEach } from "bun:test";
-import { generate } from "../../src/codegen/index";
-import { existsSync, rmSync } from "fs";
-import { mkdtemp } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { generate } from '../../src/codegen/index';
+import { existsSync, rmSync } from 'fs';
+import { mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 const minimalSpec = {
-  paths: {
-    "/items": {
-      get: {
-        operationId: "listItems",
-        tags: ["items"],
-        parameters: [
-          {
-            name: "page",
-            in: "query" as const,
-            schema: { type: "integer" },
-          },
-        ],
-        responses: { "200": { description: "OK" } },
-      },
-      post: {
-        operationId: "createItem",
-        tags: ["items"],
-        requestBody: {
-          content: {
-            "application/json": {
-              schema: { $ref: "#/components/schemas/Item" },
+    paths: {
+        '/items': {
+            get: {
+                operationId: 'listItems',
+                tags: ['items'],
+                parameters: [
+                    {
+                        name: 'page',
+                        in: 'query' as const,
+                        schema: { type: 'integer' },
+                    },
+                ],
+                responses: { 200: { description: 'OK' } },
             },
-          },
+            post: {
+                operationId: 'createItem',
+                tags: ['items'],
+                requestBody: {
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/Item' },
+                        },
+                    },
+                },
+                responses: { 201: { description: 'Created' } },
+            },
         },
-        responses: { "201": { description: "Created" } },
-      },
-    },
-    "/items/{id}": {
-      get: {
-        operationId: "getItem",
-        tags: ["items"],
-        parameters: [
-          {
-            name: "id",
-            in: "path" as const,
-            required: true,
-            schema: { type: "integer" },
-          },
-        ],
-        responses: { "200": { description: "OK" } },
-      },
-      delete: {
-        operationId: "deleteItem",
-        tags: ["items"],
-        parameters: [
-          {
-            name: "id",
-            in: "path" as const,
-            required: true,
-            schema: { type: "integer" },
-          },
-        ],
-        responses: { "204": { description: "Deleted" } },
-      },
-    },
-  },
-  components: {
-    schemas: {
-      Item: {
-        type: "object",
-        properties: {
-          id: { type: "integer" },
-          name: { type: "string" },
-          active: { type: "boolean" },
+        '/items/{id}': {
+            get: {
+                operationId: 'getItem',
+                tags: ['items'],
+                parameters: [
+                    {
+                        name: 'id',
+                        in: 'path' as const,
+                        required: true,
+                        schema: { type: 'integer' },
+                    },
+                ],
+                responses: { 200: { description: 'OK' } },
+            },
+            delete: {
+                operationId: 'deleteItem',
+                tags: ['items'],
+                parameters: [
+                    {
+                        name: 'id',
+                        in: 'path' as const,
+                        required: true,
+                        schema: { type: 'integer' },
+                    },
+                ],
+                responses: { 204: { description: 'Deleted' } },
+            },
         },
-      },
-      Status: {
-        enum: ["ACTIVE", "INACTIVE"],
-      },
     },
-  },
+    components: {
+        schemas: {
+            Item: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                    name: { type: 'string' },
+                    active: { type: 'boolean' },
+                },
+            },
+            Status: {
+                enum: ['ACTIVE', 'INACTIVE'],
+            },
+        },
+    },
 };
 
-describe("generate", () => {
-  let outDir: string;
+describe('generate', () => {
+    let outDir: string;
 
-  beforeEach(async () => {
-    outDir = await mkdtemp(join(tmpdir(), "swagger-jack-test-"));
-  });
+    beforeEach(async () => {
+        outDir = await mkdtemp(join(tmpdir(), 'swagger-jack-test-'));
+    });
 
-  afterEach(() => {
-    if (outDir && existsSync(outDir)) {
-      rmSync(outDir, { recursive: true, force: true });
-    }
-  });
+    afterEach(() => {
+        if (outDir && existsSync(outDir)) {
+            rmSync(outDir, { recursive: true, force: true });
+        }
+    });
 
-  it("writes all 4 files to outDir", async () => {
-    await generate({ spec: minimalSpec, outDir });
+    it('writes all 4 files to outDir', async () => {
+        await generate({ spec: minimalSpec, outDir });
 
-    expect(existsSync(join(outDir, "types.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "client.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "commands.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "command-map.ts"))).toBe(true);
-  });
+        expect(existsSync(join(outDir, 'types.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'client.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'commands.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'command-map.ts'))).toBe(true);
+    });
 
-  it("creates outDir if it does not exist", async () => {
-    const nested = join(outDir, "deep", "nested", "dir");
-    expect(existsSync(nested)).toBe(false);
+    it('creates outDir if it does not exist', async () => {
+        const nested = join(outDir, 'deep', 'nested', 'dir');
+        expect(existsSync(nested)).toBe(false);
 
-    await generate({ spec: minimalSpec, outDir: nested });
+        await generate({ spec: minimalSpec, outDir: nested });
 
-    expect(existsSync(nested)).toBe(true);
-    expect(existsSync(join(nested, "types.ts"))).toBe(true);
-    expect(existsSync(join(nested, "client.ts"))).toBe(true);
-    expect(existsSync(join(nested, "commands.ts"))).toBe(true);
-    expect(existsSync(join(nested, "command-map.ts"))).toBe(true);
-  });
+        expect(existsSync(nested)).toBe(true);
+        expect(existsSync(join(nested, 'types.ts'))).toBe(true);
+        expect(existsSync(join(nested, 'client.ts'))).toBe(true);
+        expect(existsSync(join(nested, 'commands.ts'))).toBe(true);
+        expect(existsSync(join(nested, 'command-map.ts'))).toBe(true);
+    });
 
-  it("types.ts contains interfaces and type declarations", async () => {
-    await generate({ spec: minimalSpec, outDir });
-    const content = await Bun.file(join(outDir, "types.ts")).text();
+    it('types.ts contains interfaces and type declarations', async () => {
+        await generate({ spec: minimalSpec, outDir });
+        const content = await Bun.file(join(outDir, 'types.ts')).text();
 
-    expect(content).toContain("// Auto-generated");
-    expect(content).toContain("export interface Item {");
-    expect(content).toContain("  id?: number;");
-    expect(content).toContain("  name?: string;");
-    expect(content).toContain("  active?: boolean;");
-    expect(content).toContain('export type Status = "ACTIVE" | "INACTIVE";');
-  });
+        expect(content).toContain('// Auto-generated');
+        expect(content).toContain('export interface Item {');
+        expect(content).toContain('  id?: number;');
+        expect(content).toContain('  name?: string;');
+        expect(content).toContain('  active?: boolean;');
+        expect(content).toContain('export type Status = "ACTIVE" | "INACTIVE";');
+    });
 
-  it("client.ts contains ApiClient class", async () => {
-    await generate({ spec: minimalSpec, outDir });
-    const content = await Bun.file(join(outDir, "client.ts")).text();
+    it('client.ts contains ApiClient class', async () => {
+        await generate({ spec: minimalSpec, outDir });
+        const content = await Bun.file(join(outDir, 'client.ts')).text();
 
-    expect(content).toContain("// Auto-generated");
-    expect(content).toContain("export class ApiClient");
-    expect(content).toContain("HeadersProvider");
-    expect(content).toContain("listItems");
-    expect(content).toContain("getItem");
-    expect(content).toContain("createItem");
-    expect(content).toContain("deleteItem");
-    // Should NOT contain HardcodedClient
-    expect(content).not.toContain("HardcodedClient");
-  });
+        expect(content).toContain('// Auto-generated');
+        expect(content).toContain('export class ApiClient');
+        expect(content).toContain('HeadersProvider');
+        expect(content).toContain('listItems');
+        expect(content).toContain('getItem');
+        expect(content).toContain('createItem');
+        expect(content).toContain('deleteItem');
+        // Should NOT contain HardcodedClient
+        expect(content).not.toContain('HardcodedClient');
+    });
 
-  it("commands.ts contains registerGeneratedCommands", async () => {
-    await generate({ spec: minimalSpec, outDir });
-    const content = await Bun.file(join(outDir, "commands.ts")).text();
+    it('commands.ts contains registerGeneratedCommands', async () => {
+        await generate({ spec: minimalSpec, outDir });
+        const content = await Bun.file(join(outDir, 'commands.ts')).text();
 
-    expect(content).toContain("// Auto-generated");
-    expect(content).toContain("registerGeneratedCommands");
-  });
+        expect(content).toContain('// Auto-generated');
+        expect(content).toContain('registerGeneratedCommands');
+    });
 
-  it("command-map.ts contains commandMap export", async () => {
-    await generate({ spec: minimalSpec, outDir });
-    const content = await Bun.file(join(outDir, "command-map.ts")).text();
+    it('command-map.ts contains commandMap export', async () => {
+        await generate({ spec: minimalSpec, outDir });
+        const content = await Bun.file(join(outDir, 'command-map.ts')).text();
 
-    expect(content).toContain("// Auto-generated");
-    expect(content).toContain("commandMap");
-  });
+        expect(content).toContain('// Auto-generated');
+        expect(content).toContain('commandMap');
+    });
 
-  it("handles spec with no schemas", async () => {
-    const specNoSchemas = {
-      paths: {
-        "/health": {
-          get: {
-            operationId: "healthCheck",
-            tags: ["system"],
-            responses: { "200": { description: "OK" } },
-          },
-        },
-      },
-    };
+    it('handles spec with no schemas', async () => {
+        const specNoSchemas = {
+            paths: {
+                '/health': {
+                    get: {
+                        operationId: 'healthCheck',
+                        tags: ['system'],
+                        responses: { 200: { description: 'OK' } },
+                    },
+                },
+            },
+        };
 
-    await generate({ spec: specNoSchemas, outDir });
+        await generate({ spec: specNoSchemas, outDir });
 
-    const types = await Bun.file(join(outDir, "types.ts")).text();
-    expect(types).toContain("// Auto-generated");
+        const types = await Bun.file(join(outDir, 'types.ts')).text();
+        expect(types).toContain('// Auto-generated');
 
-    const client = await Bun.file(join(outDir, "client.ts")).text();
-    expect(client).toContain("healthCheck");
-  });
+        const client = await Bun.file(join(outDir, 'client.ts')).text();
+        expect(client).toContain('healthCheck');
+    });
 
-  it("handles spec with empty paths", async () => {
-    const emptySpec = {
-      paths: {},
-      components: { schemas: {} },
-    };
+    it('handles spec with empty paths', async () => {
+        const emptySpec = {
+            paths: {},
+            components: { schemas: {} },
+        };
 
-    await generate({ spec: emptySpec, outDir });
+        await generate({ spec: emptySpec, outDir });
 
-    expect(existsSync(join(outDir, "types.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "client.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "commands.ts"))).toBe(true);
-    expect(existsSync(join(outDir, "command-map.ts"))).toBe(true);
-  });
+        expect(existsSync(join(outDir, 'types.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'client.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'commands.ts'))).toBe(true);
+        expect(existsSync(join(outDir, 'command-map.ts'))).toBe(true);
+    });
 });

--- a/tests/codegen/jsdoc.test.ts
+++ b/tests/codegen/jsdoc.test.ts
@@ -1,161 +1,161 @@
-import { describe, it, expect } from "bun:test";
-import { buildJsDoc } from "../../src/codegen/util";
+import { describe, it, expect } from 'bun:test';
+import { buildJsDoc } from '../../src/codegen/util';
 
-describe("buildJsDoc", () => {
-  it("returns empty array when no metadata", () => {
-    expect(buildJsDoc({})).toEqual([]);
-  });
-
-  it("returns empty array for schema with only type", () => {
-    expect(buildJsDoc({ type: "string" })).toEqual([]);
-  });
-
-  it("single-line JSDoc for description only", () => {
-    const result = buildJsDoc({ description: "A simple description" });
-    expect(result).toEqual(["/** A simple description */"]);
-  });
-
-  it("multi-line JSDoc for description + tags", () => {
-    const result = buildJsDoc({
-      description: "Quality score",
-      minimum: 0,
-      maximum: 100,
-      default: 50,
+describe('buildJsDoc', () => {
+    it('returns empty array when no metadata', () => {
+        expect(buildJsDoc({})).toEqual([]);
     });
-    expect(result).toEqual([
-      "/** Quality score",
-      " * @minimum 0",
-      " * @maximum 100",
-      " * @default 50 */",
-    ]);
-  });
 
-  it("includes @format tag", () => {
-    const result = buildJsDoc({ description: "Creation date", format: "date-time" });
-    expect(result).toEqual([
-      "/** Creation date",
-      " * @format date-time */",
-    ]);
-  });
-
-  it("includes @example tag with string value", () => {
-    const result = buildJsDoc({ description: "Code format", example: "XY9876" });
-    expect(result).toEqual([
-      "/** Code format",
-      ' * @example "XY9876" */',
-    ]);
-  });
-
-  it("includes @example tag with object value as JSON", () => {
-    const result = buildJsDoc({ example: { key: "val" } });
-    expect(result).toEqual([
-      '/** @example {"key":"val"} */',
-    ]);
-  });
-
-  it("includes @pattern tag", () => {
-    const result = buildJsDoc({ pattern: "^[A-Z]{2}\\d{4}$" });
-    expect(result).toEqual(['/** @pattern ^[A-Z]{2}\\d{4}$ */']);
-  });
-
-  it("includes string constraint tags", () => {
-    const result = buildJsDoc({ description: "Name", minLength: 1, maxLength: 255 });
-    expect(result).toEqual([
-      "/** Name",
-      " * @minLength 1",
-      " * @maxLength 255 */",
-    ]);
-  });
-
-  it("includes array constraint tags", () => {
-    const result = buildJsDoc({ description: "Tags", minItems: 0, maxItems: 10 });
-    expect(result).toEqual([
-      "/** Tags",
-      " * @minItems 0",
-      " * @maxItems 10 */",
-    ]);
-  });
-
-  it("includes @uniqueItems when true", () => {
-    const result = buildJsDoc({ uniqueItems: true });
-    expect(result).toEqual(["/** @uniqueItems */"]);
-  });
-
-  it("includes @readonly tag", () => {
-    const result = buildJsDoc({ description: "Server-assigned ID", readOnly: true });
-    expect(result).toEqual([
-      "/** Server-assigned ID",
-      " * @readonly */",
-    ]);
-  });
-
-  it("includes @writeonly tag", () => {
-    const result = buildJsDoc({ description: "Password", writeOnly: true });
-    expect(result).toEqual([
-      "/** Password",
-      " * @writeonly */",
-    ]);
-  });
-
-  it("includes @deprecated tag", () => {
-    const result = buildJsDoc({ description: "Use newField", deprecated: true });
-    expect(result).toEqual([
-      "/** @deprecated Use newField */",
-    ]);
-  });
-
-  it("deprecated with no description", () => {
-    const result = buildJsDoc({ deprecated: true });
-    expect(result).toEqual(["/** @deprecated */"]);
-  });
-
-  it("includes @exclusiveMinimum and @exclusiveMaximum", () => {
-    const result = buildJsDoc({ exclusiveMinimum: 0, exclusiveMaximum: 100 });
-    expect(result).toEqual([
-      "/** @exclusiveMinimum 0",
-      " * @exclusiveMaximum 100 */",
-    ]);
-  });
-
-  it("applies indent to all lines", () => {
-    const result = buildJsDoc({ description: "Score", minimum: 0 }, "  ");
-    expect(result).toEqual([
-      "  /** Score",
-      "   * @minimum 0 */",
-    ]);
-  });
-
-  it("escapes */ in descriptions", () => {
-    const result = buildJsDoc({ description: "Use a/* or b*/ for wildcards" });
-    expect(result).toEqual(["/** Use a/* or b*\\/ for wildcards */"]);
-  });
-
-  it("handles multi-line descriptions", () => {
-    const result = buildJsDoc({ description: "Line one\nLine two" });
-    expect(result).toEqual([
-      "/** Line one",
-      " * Line two */",
-    ]);
-  });
-
-  it("all tags together", () => {
-    const result = buildJsDoc({
-      description: "Quality score",
-      format: "double",
-      minimum: 0,
-      maximum: 100,
-      default: 50,
-      example: 75.5,
-      readOnly: true,
+    it('returns empty array for schema with only type', () => {
+        expect(buildJsDoc({ type: 'string' })).toEqual([]);
     });
-    expect(result).toEqual([
-      "/** Quality score",
-      " * @format double",
-      " * @minimum 0",
-      " * @maximum 100",
-      " * @default 50",
-      " * @example 75.5",
-      " * @readonly */",
-    ]);
-  });
+
+    it('single-line JSDoc for description only', () => {
+        const result = buildJsDoc({ description: 'A simple description' });
+        expect(result).toEqual(['/** A simple description */']);
+    });
+
+    it('multi-line JSDoc for description + tags', () => {
+        const result = buildJsDoc({
+            description: 'Quality score',
+            minimum: 0,
+            maximum: 100,
+            default: 50,
+        });
+        expect(result).toEqual([
+            '/** Quality score',
+            ' * @minimum 0',
+            ' * @maximum 100',
+            ' * @default 50 */',
+        ]);
+    });
+
+    it('includes @format tag', () => {
+        const result = buildJsDoc({ description: 'Creation date', format: 'date-time' });
+        expect(result).toEqual([
+            '/** Creation date',
+            ' * @format date-time */',
+        ]);
+    });
+
+    it('includes @example tag with string value', () => {
+        const result = buildJsDoc({ description: 'Code format', example: 'XY9876' });
+        expect(result).toEqual([
+            '/** Code format',
+            ' * @example "XY9876" */',
+        ]);
+    });
+
+    it('includes @example tag with object value as JSON', () => {
+        const result = buildJsDoc({ example: { key: 'val' } });
+        expect(result).toEqual([
+            '/** @example {"key":"val"} */',
+        ]);
+    });
+
+    it('includes @pattern tag', () => {
+        const result = buildJsDoc({ pattern: '^[A-Z]{2}\\d{4}$' });
+        expect(result).toEqual(['/** @pattern ^[A-Z]{2}\\d{4}$ */']);
+    });
+
+    it('includes string constraint tags', () => {
+        const result = buildJsDoc({ description: 'Name', minLength: 1, maxLength: 255 });
+        expect(result).toEqual([
+            '/** Name',
+            ' * @minLength 1',
+            ' * @maxLength 255 */',
+        ]);
+    });
+
+    it('includes array constraint tags', () => {
+        const result = buildJsDoc({ description: 'Tags', minItems: 0, maxItems: 10 });
+        expect(result).toEqual([
+            '/** Tags',
+            ' * @minItems 0',
+            ' * @maxItems 10 */',
+        ]);
+    });
+
+    it('includes @uniqueItems when true', () => {
+        const result = buildJsDoc({ uniqueItems: true });
+        expect(result).toEqual(['/** @uniqueItems */']);
+    });
+
+    it('includes @readonly tag', () => {
+        const result = buildJsDoc({ description: 'Server-assigned ID', readOnly: true });
+        expect(result).toEqual([
+            '/** Server-assigned ID',
+            ' * @readonly */',
+        ]);
+    });
+
+    it('includes @writeonly tag', () => {
+        const result = buildJsDoc({ description: 'Password', writeOnly: true });
+        expect(result).toEqual([
+            '/** Password',
+            ' * @writeonly */',
+        ]);
+    });
+
+    it('includes @deprecated tag', () => {
+        const result = buildJsDoc({ description: 'Use newField', deprecated: true });
+        expect(result).toEqual([
+            '/** @deprecated Use newField */',
+        ]);
+    });
+
+    it('deprecated with no description', () => {
+        const result = buildJsDoc({ deprecated: true });
+        expect(result).toEqual(['/** @deprecated */']);
+    });
+
+    it('includes @exclusiveMinimum and @exclusiveMaximum', () => {
+        const result = buildJsDoc({ exclusiveMinimum: 0, exclusiveMaximum: 100 });
+        expect(result).toEqual([
+            '/** @exclusiveMinimum 0',
+            ' * @exclusiveMaximum 100 */',
+        ]);
+    });
+
+    it('applies indent to all lines', () => {
+        const result = buildJsDoc({ description: 'Score', minimum: 0 }, '  ');
+        expect(result).toEqual([
+            '  /** Score',
+            '   * @minimum 0 */',
+        ]);
+    });
+
+    it('escapes */ in descriptions', () => {
+        const result = buildJsDoc({ description: 'Use a/* or b*/ for wildcards' });
+        expect(result).toEqual(['/** Use a/* or b*\\/ for wildcards */']);
+    });
+
+    it('handles multi-line descriptions', () => {
+        const result = buildJsDoc({ description: 'Line one\nLine two' });
+        expect(result).toEqual([
+            '/** Line one',
+            ' * Line two */',
+        ]);
+    });
+
+    it('all tags together', () => {
+        const result = buildJsDoc({
+            description: 'Quality score',
+            format: 'double',
+            minimum: 0,
+            maximum: 100,
+            default: 50,
+            example: 75.5,
+            readOnly: true,
+        });
+        expect(result).toEqual([
+            '/** Quality score',
+            ' * @format double',
+            ' * @minimum 0',
+            ' * @maximum 100',
+            ' * @default 50',
+            ' * @example 75.5',
+            ' * @readonly */',
+        ]);
+    });
 });

--- a/tests/codegen/oas31.test.ts
+++ b/tests/codegen/oas31.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from "bun:test";
-import { generateTypes } from "../../src/codegen/types";
-import { generateClient } from "../../src/codegen/client";
-import { generateCommands } from "../../src/codegen/commands";
-import { generateCommandMap } from "../../src/codegen/command-map";
-import fixture from "../fixtures/oas31.json";
+import { describe, it, expect } from 'bun:test';
+import { generateTypes } from '../../src/codegen/types';
+import { generateClient } from '../../src/codegen/client';
+import { generateCommands } from '../../src/codegen/commands';
+import { generateCommandMap } from '../../src/codegen/command-map';
+import fixture from '../fixtures/oas31.json';
 
 const schemas = fixture.components.schemas as Record<string, any>;
 const paths = fixture.paths as Record<string, any>;
@@ -13,161 +13,161 @@ const clientOutput = generateClient(paths, schemas);
 const commandsOutput = generateCommands(paths, schemas);
 const commandMapOutput = generateCommandMap(paths, schemas);
 
-describe("OAS 3.1: type arrays (nullable)", () => {
-  it("type: ['string', 'null'] produces string | null", () => {
-    const block = typesOutput.split("export interface NullableItem")[1]?.split("\n}\n")[0] || "";
-    expect(block).toMatch(/description\??: string \| null/);
-  });
+describe('OAS 3.1: type arrays (nullable)', () => {
+    it("type: ['string', 'null'] produces string | null", () => {
+        const block = typesOutput.split('export interface NullableItem')[1]?.split('\n}\n')[0] || '';
+        expect(block).toMatch(/description\??: string \| null/);
+    });
 
-  it("type: ['integer', 'null'] produces number | null", () => {
-    const block = typesOutput.split("export interface NullableItem")[1]?.split("\n}\n")[0] || "";
-    expect(block).toMatch(/priority\??: number \| null/);
-  });
+    it("type: ['integer', 'null'] produces number | null", () => {
+        const block = typesOutput.split('export interface NullableItem')[1]?.split('\n}\n')[0] || '';
+        expect(block).toMatch(/priority\??: number \| null/);
+    });
 
-  it("type: ['string', 'integer'] without null produces string | number", () => {
-    expect(typesOutput).toMatch(/export type MultiType = string \| number/);
-  });
+    it("type: ['string', 'integer'] without null produces string | number", () => {
+        expect(typesOutput).toMatch(/export type MultiType = string \| number/);
+    });
 
-  it("3.0 nullable: true still works", () => {
-    expect(typesOutput).toBeTruthy();
-  });
+    it('3.0 nullable: true still works', () => {
+        expect(typesOutput).toBeTruthy();
+    });
 });
 
-describe("OAS 3.1: const", () => {
-  it("const string produces literal type", () => {
-    expect(typesOutput).toContain('"active"');
-    const line = typesOutput.split("\n").find(l => l.includes("StatusConst"));
-    expect(line).toContain('"active"');
-  });
+describe('OAS 3.1: const', () => {
+    it('const string produces literal type', () => {
+        expect(typesOutput).toContain('"active"');
+        const line = typesOutput.split('\n').find(l => l.includes('StatusConst'));
+        expect(line).toContain('"active"');
+    });
 });
 
-describe("OAS 3.1: enum widening", () => {
-  it("integer enum produces numeric literals", () => {
-    expect(typesOutput).toContain("export type IntEnum =");
-    const enumLine = typesOutput.split("export type IntEnum =")[1]?.split(";")[0] || "";
-    expect(enumLine).toContain("1");
-    expect(enumLine).toContain("5");
-    expect(enumLine).not.toContain('"1"');
-  });
+describe('OAS 3.1: enum widening', () => {
+    it('integer enum produces numeric literals', () => {
+        expect(typesOutput).toContain('export type IntEnum =');
+        const enumLine = typesOutput.split('export type IntEnum =')[1]?.split(';')[0] || '';
+        expect(enumLine).toContain('1');
+        expect(enumLine).toContain('5');
+        expect(enumLine).not.toContain('"1"');
+    });
 
-  it("mixed enum with null produces correct union", () => {
-    expect(typesOutput).toContain("export type MixedEnum =");
-    const enumLine = typesOutput.split("export type MixedEnum =")[1]?.split(";")[0] || "";
-    expect(enumLine).toContain('"auto"');
-    expect(enumLine).toContain('"manual"');
-    expect(enumLine).toContain("0");
-    expect(enumLine).toContain("1");
-    expect(enumLine).toContain("null");
-  });
+    it('mixed enum with null produces correct union', () => {
+        expect(typesOutput).toContain('export type MixedEnum =');
+        const enumLine = typesOutput.split('export type MixedEnum =')[1]?.split(';')[0] || '';
+        expect(enumLine).toContain('"auto"');
+        expect(enumLine).toContain('"manual"');
+        expect(enumLine).toContain('0');
+        expect(enumLine).toContain('1');
+        expect(enumLine).toContain('null');
+    });
 });
 
-describe("OAS 3.1: not (negation)", () => {
-  it("not schema emits JSDoc annotation", () => {
-    expect(typesOutput).toContain("NotString");
-    expect(typesOutput).toContain("@not");
-  });
+describe('OAS 3.1: not (negation)', () => {
+    it('not schema emits JSDoc annotation', () => {
+        expect(typesOutput).toContain('NotString');
+        expect(typesOutput).toContain('@not');
+    });
 
-  it("not schema does not crash generators", () => {
-    expect(typesOutput).toBeTruthy();
-    expect(commandsOutput).toBeTruthy();
-  });
+    it('not schema does not crash generators', () => {
+        expect(typesOutput).toBeTruthy();
+        expect(commandsOutput).toBeTruthy();
+    });
 });
 
-describe("OAS 3.1: prefixItems (tuples)", () => {
-  it("prefixItems with items:false produces fixed tuple", () => {
-    expect(typesOutput).toContain("TupleSchema");
-    expect(typesOutput).toMatch(/\[number, number, number\]/);
-  });
+describe('OAS 3.1: prefixItems (tuples)', () => {
+    it('prefixItems with items:false produces fixed tuple', () => {
+        expect(typesOutput).toContain('TupleSchema');
+        expect(typesOutput).toMatch(/\[number, number, number\]/);
+    });
 
-  it("prefixItems with items schema produces tuple with rest", () => {
-    expect(typesOutput).toContain("TupleWithRest");
-    const line = typesOutput.split("TupleWithRest")[1]?.split(";")[0] || "";
-    expect(line).toContain("string");
-    expect(line).toContain("number");
-  });
+    it('prefixItems with items schema produces tuple with rest', () => {
+        expect(typesOutput).toContain('TupleWithRest');
+        const line = typesOutput.split('TupleWithRest')[1]?.split(';')[0] || '';
+        expect(line).toContain('string');
+        expect(line).toContain('number');
+    });
 });
 
-describe("OAS 3.1: $ref with siblings", () => {
-  it("$ref sibling description overrides ref target description in JSDoc", () => {
-    const block = typesOutput.split("export interface RefWithSiblings")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("Custom description overriding the $ref target");
-  });
+describe('OAS 3.1: $ref with siblings', () => {
+    it('$ref sibling description overrides ref target description in JSDoc', () => {
+        const block = typesOutput.split('export interface RefWithSiblings')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('Custom description overriding the $ref target');
+    });
 
-  it("NullableItem.status has overridden description from $ref sibling", () => {
-    const block = typesOutput.split("export interface NullableItem")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("Overridden description via $ref sibling");
-  });
+    it('NullableItem.status has overridden description from $ref sibling', () => {
+        const block = typesOutput.split('export interface NullableItem')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('Overridden description via $ref sibling');
+    });
 });
 
-describe("OAS 3.1: $defs (local definitions)", () => {
-  it("$defs schemas are resolved and properties use them", () => {
-    expect(typesOutput).toContain("export interface EventWithDefs");
-    const block = typesOutput.split("export interface EventWithDefs")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("severity");
-    expect(block).toContain("occurredAt");
-  });
+describe('OAS 3.1: $defs (local definitions)', () => {
+    it('$defs schemas are resolved and properties use them', () => {
+        expect(typesOutput).toContain('export interface EventWithDefs');
+        const block = typesOutput.split('export interface EventWithDefs')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('severity');
+        expect(block).toContain('occurredAt');
+    });
 
-  it("$defs schemas are emitted as top-level types", () => {
-    expect(typesOutput).toContain("Severity");
-    expect(typesOutput).toContain("Timestamp");
-  });
+    it('$defs schemas are emitted as top-level types', () => {
+        expect(typesOutput).toContain('Severity');
+        expect(typesOutput).toContain('Timestamp');
+    });
 });
 
-describe("OAS 3.0 missing: multipleOf, minProperties, maxProperties", () => {
-  it("multipleOf emits JSDoc tag", () => {
-    expect(typesOutput).toContain("@multipleOf 0.01");
-  });
+describe('OAS 3.0 missing: multipleOf, minProperties, maxProperties', () => {
+    it('multipleOf emits JSDoc tag', () => {
+        expect(typesOutput).toContain('@multipleOf 0.01');
+    });
 
-  it("minProperties emits JSDoc tag", () => {
-    expect(typesOutput).toContain("@minProperties 1");
-  });
+    it('minProperties emits JSDoc tag', () => {
+        expect(typesOutput).toContain('@minProperties 1');
+    });
 
-  it("maxProperties emits JSDoc tag", () => {
-    expect(typesOutput).toContain("@maxProperties 20");
-  });
+    it('maxProperties emits JSDoc tag', () => {
+        expect(typesOutput).toContain('@maxProperties 20');
+    });
 });
 
-describe("OAS 3.1: patternProperties", () => {
-  it("patternProperties emits index signature with JSDoc", () => {
-    const block = typesOutput.split("export interface PatternPropsExample")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("[key: string]:");
-    expect(block).toContain("^data_");
-  });
+describe('OAS 3.1: patternProperties', () => {
+    it('patternProperties emits index signature with JSDoc', () => {
+        const block = typesOutput.split('export interface PatternPropsExample')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('[key: string]:');
+        expect(block).toContain('^data_');
+    });
 
-  it("NullableItem.metadata has patternProperties annotation", () => {
-    const block = typesOutput.split("export interface NullableItem")[1]?.split("\n}\n")[0] || "";
-    expect(block).toContain("x-");
-  });
+    it('NullableItem.metadata has patternProperties annotation', () => {
+        const block = typesOutput.split('export interface NullableItem')[1]?.split('\n}\n')[0] || '';
+        expect(block).toContain('x-');
+    });
 });
 
-describe("OAS 3.0 missing: path-level parameters", () => {
-  it("path-level parameters are inherited by operations in client", () => {
+describe('OAS 3.0 missing: path-level parameters', () => {
+    it('path-level parameters are inherited by operations in client', () => {
     // /v31/items/{itemId} has path-level parameter itemId
-    expect(clientOutput).toMatch(/getV31Item\(itemId: number/);
-  });
+        expect(clientOutput).toMatch(/getV31Item\(itemId: number/);
+    });
 
-  it("path-level parameters appear in command map", () => {
-    expect(commandMapOutput).toContain("getV31Item");
-    expect(commandMapOutput).toContain('"itemId"');
-  });
+    it('path-level parameters appear in command map', () => {
+        expect(commandMapOutput).toContain('getV31Item');
+        expect(commandMapOutput).toContain('"itemId"');
+    });
 
-  it("operations can have their own params alongside path-level params", () => {
-    expect(clientOutput).toContain("listV31Items");
-  });
+    it('operations can have their own params alongside path-level params', () => {
+        expect(clientOutput).toContain('listV31Items');
+    });
 });
 
-describe("OAS 3.0 missing: style/explode on parameters", () => {
-  it("style annotation appears in client JSDoc", () => {
-    expect(clientOutput).toContain("pipeDelimited");
-  });
+describe('OAS 3.0 missing: style/explode on parameters', () => {
+    it('style annotation appears in client JSDoc', () => {
+        expect(clientOutput).toContain('pipeDelimited');
+    });
 
-  it("style annotation appears in command option description", () => {
-    const block = commandsOutput.split("search-v31")[1]?.split(".action(")[0] || "";
-    expect(block).toContain("pipeDelimited");
-  });
+    it('style annotation appears in command option description', () => {
+        const block = commandsOutput.split('search-v31')[1]?.split('.action(')[0] || '';
+        expect(block).toContain('pipeDelimited');
+    });
 
-  it("deepObject style is annotated", () => {
-    const block = commandsOutput.split("search-v31")[1]?.split(".action(")[0] || "";
-    expect(block).toContain("deepObject");
-  });
+    it('deepObject style is annotated', () => {
+        const block = commandsOutput.split('search-v31')[1]?.split('.action(')[0] || '';
+        expect(block).toContain('deepObject');
+    });
 });

--- a/tests/codegen/response-type.test.ts
+++ b/tests/codegen/response-type.test.ts
@@ -1,64 +1,64 @@
-import { describe, it, expect } from "bun:test";
-import { resolveResponseType } from "../../src/codegen/util";
+import { describe, it, expect } from 'bun:test';
+import { resolveResponseType } from '../../src/codegen/util';
 
-describe("resolveResponseType", () => {
-  const schemas = {
-    MatterDto: { type: "object", properties: { id: { type: "integer" } } },
-    MatterStatus: { type: "string", enum: ["active", "archived"] },
-  } as Record<string, any>;
+describe('resolveResponseType', () => {
+    const schemas = {
+        MatterDto: { type: 'object', properties: { id: { type: 'integer' } } },
+        MatterStatus: { type: 'string', enum: ['active', 'archived'] },
+    } as Record<string, any>;
 
-  it("resolves $ref response to type name", () => {
-    const responses = {
-      "200": { content: { "application/json": { schema: { $ref: "#/components/schemas/MatterDto" } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("MatterDto");
-  });
+    it('resolves $ref response to type name', () => {
+        const responses = {
+            200: { content: { 'application/json': { schema: { $ref: '#/components/schemas/MatterDto' } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('MatterDto');
+    });
 
-  it("resolves array response to TypeName[]", () => {
-    const responses = {
-      "200": { content: { "application/json": { schema: { type: "array", items: { $ref: "#/components/schemas/MatterDto" } } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("MatterDto[]");
-  });
+    it('resolves array response to TypeName[]', () => {
+        const responses = {
+            200: { content: { 'application/json': { schema: { type: 'array', items: { $ref: '#/components/schemas/MatterDto' } } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('MatterDto[]');
+    });
 
-  it("returns void for no-body response", () => {
-    const responses = {
-      "204": { description: "No Content" },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("void");
-  });
+    it('returns void for no-body response', () => {
+        const responses = {
+            204: { description: 'No Content' },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('void');
+    });
 
-  it("prefers 200 over 201", () => {
-    const responses = {
-      "201": { content: { "application/json": { schema: { $ref: "#/components/schemas/MatterStatus" } } } },
-      "200": { content: { "application/json": { schema: { $ref: "#/components/schemas/MatterDto" } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("MatterDto");
-  });
+    it('prefers 200 over 201', () => {
+        const responses = {
+            201: { content: { 'application/json': { schema: { $ref: '#/components/schemas/MatterStatus' } } } },
+            200: { content: { 'application/json': { schema: { $ref: '#/components/schemas/MatterDto' } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('MatterDto');
+    });
 
-  it("falls back to 201 when 200 has no body", () => {
-    const responses = {
-      "200": { description: "OK" },
-      "201": { content: { "application/json": { schema: { $ref: "#/components/schemas/MatterDto" } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("MatterDto");
-  });
+    it('falls back to 201 when 200 has no body', () => {
+        const responses = {
+            200: { description: 'OK' },
+            201: { content: { 'application/json': { schema: { $ref: '#/components/schemas/MatterDto' } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('MatterDto');
+    });
 
-  it("returns void when responses is empty", () => {
-    expect(resolveResponseType({}, schemas)).toBe("void");
-  });
+    it('returns void when responses is empty', () => {
+        expect(resolveResponseType({}, schemas)).toBe('void');
+    });
 
-  it("returns void when response has no JSON content", () => {
-    const responses = {
-      "200": { content: { "text/plain": { schema: { type: "string" } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("void");
-  });
+    it('returns void when response has no JSON content', () => {
+        const responses = {
+            200: { content: { 'text/plain': { schema: { type: 'string' } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('void');
+    });
 
-  it("resolves inline response schema", () => {
-    const responses = {
-      "200": { content: { "application/json": { schema: { type: "string" } } } },
-    };
-    expect(resolveResponseType(responses, schemas)).toBe("string");
-  });
+    it('resolves inline response schema', () => {
+        const responses = {
+            200: { content: { 'application/json': { schema: { type: 'string' } } } },
+        };
+        expect(resolveResponseType(responses, schemas)).toBe('string');
+    });
 });

--- a/tests/codegen/stripe-e2e.test.ts
+++ b/tests/codegen/stripe-e2e.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeAll } from "bun:test";
-import { generate } from "../../src/codegen/index";
-import { mkdtemp } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, it, expect, beforeAll } from 'bun:test';
+import { generate } from '../../src/codegen/index';
+import { mkdtemp } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
-const STRIPE_SPEC_URL =
-  "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.sdk.json";
+const STRIPE_SPEC_URL
+    = 'https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.sdk.json';
 
 let spec: any;
 let outDir: string;
@@ -15,119 +15,137 @@ let commandsOutput: string;
 let commandMapOutput: string;
 
 beforeAll(async () => {
-  // Download Stripe spec — skip suite if offline
-  try {
-    const res = await fetch(STRIPE_SPEC_URL);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    spec = await res.json();
-  } catch {
-    spec = null;
-    return;
-  }
+    // Download Stripe spec — skip suite if offline
+    try {
+        const res = await fetch(STRIPE_SPEC_URL);
 
-  outDir = await mkdtemp(join(tmpdir(), "apijack-stripe-e2e-"));
-  await generate({ spec, outDir });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
 
-  typesOutput = await Bun.file(join(outDir, "types.ts")).text();
-  clientOutput = await Bun.file(join(outDir, "client.ts")).text();
-  commandsOutput = await Bun.file(join(outDir, "commands.ts")).text();
-  commandMapOutput = await Bun.file(join(outDir, "command-map.ts")).text();
+        spec = await res.json();
+    } catch {
+        spec = null;
+
+        return;
+    }
+
+    outDir = await mkdtemp(join(tmpdir(), 'apijack-stripe-e2e-'));
+    await generate({ spec, outDir });
+
+    typesOutput = await Bun.file(join(outDir, 'types.ts')).text();
+    clientOutput = await Bun.file(join(outDir, 'client.ts')).text();
+    commandsOutput = await Bun.file(join(outDir, 'commands.ts')).text();
+    commandMapOutput = await Bun.file(join(outDir, 'command-map.ts')).text();
 });
 
 function skipIfOffline() {
-  if (!spec) {
-    console.log("    ⏭ skipped (Stripe spec not available)");
-    return true;
-  }
-  return false;
+    if (!spec) {
+        console.log('    ⏭ skipped (Stripe spec not available)');
+
+        return true;
+    }
+
+    return false;
 }
 
-describe("Stripe OpenAPI e2e", () => {
-  // --- Coverage ---
+describe('Stripe OpenAPI e2e', () => {
+    // --- Coverage ---
 
-  it("generates a type for every schema", () => {
-    if (skipIfOffline()) return;
-    const schemaCount = Object.keys(spec.components.schemas).length;
-    const declarations = typesOutput.match(/export (interface|type) /g) || [];
-    expect(declarations.length).toBe(schemaCount);
-  });
+    it('generates a type for every schema', () => {
+        if (skipIfOffline()) return;
 
-  it("generates a method for every operation", () => {
-    if (skipIfOffline()) return;
-    let opCount = 0;
-    for (const methods of Object.values(spec.paths) as any[]) {
-      for (const m of ["get", "post", "put", "patch", "delete", "head", "options"]) {
-        if (methods[m]?.operationId) opCount++;
-      }
-    }
-    const asyncMethods = clientOutput.match(/^\s+async \w+\(/gm) || [];
-    expect(asyncMethods.length).toBe(opCount);
-  });
-
-  // --- No invalid identifiers ---
-
-  it("produces no dot-notation in type declarations", () => {
-    if (skipIfOffline()) return;
-    const dotDeclarations = typesOutput.match(
-      /export (interface|type) \S*\.\S*/g,
-    );
-    expect(dotDeclarations).toBeNull();
-  });
-
-  it("produces no 'any' typed fields", () => {
-    if (skipIfOffline()) return;
-    const anyFields = (typesOutput.match(/: any;/g) || []).length;
-    expect(anyFields).toBe(0);
-  });
-
-  // --- No name collisions ---
-
-  it("has no duplicate type declarations", () => {
-    if (skipIfOffline()) return;
-    const names = [
-      ...typesOutput.matchAll(/export (interface|type) (\w+)/g),
-    ].map((m) => m[2]);
-    const unique = new Set(names);
-    expect(names.length).toBe(unique.size);
-  });
-
-  // --- TypeScript validity ---
-
-  it("types.ts compiles without errors", async () => {
-    if (skipIfOffline()) return;
-    const typesPath = join(outDir, "types.ts");
-    const proc = Bun.spawn(["bun", "build", "--no-bundle", typesPath], {
-      stdout: "pipe",
-      stderr: "pipe",
+        const schemaCount = Object.keys(spec.components.schemas).length;
+        const declarations = typesOutput.match(/export (interface|type) /g) || [];
+        expect(declarations.length).toBe(schemaCount);
     });
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      expect(stderr).toBe("");
-    }
-    expect(exitCode).toBe(0);
-  });
 
-  // --- Dot-notation schemas specifically ---
+    it('generates a method for every operation', () => {
+        if (skipIfOffline()) return;
 
-  it("sanitizes billing.alert to billing__alert", () => {
-    if (skipIfOffline()) return;
-    expect(typesOutput).toContain("export interface billing__alert {");
-  });
+        let opCount = 0;
 
-  it("avoids collision between billing.alert.triggered and billing.alert_triggered", () => {
-    if (skipIfOffline()) return;
-    expect(typesOutput).toContain("export interface billing__alert__triggered {");
-    expect(typesOutput).toContain("export interface billing__alert_triggered {");
-  });
+        for (const methods of Object.values(spec.paths) as any[]) {
+            for (const m of ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']) {
+                if (methods[m]?.operationId) opCount++;
+            }
+        }
 
-  // --- All files generated ---
+        const asyncMethods = clientOutput.match(/^\s+async \w+\(/gm) || [];
+        expect(asyncMethods.length).toBe(opCount);
+    });
 
-  it("generates all four output files", () => {
-    if (skipIfOffline()) return;
-    expect(typesOutput.length).toBeGreaterThan(0);
-    expect(clientOutput.length).toBeGreaterThan(0);
-    expect(commandsOutput.length).toBeGreaterThan(0);
-    expect(commandMapOutput.length).toBeGreaterThan(0);
-  });
+    // --- No invalid identifiers ---
+
+    it('produces no dot-notation in type declarations', () => {
+        if (skipIfOffline()) return;
+
+        const dotDeclarations = typesOutput.match(
+            /export (interface|type) \S*\.\S*/g,
+        );
+        expect(dotDeclarations).toBeNull();
+    });
+
+    it("produces no 'any' typed fields", () => {
+        if (skipIfOffline()) return;
+
+        const anyFields = (typesOutput.match(/: any;/g) || []).length;
+        expect(anyFields).toBe(0);
+    });
+
+    // --- No name collisions ---
+
+    it('has no duplicate type declarations', () => {
+        if (skipIfOffline()) return;
+
+        const names = [
+            ...typesOutput.matchAll(/export (interface|type) (\w+)/g),
+        ].map(m => m[2]);
+        const unique = new Set(names);
+        expect(names.length).toBe(unique.size);
+    });
+
+    // --- TypeScript validity ---
+
+    it('types.ts compiles without errors', async () => {
+        if (skipIfOffline()) return;
+
+        const typesPath = join(outDir, 'types.ts');
+        const proc = Bun.spawn(['bun', 'build', '--no-bundle', typesPath], {
+            stdout: 'pipe',
+            stderr: 'pipe',
+        });
+        const exitCode = await proc.exited;
+
+        if (exitCode !== 0) {
+            const stderr = await new Response(proc.stderr).text();
+            expect(stderr).toBe('');
+        }
+
+        expect(exitCode).toBe(0);
+    });
+
+    // --- Dot-notation schemas specifically ---
+
+    it('sanitizes billing.alert to billing__alert', () => {
+        if (skipIfOffline()) return;
+
+        expect(typesOutput).toContain('export interface billing__alert {');
+    });
+
+    it('avoids collision between billing.alert.triggered and billing.alert_triggered', () => {
+        if (skipIfOffline()) return;
+
+        expect(typesOutput).toContain('export interface billing__alert__triggered {');
+        expect(typesOutput).toContain('export interface billing__alert_triggered {');
+    });
+
+    // --- All files generated ---
+
+    it('generates all four output files', () => {
+        if (skipIfOffline()) return;
+
+        expect(typesOutput.length).toBeGreaterThan(0);
+        expect(clientOutput.length).toBeGreaterThan(0);
+        expect(commandsOutput.length).toBeGreaterThan(0);
+        expect(commandMapOutput.length).toBeGreaterThan(0);
+    });
 });

--- a/tests/codegen/types.test.ts
+++ b/tests/codegen/types.test.ts
@@ -1,351 +1,351 @@
-import { describe, expect, it } from "bun:test";
-import { generateTypes } from "../../src/codegen/types";
-import type { OpenApiSchema } from "../../src/codegen/openapi-types";
-import fixture from "../fixtures/petstore.json";
+import { describe, expect, it } from 'bun:test';
+import { generateTypes } from '../../src/codegen/types';
+import type { OpenApiSchema } from '../../src/codegen/openapi-types';
+import fixture from '../fixtures/petstore.json';
 
-describe("generateTypes — unit tests", () => {
-  it("generates a simple interface with properties", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      User: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-          age: { type: "integer" },
-          active: { type: "boolean" },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export interface User {");
-    expect(output).toContain("  name?: string;");
-    expect(output).toContain("  age?: number;");
-    expect(output).toContain("  active?: boolean;");
-    expect(output).toContain("}");
-  });
+describe('generateTypes — unit tests', () => {
+    it('generates a simple interface with properties', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            User: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                    age: { type: 'integer' },
+                    active: { type: 'boolean' },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export interface User {');
+        expect(output).toContain('  name?: string;');
+        expect(output).toContain('  age?: number;');
+        expect(output).toContain('  active?: boolean;');
+        expect(output).toContain('}');
+    });
 
-  it("generates an enum as a union type", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Status: {
-        enum: ["ACTIVE", "INACTIVE", "PENDING"],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain(
-      'export type Status = "ACTIVE" | "INACTIVE" | "PENDING";',
-    );
-  });
+    it('generates an enum as a union type', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Status: {
+                enum: ['ACTIVE', 'INACTIVE', 'PENDING'],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain(
+            'export type Status = "ACTIVE" | "INACTIVE" | "PENDING";',
+        );
+    });
 
-  it("generates allOf as intersection type", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      AdminUser: {
-        allOf: [
-          { $ref: "#/components/schemas/User" },
-          { $ref: "#/components/schemas/AdminRole" },
-        ],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export type AdminUser = User & AdminRole;");
-  });
+    it('generates allOf as intersection type', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            AdminUser: {
+                allOf: [
+                    { $ref: '#/components/schemas/User' },
+                    { $ref: '#/components/schemas/AdminRole' },
+                ],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export type AdminUser = User & AdminRole;');
+    });
 
-  it("generates oneOf as union type", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Shape: {
-        oneOf: [
-          { $ref: "#/components/schemas/Circle" },
-          { $ref: "#/components/schemas/Square" },
-        ],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export type Shape = Circle | Square;");
-  });
+    it('generates oneOf as union type', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Shape: {
+                oneOf: [
+                    { $ref: '#/components/schemas/Circle' },
+                    { $ref: '#/components/schemas/Square' },
+                ],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export type Shape = Circle | Square;');
+    });
 
-  it("generates anyOf as union type", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Input: {
-        anyOf: [
-          { $ref: "#/components/schemas/TextInput" },
-          { $ref: "#/components/schemas/NumberInput" },
-        ],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export type Input = TextInput | NumberInput;");
-  });
+    it('generates anyOf as union type', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Input: {
+                anyOf: [
+                    { $ref: '#/components/schemas/TextInput' },
+                    { $ref: '#/components/schemas/NumberInput' },
+                ],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export type Input = TextInput | NumberInput;');
+    });
 
-  it("handles $ref properties", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Order: {
-        type: "object",
-        properties: {
-          item: { $ref: "#/components/schemas/Product" },
-          tags: { type: "array", items: { type: "string" } },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("  item?: Product;");
-    expect(output).toContain("  tags?: string[];");
-  });
+    it('handles $ref properties', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Order: {
+                type: 'object',
+                properties: {
+                    item: { $ref: '#/components/schemas/Product' },
+                    tags: { type: 'array', items: { type: 'string' } },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('  item?: Product;');
+        expect(output).toContain('  tags?: string[];');
+    });
 
-  it("handles nullable properties", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Profile: {
-        type: "object",
-        properties: {
-          bio: { type: "string", nullable: true },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("  bio?: string | null;");
-  });
+    it('handles nullable properties', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Profile: {
+                type: 'object',
+                properties: {
+                    bio: { type: 'string', nullable: true },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('  bio?: string | null;');
+    });
 
-  it("includes auto-generated header", () => {
-    const output = generateTypes({});
-    expect(output).toContain("// Auto-generated");
-  });
+    it('includes auto-generated header', () => {
+        const output = generateTypes({});
+        expect(output).toContain('// Auto-generated');
+    });
 
-  it("generates multiple schemas", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Foo: {
-        type: "object",
-        properties: {
-          x: { type: "string" },
-        },
-      },
-      Bar: {
-        enum: ["A", "B"],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export interface Foo {");
-    expect(output).toContain('export type Bar = "A" | "B";');
-  });
+    it('generates multiple schemas', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Foo: {
+                type: 'object',
+                properties: {
+                    x: { type: 'string' },
+                },
+            },
+            Bar: {
+                enum: ['A', 'B'],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export interface Foo {');
+        expect(output).toContain('export type Bar = "A" | "B";');
+    });
 
-  it("handles schema with properties but no explicit type", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Implicit: {
-        properties: {
-          value: { type: "number" },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export interface Implicit {");
-    expect(output).toContain("  value?: number;");
-  });
+    it('handles schema with properties but no explicit type', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Implicit: {
+                properties: {
+                    value: { type: 'number' },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export interface Implicit {');
+        expect(output).toContain('  value?: number;');
+    });
 
-  it("allOf with inline schema emits inline intersection member", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Mixed: {
-        allOf: [
-          { $ref: "#/components/schemas/Base" },
-          { type: "object", properties: { extra: { type: "string" } } },
-        ],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export type Mixed = Base &");
-    expect(output).toContain("extra");
-  });
+    it('allOf with inline schema emits inline intersection member', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Mixed: {
+                allOf: [
+                    { $ref: '#/components/schemas/Base' },
+                    { type: 'object', properties: { extra: { type: 'string' } } },
+                ],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export type Mixed = Base &');
+        expect(output).toContain('extra');
+    });
 
-  it("sanitizes dot-notation schema names in interface declarations", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      "billing.alert": {
-        type: "object",
-        properties: {
-          id: { type: "string" },
-          status: { type: "string" },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export interface billing__alert {");
-    expect(output).not.toContain("export interface billing.alert {");
-  });
+    it('sanitizes dot-notation schema names in interface declarations', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            'billing.alert': {
+                type: 'object',
+                properties: {
+                    id: { type: 'string' },
+                    status: { type: 'string' },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export interface billing__alert {');
+        expect(output).not.toContain('export interface billing.alert {');
+    });
 
-  it("sanitizes dot-notation schema names in type alias declarations", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      "account.updated": {
-        anyOf: [
-          { $ref: "#/components/schemas/account" },
-          { $ref: "#/components/schemas/event" },
-        ],
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export type account__updated = ");
-    expect(output).not.toContain("export type account.updated = ");
-  });
+    it('sanitizes dot-notation schema names in type alias declarations', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            'account.updated': {
+                anyOf: [
+                    { $ref: '#/components/schemas/account' },
+                    { $ref: '#/components/schemas/event' },
+                ],
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export type account__updated = ');
+        expect(output).not.toContain('export type account.updated = ');
+    });
 
-  it("sanitizes dot-notation in $ref references within properties", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      "apps.secret": {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-        },
-      },
-      Container: {
-        type: "object",
-        properties: {
-          secret: { $ref: "#/components/schemas/apps.secret" },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("secret?: apps__secret;");
-    expect(output).not.toContain("secret?: apps.secret;");
-  });
+    it('sanitizes dot-notation in $ref references within properties', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            'apps.secret': {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                },
+            },
+            'Container': {
+                type: 'object',
+                properties: {
+                    secret: { $ref: '#/components/schemas/apps.secret' },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('secret?: apps__secret;');
+        expect(output).not.toContain('secret?: apps.secret;');
+    });
 
-  it("sanitizes multi-dot schema names", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      "account.application.authorized": {
-        type: "object",
-        properties: {
-          object: { $ref: "#/components/schemas/application" },
-        },
-      },
-    };
-    const output = generateTypes(schemas);
-    expect(output).toContain("export interface account__application__authorized {");
-  });
+    it('sanitizes multi-dot schema names', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            'account.application.authorized': {
+                type: 'object',
+                properties: {
+                    object: { $ref: '#/components/schemas/application' },
+                },
+            },
+        };
+        const output = generateTypes(schemas);
+        expect(output).toContain('export interface account__application__authorized {');
+    });
 });
 
-describe("generateTypes — petstore fixture", () => {
-  const schemas = fixture.components.schemas as Record<string, any>;
-  const output = generateTypes(schemas);
+describe('generateTypes — petstore fixture', () => {
+    const schemas = fixture.components.schemas as Record<string, any>;
+    const output = generateTypes(schemas);
 
-  it("generates interface for object schema", () => {
-    expect(output).toContain("export interface MatterDto {");
-    expect(output).toContain("id?: number;");
-    expect(output).toContain("name?: string;");
-  });
+    it('generates interface for object schema', () => {
+        expect(output).toContain('export interface MatterDto {');
+        expect(output).toContain('id?: number;');
+        expect(output).toContain('name?: string;');
+    });
 
-  it("generates enum as union type", () => {
-    expect(output).toContain('export type MatterStatus = "active" | "archived" | "deleted";');
-  });
+    it('generates enum as union type', () => {
+        expect(output).toContain('export type MatterStatus = "active" | "archived" | "deleted";');
+    });
 
-  it("resolves $ref to type name", () => {
-    expect(output).toContain("status?: MatterStatus;");
-  });
+    it('resolves $ref to type name', () => {
+        expect(output).toContain('status?: MatterStatus;');
+    });
 
-  it("generates array type", () => {
-    expect(output).toContain("users?: UserDto[];");
-  });
+    it('generates array type', () => {
+        expect(output).toContain('users?: UserDto[];');
+    });
 
-  it("handles nullable fields", () => {
-    expect(output).toContain("description?: string | null;");
-  });
+    it('handles nullable fields', () => {
+        expect(output).toContain('description?: string | null;');
+    });
 
-  it("generates allOf as intersection type", () => {
-    expect(output).toContain("export type MatterWithUsers = MatterDto & UserDto;");
-  });
+    it('generates allOf as intersection type', () => {
+        expect(output).toContain('export type MatterWithUsers = MatterDto & UserDto;');
+    });
 
-  it("generates oneOf as union type", () => {
-    expect(output).toContain("export type SearchResult = MatterDto | UserDto;");
-  });
+    it('generates oneOf as union type', () => {
+        expect(output).toContain('export type SearchResult = MatterDto | UserDto;');
+    });
 
-  // Enum reuse
-  it("enum $ref resolves to type name, not inline values", () => {
-    expect(output).toMatch(/status\??: MatterStatus/);
-    const describedBlock = output.split("export interface DescribedDto")[1]?.split("\n}")[0] || "";
-    expect(describedBlock).not.toContain('"active"');
-  });
+    // Enum reuse
+    it('enum $ref resolves to type name, not inline values', () => {
+        expect(output).toMatch(/status\??: MatterStatus/);
+        const describedBlock = output.split('export interface DescribedDto')[1]?.split('\n}')[0] || '';
+        expect(describedBlock).not.toContain('"active"');
+    });
 
-  // Inline object types
-  it("inline object properties emit object literal type instead of Record", () => {
-    expect(output).toContain("config?:");
-    expect(output).not.toMatch(/config\??: Record<string, unknown>/);
-    const describedBlock = output.split("export interface DescribedDto")[1]?.split("\n}\n")[0] || "";
-    expect(describedBlock).toContain("enabled");
-    expect(describedBlock).toContain("threshold");
-  });
+    // Inline object types
+    it('inline object properties emit object literal type instead of Record', () => {
+        expect(output).toContain('config?:');
+        expect(output).not.toMatch(/config\??: Record<string, unknown>/);
+        const describedBlock = output.split('export interface DescribedDto')[1]?.split('\n}\n')[0] || '';
+        expect(describedBlock).toContain('enabled');
+        expect(describedBlock).toContain('threshold');
+    });
 
-  // allOf with inline schema
-  it("allOf with inline schema emits inline intersection member", () => {
-    expect(output).toContain("export type ExtendedMatter = MatterDto &");
-    expect(output).toContain("priority");
-    expect(output).toContain("notes");
-    expect(output).not.toMatch(/ExtendedMatter = MatterDto & unknown/);
-  });
+    // allOf with inline schema
+    it('allOf with inline schema emits inline intersection member', () => {
+        expect(output).toContain('export type ExtendedMatter = MatterDto &');
+        expect(output).toContain('priority');
+        expect(output).toContain('notes');
+        expect(output).not.toMatch(/ExtendedMatter = MatterDto & unknown/);
+    });
 
-  // Discriminated unions
-  it("oneOf with discriminator emits discriminated union", () => {
-    expect(output).toContain('EmailNotification & { channel: "email" }');
-    expect(output).toContain('SmsNotification & { channel: "sms" }');
-  });
+    // Discriminated unions
+    it('oneOf with discriminator emits discriminated union', () => {
+        expect(output).toContain('EmailNotification & { channel: "email" }');
+        expect(output).toContain('SmsNotification & { channel: "sms" }');
+    });
 
-  // additionalProperties
-  it("additionalProperties with schema emits index signature", () => {
-    expect(output).toContain("[key: string]:");
-  });
+    // additionalProperties
+    it('additionalProperties with schema emits index signature', () => {
+        expect(output).toContain('[key: string]:');
+    });
 
-  // Required properties
-  it("required properties omit the ? marker", () => {
-    const describedBlock = output.split("export interface DescribedDto")[1]?.split("\n}\n")[0] || "";
-    expect(describedBlock).toMatch(/\bname: string/);
-    expect(describedBlock).toMatch(/\bemail: string/);
-    expect(describedBlock).toMatch(/\bscore\?: number/);
-  });
+    // Required properties
+    it('required properties omit the ? marker', () => {
+        const describedBlock = output.split('export interface DescribedDto')[1]?.split('\n}\n')[0] || '';
+        expect(describedBlock).toMatch(/\bname: string/);
+        expect(describedBlock).toMatch(/\bemail: string/);
+        expect(describedBlock).toMatch(/\bscore\?: number/);
+    });
 
-  it("allOf merges required arrays", () => {
-    expect(output).toMatch(/priority: number/);
-  });
+    it('allOf merges required arrays', () => {
+        expect(output).toMatch(/priority: number/);
+    });
 
-  // JSDoc
-  it("schema description emits JSDoc above interface", () => {
-    expect(output).toContain("/** A well-described DTO for testing JSDoc generation */");
-  });
+    // JSDoc
+    it('schema description emits JSDoc above interface', () => {
+        expect(output).toContain('/** A well-described DTO for testing JSDoc generation */');
+    });
 
-  it("property description emits JSDoc above property", () => {
-    expect(output).toContain("/** Server-assigned unique identifier");
-  });
+    it('property description emits JSDoc above property', () => {
+        expect(output).toContain('/** Server-assigned unique identifier');
+    });
 
-  it("property with format emits @format tag", () => {
-    expect(output).toContain("@format date-time");
-  });
+    it('property with format emits @format tag', () => {
+        expect(output).toContain('@format date-time');
+    });
 
-  it("property with constraints emits constraint tags", () => {
-    expect(output).toContain("@minimum 0");
-    expect(output).toContain("@maximum 100");
-    expect(output).toContain("@minLength 1");
-    expect(output).toContain("@maxLength 255");
-  });
+    it('property with constraints emits constraint tags', () => {
+        expect(output).toContain('@minimum 0');
+        expect(output).toContain('@maximum 100');
+        expect(output).toContain('@minLength 1');
+        expect(output).toContain('@maxLength 255');
+    });
 
-  it("property with default emits @default tag", () => {
-    expect(output).toContain("@default 50");
-  });
+    it('property with default emits @default tag', () => {
+        expect(output).toContain('@default 50');
+    });
 
-  it("property with example emits @example tag", () => {
-    expect(output).toContain('@example "XY9876"');
-  });
+    it('property with example emits @example tag', () => {
+        expect(output).toContain('@example "XY9876"');
+    });
 
-  it("property with pattern emits @pattern tag", () => {
-    expect(output).toContain("@pattern ^[A-Z]{2}\\d{4}$");
-  });
+    it('property with pattern emits @pattern tag', () => {
+        expect(output).toContain('@pattern ^[A-Z]{2}\\d{4}$');
+    });
 
-  it("readOnly property emits @readonly tag", () => {
-    expect(output).toContain("@readonly");
-  });
+    it('readOnly property emits @readonly tag', () => {
+        expect(output).toContain('@readonly');
+    });
 
-  it("writeOnly property emits @writeonly tag", () => {
-    expect(output).toContain("@writeonly");
-  });
+    it('writeOnly property emits @writeonly tag', () => {
+        expect(output).toContain('@writeonly');
+    });
 
-  it("deprecated property emits @deprecated tag", () => {
-    const describedBlock = output.split("export interface DescribedDto")[1]?.split("\n}\n")[0] || "";
-    expect(describedBlock).toContain("@deprecated");
-  });
+    it('deprecated property emits @deprecated tag', () => {
+        const describedBlock = output.split('export interface DescribedDto')[1]?.split('\n}\n')[0] || '';
+        expect(describedBlock).toContain('@deprecated');
+    });
 
-  it("deprecated schema emits @deprecated JSDoc", () => {
-    expect(output).toContain("/** @deprecated Use DescribedDto instead */");
-  });
+    it('deprecated schema emits @deprecated JSDoc', () => {
+        expect(output).toContain('/** @deprecated Use DescribedDto instead */');
+    });
 
-  it("array constraints emit @minItems and @maxItems", () => {
-    expect(output).toContain("@minItems 0");
-    expect(output).toContain("@maxItems 10");
-  });
+    it('array constraints emit @minItems and @maxItems', () => {
+        expect(output).toContain('@minItems 0');
+        expect(output).toContain('@maxItems 10');
+    });
 });

--- a/tests/codegen/util.test.ts
+++ b/tests/codegen/util.test.ts
@@ -1,515 +1,515 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from 'bun:test';
 import {
-  normalizeTag,
-  resolveType,
-  refToName,
-  schemaToTsType,
-  sanitizeVar,
-  capitalize,
-  resolveSchemaProps,
-  buildJsDoc,
-  resolveResponseType,
-  sanitizeTypeName,
-} from "../../src/codegen/util";
-import type { OpenApiSchema } from "../../src/codegen/openapi-types";
+    normalizeTag,
+    resolveType,
+    refToName,
+    schemaToTsType,
+    sanitizeVar,
+    capitalize,
+    resolveSchemaProps,
+    buildJsDoc,
+    resolveResponseType,
+    sanitizeTypeName,
+} from '../../src/codegen/util';
+import type { OpenApiSchema } from '../../src/codegen/openapi-types';
 
-describe("normalizeTag", () => {
-  it("splits on colons and whitespace", () => {
-    expect(normalizeTag("Admin : Matters")).toEqual(["admin", "matters"]);
-  });
-
-  it("preserves hyphens within tokens", () => {
-    expect(normalizeTag("user-profile")).toEqual(["user-profile"]);
-  });
-
-  it("splits on slashes and whitespace", () => {
-    expect(normalizeTag("Content Extraction / Loads")).toEqual([
-      "content",
-      "extraction",
-      "loads",
-    ]);
-  });
-
-  it("lowercases all tokens", () => {
-    expect(normalizeTag("FOO BAR")).toEqual(["foo", "bar"]);
-  });
-
-  it("strips leading/trailing hyphens from tokens", () => {
-    expect(normalizeTag("-foo-")).toEqual(["foo"]);
-  });
-
-  it("handles single-word tag", () => {
-    expect(normalizeTag("admin")).toEqual(["admin"]);
-  });
-});
-
-describe("resolveType", () => {
-  it("resolves string type", () => {
-    expect(resolveType({ type: "string" })).toBe("string");
-  });
-
-  it("resolves integer type as number", () => {
-    expect(resolveType({ type: "integer" })).toBe("number");
-  });
-
-  it("resolves number type", () => {
-    expect(resolveType({ type: "number" })).toBe("number");
-  });
-
-  it("resolves boolean type", () => {
-    expect(resolveType({ type: "boolean" })).toBe("boolean");
-  });
-
-  it("resolves $ref", () => {
-    expect(resolveType({ $ref: "#/components/schemas/Foo" })).toBe("Foo");
-  });
-
-  it("resolves array of strings", () => {
-    expect(resolveType({ type: "array", items: { type: "string" } })).toBe(
-      "string[]",
-    );
-  });
-
-  it("resolves array of $ref", () => {
-    expect(
-      resolveType({
-        type: "array",
-        items: { $ref: "#/components/schemas/Bar" },
-      }),
-    ).toBe("Bar[]");
-  });
-
-  it("resolves nullable type", () => {
-    expect(resolveType({ type: "string", nullable: true })).toBe(
-      "string | null",
-    );
-  });
-
-  it("resolves string enum", () => {
-    expect(
-      resolveType({ type: "string", enum: ["A", "B", "C"] }),
-    ).toBe('"A" | "B" | "C"');
-  });
-
-  it("resolves plain object type as Record", () => {
-    expect(resolveType({ type: "object" })).toBe("Record<string, unknown>");
-  });
-
-  it("resolves object with properties as inline object literal at depth 0", () => {
-    const result = resolveType({ type: "object", properties: { foo: { type: "string" } } });
-    expect(result).toContain("{");
-    expect(result).toContain("foo");
-    expect(result).toContain("string");
-  });
-
-  it("resolves object at depth 3+ as Record", () => {
-    const result = resolveType(
-      { type: "object", properties: { foo: { type: "string" } } },
-      {},
-      3,
-    );
-    expect(result).toBe("Record<string, unknown>");
-  });
-
-  it("returns unknown for unrecognized schemas", () => {
-    expect(resolveType({})).toBe("unknown");
-  });
-
-  it("wraps union items in parens for array", () => {
-    const result = resolveType({
-      type: "array",
-      items: {
-        oneOf: [
-          { $ref: "#/components/schemas/A" },
-          { $ref: "#/components/schemas/B" },
-        ],
-      },
+describe('normalizeTag', () => {
+    it('splits on colons and whitespace', () => {
+        expect(normalizeTag('Admin : Matters')).toEqual(['admin', 'matters']);
     });
-    expect(result).toBe("(A | B)[]");
-  });
 
-  it("resolves allOf in property type", () => {
-    const result = resolveType({
-      allOf: [
-        { $ref: "#/components/schemas/Base" },
-        { $ref: "#/components/schemas/Extra" },
-      ],
+    it('preserves hyphens within tokens', () => {
+        expect(normalizeTag('user-profile')).toEqual(['user-profile']);
     });
-    expect(result).toBe("Base & Extra");
-  });
 
-  it("resolves oneOf in property type", () => {
-    const result = resolveType({
-      oneOf: [
-        { $ref: "#/components/schemas/A" },
-        { $ref: "#/components/schemas/B" },
-      ],
+    it('splits on slashes and whitespace', () => {
+        expect(normalizeTag('Content Extraction / Loads')).toEqual([
+            'content',
+            'extraction',
+            'loads',
+        ]);
     });
-    expect(result).toBe("A | B");
-  });
+
+    it('lowercases all tokens', () => {
+        expect(normalizeTag('FOO BAR')).toEqual(['foo', 'bar']);
+    });
+
+    it('strips leading/trailing hyphens from tokens', () => {
+        expect(normalizeTag('-foo-')).toEqual(['foo']);
+    });
+
+    it('handles single-word tag', () => {
+        expect(normalizeTag('admin')).toEqual(['admin']);
+    });
 });
 
-describe("refToName", () => {
-  it("extracts the last segment from a $ref", () => {
-    expect(refToName("#/components/schemas/Foo")).toBe("Foo");
-  });
+describe('resolveType', () => {
+    it('resolves string type', () => {
+        expect(resolveType({ type: 'string' })).toBe('string');
+    });
 
-  it("handles deeply nested refs", () => {
-    expect(refToName("#/a/b/c/d/MyType")).toBe("MyType");
-  });
+    it('resolves integer type as number', () => {
+        expect(resolveType({ type: 'integer' })).toBe('number');
+    });
 
-  it("sanitizes dot-notation schema names", () => {
-    expect(refToName("#/components/schemas/billing.alert")).toBe("billing__alert");
-  });
+    it('resolves number type', () => {
+        expect(resolveType({ type: 'number' })).toBe('number');
+    });
 
-  it("sanitizes multi-dot schema names", () => {
-    expect(refToName("#/components/schemas/account.application.authorized")).toBe("account__application__authorized");
-  });
+    it('resolves boolean type', () => {
+        expect(resolveType({ type: 'boolean' })).toBe('boolean');
+    });
+
+    it('resolves $ref', () => {
+        expect(resolveType({ $ref: '#/components/schemas/Foo' })).toBe('Foo');
+    });
+
+    it('resolves array of strings', () => {
+        expect(resolveType({ type: 'array', items: { type: 'string' } })).toBe(
+            'string[]',
+        );
+    });
+
+    it('resolves array of $ref', () => {
+        expect(
+            resolveType({
+                type: 'array',
+                items: { $ref: '#/components/schemas/Bar' },
+            }),
+        ).toBe('Bar[]');
+    });
+
+    it('resolves nullable type', () => {
+        expect(resolveType({ type: 'string', nullable: true })).toBe(
+            'string | null',
+        );
+    });
+
+    it('resolves string enum', () => {
+        expect(
+            resolveType({ type: 'string', enum: ['A', 'B', 'C'] }),
+        ).toBe('"A" | "B" | "C"');
+    });
+
+    it('resolves plain object type as Record', () => {
+        expect(resolveType({ type: 'object' })).toBe('Record<string, unknown>');
+    });
+
+    it('resolves object with properties as inline object literal at depth 0', () => {
+        const result = resolveType({ type: 'object', properties: { foo: { type: 'string' } } });
+        expect(result).toContain('{');
+        expect(result).toContain('foo');
+        expect(result).toContain('string');
+    });
+
+    it('resolves object at depth 3+ as Record', () => {
+        const result = resolveType(
+            { type: 'object', properties: { foo: { type: 'string' } } },
+            {},
+            3,
+        );
+        expect(result).toBe('Record<string, unknown>');
+    });
+
+    it('returns unknown for unrecognized schemas', () => {
+        expect(resolveType({})).toBe('unknown');
+    });
+
+    it('wraps union items in parens for array', () => {
+        const result = resolveType({
+            type: 'array',
+            items: {
+                oneOf: [
+                    { $ref: '#/components/schemas/A' },
+                    { $ref: '#/components/schemas/B' },
+                ],
+            },
+        });
+        expect(result).toBe('(A | B)[]');
+    });
+
+    it('resolves allOf in property type', () => {
+        const result = resolveType({
+            allOf: [
+                { $ref: '#/components/schemas/Base' },
+                { $ref: '#/components/schemas/Extra' },
+            ],
+        });
+        expect(result).toBe('Base & Extra');
+    });
+
+    it('resolves oneOf in property type', () => {
+        const result = resolveType({
+            oneOf: [
+                { $ref: '#/components/schemas/A' },
+                { $ref: '#/components/schemas/B' },
+            ],
+        });
+        expect(result).toBe('A | B');
+    });
 });
 
-describe("sanitizeTypeName", () => {
-  it("replaces dots with double underscores", () => {
-    expect(sanitizeTypeName("billing.alert")).toBe("billing__alert");
-  });
+describe('refToName', () => {
+    it('extracts the last segment from a $ref', () => {
+        expect(refToName('#/components/schemas/Foo')).toBe('Foo');
+    });
 
-  it("handles multiple dots", () => {
-    expect(sanitizeTypeName("account.application.authorized")).toBe("account__application__authorized");
-  });
+    it('handles deeply nested refs', () => {
+        expect(refToName('#/a/b/c/d/MyType')).toBe('MyType');
+    });
 
-  it("leaves clean names unchanged", () => {
-    expect(sanitizeTypeName("payment_intent")).toBe("payment_intent");
-  });
+    it('sanitizes dot-notation schema names', () => {
+        expect(refToName('#/components/schemas/billing.alert')).toBe('billing__alert');
+    });
 
-  it("handles names with mixed problematic characters", () => {
-    expect(sanitizeTypeName("foo.bar-baz")).toBe("foo__bar_baz");
-  });
-
-  it("avoids collisions between dot and underscore variants", () => {
-    expect(sanitizeTypeName("billing.alert_triggered")).not.toBe(
-      sanitizeTypeName("billing.alert.triggered"),
-    );
-  });
+    it('sanitizes multi-dot schema names', () => {
+        expect(refToName('#/components/schemas/account.application.authorized')).toBe('account__application__authorized');
+    });
 });
 
-describe("schemaToTsType", () => {
-  it("maps integer to number", () => {
-    expect(schemaToTsType({ type: "integer" })).toBe("number");
-  });
+describe('sanitizeTypeName', () => {
+    it('replaces dots with double underscores', () => {
+        expect(sanitizeTypeName('billing.alert')).toBe('billing__alert');
+    });
 
-  it("maps number to number", () => {
-    expect(schemaToTsType({ type: "number" })).toBe("number");
-  });
+    it('handles multiple dots', () => {
+        expect(sanitizeTypeName('account.application.authorized')).toBe('account__application__authorized');
+    });
 
-  it("maps boolean to boolean", () => {
-    expect(schemaToTsType({ type: "boolean" })).toBe("boolean");
-  });
+    it('leaves clean names unchanged', () => {
+        expect(sanitizeTypeName('payment_intent')).toBe('payment_intent');
+    });
 
-  it("maps string to string", () => {
-    expect(schemaToTsType({ type: "string" })).toBe("string");
-  });
+    it('handles names with mixed problematic characters', () => {
+        expect(sanitizeTypeName('foo.bar-baz')).toBe('foo__bar_baz');
+    });
 
-  it("maps $ref to type name", () => {
-    expect(schemaToTsType({ $ref: "#/components/schemas/Widget" })).toBe(
-      "Widget",
-    );
-  });
-
-  it("returns unknown for unrecognized", () => {
-    expect(schemaToTsType({ type: "array" })).toBe("unknown");
-  });
+    it('avoids collisions between dot and underscore variants', () => {
+        expect(sanitizeTypeName('billing.alert_triggered')).not.toBe(
+            sanitizeTypeName('billing.alert.triggered'),
+        );
+    });
 });
 
-describe("sanitizeVar", () => {
-  it("replaces non-alphanumeric chars with underscores", () => {
-    expect(sanitizeVar("foo-bar")).toBe("foo_bar");
-  });
+describe('schemaToTsType', () => {
+    it('maps integer to number', () => {
+        expect(schemaToTsType({ type: 'integer' })).toBe('number');
+    });
 
-  it("replaces dots and spaces", () => {
-    expect(sanitizeVar("foo.bar baz")).toBe("foo_bar_baz");
-  });
+    it('maps number to number', () => {
+        expect(schemaToTsType({ type: 'number' })).toBe('number');
+    });
 
-  it("keeps alphanumeric chars unchanged", () => {
-    expect(sanitizeVar("fooBar123")).toBe("fooBar123");
-  });
+    it('maps boolean to boolean', () => {
+        expect(schemaToTsType({ type: 'boolean' })).toBe('boolean');
+    });
+
+    it('maps string to string', () => {
+        expect(schemaToTsType({ type: 'string' })).toBe('string');
+    });
+
+    it('maps $ref to type name', () => {
+        expect(schemaToTsType({ $ref: '#/components/schemas/Widget' })).toBe(
+            'Widget',
+        );
+    });
+
+    it('returns unknown for unrecognized', () => {
+        expect(schemaToTsType({ type: 'array' })).toBe('unknown');
+    });
 });
 
-describe("capitalize", () => {
-  it("capitalizes the first letter", () => {
-    expect(capitalize("hello")).toBe("Hello");
-  });
+describe('sanitizeVar', () => {
+    it('replaces non-alphanumeric chars with underscores', () => {
+        expect(sanitizeVar('foo-bar')).toBe('foo_bar');
+    });
 
-  it("handles single char", () => {
-    expect(capitalize("a")).toBe("A");
-  });
+    it('replaces dots and spaces', () => {
+        expect(sanitizeVar('foo.bar baz')).toBe('foo_bar_baz');
+    });
 
-  it("does not change already capitalized", () => {
-    expect(capitalize("Hello")).toBe("Hello");
-  });
-
-  it("handles empty string", () => {
-    expect(capitalize("")).toBe("");
-  });
+    it('keeps alphanumeric chars unchanged', () => {
+        expect(sanitizeVar('fooBar123')).toBe('fooBar123');
+    });
 });
 
-describe("resolveSchemaProps", () => {
-  it("returns empty array for undefined schema", () => {
-    expect(resolveSchemaProps(undefined, {})).toEqual([]);
-  });
+describe('capitalize', () => {
+    it('capitalizes the first letter', () => {
+        expect(capitalize('hello')).toBe('Hello');
+    });
 
-  it("returns empty array for schema without properties", () => {
-    expect(resolveSchemaProps({ type: "object" }, {})).toEqual([]);
-  });
+    it('handles single char', () => {
+        expect(capitalize('a')).toBe('A');
+    });
 
-  it("resolves basic properties", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        age: { type: "integer" },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result).toHaveLength(2);
-    expect(result[0].name).toBe("name");
-    expect(result[0].type).toBe("string");
-    expect(result[0].cliFlag).toBe("name");
-    expect(result[0].camelName).toBe("name");
-    expect(result[1].name).toBe("age");
-    expect(result[1].type).toBe("number");
-  });
+    it('does not change already capitalized', () => {
+        expect(capitalize('Hello')).toBe('Hello');
+    });
 
-  it("preserves camelCase property names as CLI flags", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        firstName: { type: "string" },
-        lastName: { type: "string" },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result[0].cliFlag).toBe("firstName");
-    expect(result[1].cliFlag).toBe("lastName");
-  });
+    it('handles empty string', () => {
+        expect(capitalize('')).toBe('');
+    });
+});
 
-  it("resolves $ref schemas", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Widget: {
-        type: "object",
-        properties: {
-          color: { type: "string" },
-        },
-      },
-    };
-    const schema: OpenApiSchema = {
-      $ref: "#/components/schemas/Widget",
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("color");
-  });
+describe('resolveSchemaProps', () => {
+    it('returns empty array for undefined schema', () => {
+        expect(resolveSchemaProps(undefined, {})).toEqual([]);
+    });
 
-  it("merges allOf properties", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Base: {
-        type: "object",
-        properties: {
-          id: { type: "integer" },
-        },
-      },
-      Extra: {
-        type: "object",
-        properties: {
-          label: { type: "string" },
-        },
-      },
-    };
-    const schema: OpenApiSchema = {
-      allOf: [
-        { $ref: "#/components/schemas/Base" },
-        { $ref: "#/components/schemas/Extra" },
-      ],
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result).toHaveLength(2);
-    expect(result.map((p) => p.name)).toEqual(["id", "label"]);
-  });
+    it('returns empty array for schema without properties', () => {
+        expect(resolveSchemaProps({ type: 'object' }, {})).toEqual([]);
+    });
 
-  it("deduplicates allOf properties by name", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      Base: {
-        type: "object",
-        properties: {
-          id: { type: "integer" },
-          name: { type: "string" },
-        },
-      },
-    };
-    const schema: OpenApiSchema = {
-      allOf: [
-        { $ref: "#/components/schemas/Base" },
-        {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            extra: { type: "boolean" },
-          },
-        },
-      ],
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result).toHaveLength(3);
-    expect(result.map((p) => p.name)).toEqual(["id", "name", "extra"]);
-  });
+    it('resolves basic properties', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                age: { type: 'integer' },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result).toHaveLength(2);
+        expect(result[0].name).toBe('name');
+        expect(result[0].type).toBe('string');
+        expect(result[0].cliFlag).toBe('name');
+        expect(result[0].camelName).toBe('name');
+        expect(result[1].name).toBe('age');
+        expect(result[1].type).toBe('number');
+    });
 
-  it("resolves oneOf variants with variant tags", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      TypeA: {
-        type: "object",
-        properties: {
-          fieldA: { type: "string" },
-        },
-      },
-      TypeB: {
-        type: "object",
-        properties: {
-          fieldB: { type: "number" },
-        },
-      },
-    };
-    const schema: OpenApiSchema = {
-      oneOf: [
-        { $ref: "#/components/schemas/TypeA" },
-        { $ref: "#/components/schemas/TypeB" },
-      ],
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result).toHaveLength(2);
-    expect(result[0].name).toBe("fieldA");
-    expect(result[0].variant).toBe("TypeA");
-    expect(result[1].name).toBe("fieldB");
-    expect(result[1].variant).toBe("TypeB");
-  });
+    it('preserves camelCase property names as CLI flags', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                firstName: { type: 'string' },
+                lastName: { type: 'string' },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result[0].cliFlag).toBe('firstName');
+        expect(result[1].cliFlag).toBe('lastName');
+    });
 
-  it("resolves single-variant oneOf without variant tags", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      OnlyType: {
-        type: "object",
-        properties: {
-          field: { type: "string" },
-        },
-      },
-    };
-    const schema: OpenApiSchema = {
-      oneOf: [{ $ref: "#/components/schemas/OnlyType" }],
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("field");
-    expect(result[0].variant).toBeUndefined();
-  });
+    it('resolves $ref schemas', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Widget: {
+                type: 'object',
+                properties: {
+                    color: { type: 'string' },
+                },
+            },
+        };
+        const schema: OpenApiSchema = {
+            $ref: '#/components/schemas/Widget',
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('color');
+    });
 
-  it("resolves enum values from direct enum", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        status: { type: "string", enum: ["ACTIVE", "INACTIVE"] },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result[0].enumValues).toEqual(["ACTIVE", "INACTIVE"]);
-  });
+    it('merges allOf properties', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Base: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                },
+            },
+            Extra: {
+                type: 'object',
+                properties: {
+                    label: { type: 'string' },
+                },
+            },
+        };
+        const schema: OpenApiSchema = {
+            allOf: [
+                { $ref: '#/components/schemas/Base' },
+                { $ref: '#/components/schemas/Extra' },
+            ],
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result).toHaveLength(2);
+        expect(result.map(p => p.name)).toEqual(['id', 'label']);
+    });
 
-  it("resolves enum values from $ref", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      StatusEnum: { type: "string", enum: ["OPEN", "CLOSED"] },
-    };
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        status: { $ref: "#/components/schemas/StatusEnum" },
-      },
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result[0].enumValues).toEqual(["OPEN", "CLOSED"]);
-  });
+    it('deduplicates allOf properties by name', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            Base: {
+                type: 'object',
+                properties: {
+                    id: { type: 'integer' },
+                    name: { type: 'string' },
+                },
+            },
+        };
+        const schema: OpenApiSchema = {
+            allOf: [
+                { $ref: '#/components/schemas/Base' },
+                {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string' },
+                        extra: { type: 'boolean' },
+                    },
+                },
+            ],
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result).toHaveLength(3);
+        expect(result.map(p => p.name)).toEqual(['id', 'name', 'extra']);
+    });
 
-  it("unwraps array items", () => {
-    const schema: OpenApiSchema = {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-        },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("name");
-  });
+    it('resolves oneOf variants with variant tags', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            TypeA: {
+                type: 'object',
+                properties: {
+                    fieldA: { type: 'string' },
+                },
+            },
+            TypeB: {
+                type: 'object',
+                properties: {
+                    fieldB: { type: 'number' },
+                },
+            },
+        };
+        const schema: OpenApiSchema = {
+            oneOf: [
+                { $ref: '#/components/schemas/TypeA' },
+                { $ref: '#/components/schemas/TypeB' },
+            ],
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result).toHaveLength(2);
+        expect(result[0].name).toBe('fieldA');
+        expect(result[0].variant).toBe('TypeA');
+        expect(result[1].name).toBe('fieldB');
+        expect(result[1].variant).toBe('TypeB');
+    });
 
-  it("skips readOnly properties", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        id: { type: "integer", readOnly: true },
-        name: { type: "string" },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe("name");
-  });
+    it('resolves single-variant oneOf without variant tags', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            OnlyType: {
+                type: 'object',
+                properties: {
+                    field: { type: 'string' },
+                },
+            },
+        };
+        const schema: OpenApiSchema = {
+            oneOf: [{ $ref: '#/components/schemas/OnlyType' }],
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('field');
+        expect(result[0].variant).toBeUndefined();
+    });
 
-  it("tracks required properties", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      required: ["name"],
-      properties: {
-        name: { type: "string" },
-        optional: { type: "string" },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result[0].required).toBe(true);
-    expect(result[1].required).toBe(false);
-  });
+    it('resolves enum values from direct enum', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                status: { type: 'string', enum: ['ACTIVE', 'INACTIVE'] },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result[0].enumValues).toEqual(['ACTIVE', 'INACTIVE']);
+    });
 
-  it("includes description, format, default, deprecated from property schema", () => {
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        email: {
-          type: "string",
-          description: "User email",
-          format: "email",
-          default: "test@example.com",
-          deprecated: true,
-        },
-      },
-    };
-    const result = resolveSchemaProps(schema, {});
-    expect(result[0].description).toBe("User email");
-    expect(result[0].format).toBe("email");
-    expect(result[0].default).toBe("test@example.com");
-    expect(result[0].deprecated).toBe(true);
-  });
+    it('resolves enum values from $ref', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            StatusEnum: { type: 'string', enum: ['OPEN', 'CLOSED'] },
+        };
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                status: { $ref: '#/components/schemas/StatusEnum' },
+            },
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result[0].enumValues).toEqual(['OPEN', 'CLOSED']);
+    });
 
-  it("inherits description from $ref schema", () => {
-    const schemas: Record<string, OpenApiSchema> = {
-      StatusEnum: {
-        type: "string",
-        enum: ["ACTIVE", "INACTIVE"],
-        description: "Status of the resource",
-      },
-    };
-    const schema: OpenApiSchema = {
-      type: "object",
-      properties: {
-        status: { $ref: "#/components/schemas/StatusEnum" },
-      },
-    };
-    const result = resolveSchemaProps(schema, schemas);
-    expect(result[0].description).toBe("Status of the resource");
-  });
+    it('unwraps array items', () => {
+        const schema: OpenApiSchema = {
+            type: 'array',
+            items: {
+                type: 'object',
+                properties: {
+                    name: { type: 'string' },
+                },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('name');
+    });
+
+    it('skips readOnly properties', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                id: { type: 'integer', readOnly: true },
+                name: { type: 'string' },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('name');
+    });
+
+    it('tracks required properties', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            required: ['name'],
+            properties: {
+                name: { type: 'string' },
+                optional: { type: 'string' },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result[0].required).toBe(true);
+        expect(result[1].required).toBe(false);
+    });
+
+    it('includes description, format, default, deprecated from property schema', () => {
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                email: {
+                    type: 'string',
+                    description: 'User email',
+                    format: 'email',
+                    default: 'test@example.com',
+                    deprecated: true,
+                },
+            },
+        };
+        const result = resolveSchemaProps(schema, {});
+        expect(result[0].description).toBe('User email');
+        expect(result[0].format).toBe('email');
+        expect(result[0].default).toBe('test@example.com');
+        expect(result[0].deprecated).toBe(true);
+    });
+
+    it('inherits description from $ref schema', () => {
+        const schemas: Record<string, OpenApiSchema> = {
+            StatusEnum: {
+                type: 'string',
+                enum: ['ACTIVE', 'INACTIVE'],
+                description: 'Status of the resource',
+            },
+        };
+        const schema: OpenApiSchema = {
+            type: 'object',
+            properties: {
+                status: { $ref: '#/components/schemas/StatusEnum' },
+            },
+        };
+        const result = resolveSchemaProps(schema, schemas);
+        expect(result[0].description).toBe('Status of the resource');
+    });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,422 +1,421 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, existsSync, readFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
-  resolveAuth,
-  saveEnvironment,
-  switchEnvironment,
-  listEnvironments,
-  getActiveEnvConfig,
-  updateEnvironmentField,
-  loadConfig,
-} from "../src/config";
+    resolveAuth,
+    saveEnvironment,
+    switchEnvironment,
+    listEnvironments,
+    getActiveEnvConfig,
+    updateEnvironmentField,
+    loadConfig,
+} from '../src/config';
 
 function makeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "cli-config-test-"));
+    return mkdtempSync(join(tmpdir(), 'cli-config-test-'));
 }
 
-describe("config management", () => {
-  let tmpDir: string;
-  let configPath: string;
+describe('config management', () => {
+    let tmpDir: string;
+    let configPath: string;
 
-  beforeEach(() => {
-    tmpDir = makeTmpDir();
-    configPath = join(tmpDir, "config.json");
-  });
-
-  afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
-    // Clean env vars that tests may set
-    delete process.env.MYAPP_URL;
-    delete process.env.MYAPP_USER;
-    delete process.env.MYAPP_PASS;
-    delete process.env.TESTCLI_URL;
-    delete process.env.TESTCLI_USER;
-    delete process.env.TESTCLI_PASS;
-  });
-
-  describe("resolveAuth()", () => {
-    test("reads env vars with parameterized prefix", () => {
-      process.env.MYAPP_URL = "https://env.example.com";
-      process.env.MYAPP_USER = "envuser";
-      process.env.MYAPP_PASS = "envpass";
-
-      const result = resolveAuth("myapp", { configPath });
-      expect(result).not.toBeNull();
-      expect(result!.baseUrl).toBe("https://env.example.com");
-      expect(result!.username).toBe("envuser");
-      expect(result!.password).toBe("envpass");
+    beforeEach(() => {
+        tmpDir = makeTmpDir();
+        configPath = join(tmpDir, 'config.json');
     });
 
-    test("env vars take precedence over config file", async () => {
-      await saveEnvironment("testcli", "prod", {
-        url: "https://file.example.com",
-        user: "fileuser",
-        password: "filepass",
-      }, true, { configPath, allowInsecureStorage: true });
-
-      process.env.TESTCLI_URL = "https://env.example.com";
-      process.env.TESTCLI_USER = "envuser";
-      process.env.TESTCLI_PASS = "envpass";
-
-      const result = resolveAuth("testcli", { configPath });
-      expect(result!.baseUrl).toBe("https://env.example.com");
-      expect(result!.username).toBe("envuser");
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
+        // Clean env vars that tests may set
+        delete process.env.MYAPP_URL;
+        delete process.env.MYAPP_USER;
+        delete process.env.MYAPP_PASS;
+        delete process.env.TESTCLI_URL;
+        delete process.env.TESTCLI_USER;
+        delete process.env.TESTCLI_PASS;
     });
 
-    test("reads config file and returns active environment", async () => {
-      await saveEnvironment("myapp", "staging", {
-        url: "http://localhost:9090",
-        user: "staginguser",
-        password: "stagingpass",
-      }, true, { configPath });
+    describe('resolveAuth()', () => {
+        test('reads env vars with parameterized prefix', () => {
+            process.env.MYAPP_URL = 'https://env.example.com';
+            process.env.MYAPP_USER = 'envuser';
+            process.env.MYAPP_PASS = 'envpass';
 
-      const result = resolveAuth("myapp", { configPath });
-      expect(result).not.toBeNull();
-      expect(result!.baseUrl).toBe("http://localhost:9090");
-      expect(result!.username).toBe("staginguser");
-      expect(result!.password).toBe("stagingpass");
+            const result = resolveAuth('myapp', { configPath });
+            expect(result).not.toBeNull();
+            expect(result!.baseUrl).toBe('https://env.example.com');
+            expect(result!.username).toBe('envuser');
+            expect(result!.password).toBe('envpass');
+        });
+
+        test('env vars take precedence over config file', async () => {
+            await saveEnvironment('testcli', 'prod', {
+                url: 'https://file.example.com',
+                user: 'fileuser',
+                password: 'filepass',
+            }, true, { configPath, allowInsecureStorage: true });
+
+            process.env.TESTCLI_URL = 'https://env.example.com';
+            process.env.TESTCLI_USER = 'envuser';
+            process.env.TESTCLI_PASS = 'envpass';
+
+            const result = resolveAuth('testcli', { configPath });
+            expect(result!.baseUrl).toBe('https://env.example.com');
+            expect(result!.username).toBe('envuser');
+        });
+
+        test('reads config file and returns active environment', async () => {
+            await saveEnvironment('myapp', 'staging', {
+                url: 'http://localhost:9090',
+                user: 'staginguser',
+                password: 'stagingpass',
+            }, true, { configPath });
+
+            const result = resolveAuth('myapp', { configPath });
+            expect(result).not.toBeNull();
+            expect(result!.baseUrl).toBe('http://localhost:9090');
+            expect(result!.username).toBe('staginguser');
+            expect(result!.password).toBe('stagingpass');
+        });
+
+        test('returns null when no env vars and no config file', () => {
+            const result = resolveAuth('myapp', { configPath });
+            expect(result).toBeNull();
+        });
+
+        test('returns null when env vars are partially set', () => {
+            process.env.MYAPP_URL = 'https://example.com';
+            // MYAPP_USER and MYAPP_PASS not set
+
+            const result = resolveAuth('myapp', { configPath });
+            expect(result).toBeNull();
+        });
+
+        test('uppercases cli name for env var prefix', () => {
+            process.env.MYAPP_URL = 'https://upper.example.com';
+            process.env.MYAPP_USER = 'upperuser';
+            process.env.MYAPP_PASS = 'upperpass';
+
+            const result = resolveAuth('MyApp', { configPath });
+            expect(result).not.toBeNull();
+            expect(result!.baseUrl).toBe('https://upper.example.com');
+        });
     });
 
-    test("returns null when no env vars and no config file", () => {
-      const result = resolveAuth("myapp", { configPath });
-      expect(result).toBeNull();
+    describe('saveEnvironment()', () => {
+        test('creates config file with correct structure', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'secret',
+            }, true, { configPath });
+
+            expect(existsSync(configPath)).toBe(true);
+
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.active).toBe('local');
+            expect(raw.environments.local).toEqual({
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'secret',
+            });
+        });
+
+        test('adds environment to existing config', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'secret',
+            }, true, { configPath });
+
+            await saveEnvironment('myapp', 'staging', {
+                url: 'http://localhost:9091',
+                user: 'stageuser',
+                password: 'stagepass',
+            }, false, { configPath });
+
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.active).toBe('local'); // didn't change active
+            expect(Object.keys(raw.environments)).toEqual(['local', 'staging']);
+        });
+
+        test('sets active when setActive is true (default)', async () => {
+            await saveEnvironment('myapp', 'first', {
+                url: 'http://first.example.com',
+                user: 'u1',
+                password: 'p1',
+            }, true, { configPath, allowInsecureStorage: true });
+
+            await saveEnvironment('myapp', 'second', {
+                url: 'http://second.example.com',
+                user: 'u2',
+                password: 'p2',
+            }, true, { configPath, allowInsecureStorage: true });
+
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.active).toBe('second');
+        });
+
+        test('preserves extra fields in environment object', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'secret',
+                projectId: 42,
+                region: 'us-east-1',
+            } as any, true, { configPath });
+
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.environments.local.projectId).toBe(42);
+            expect(raw.environments.local.region).toBe('us-east-1');
+        });
     });
 
-    test("returns null when env vars are partially set", () => {
-      process.env.MYAPP_URL = "https://example.com";
-      // MYAPP_USER and MYAPP_PASS not set
+    describe('switchEnvironment()', () => {
+        test('changes active environment', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'u',
+                password: 'p',
+            }, true, { configPath });
 
-      const result = resolveAuth("myapp", { configPath });
-      expect(result).toBeNull();
+            await saveEnvironment('myapp', 'prod', {
+                url: 'https://prod.example.com',
+                user: 'u2',
+                password: 'p2',
+            }, false, { configPath, allowInsecureStorage: true });
+
+            const switched = await switchEnvironment('myapp', 'prod', { configPath });
+            expect(switched).toBe(true);
+
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.active).toBe('prod');
+        });
+
+        test('returns false for non-existent environment', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'u',
+                password: 'p',
+            }, true, { configPath });
+
+            const switched = await switchEnvironment('myapp', 'missing', { configPath });
+            expect(switched).toBe(false);
+        });
+
+        test('returns false when no config file exists', async () => {
+            const switched = await switchEnvironment('myapp', 'anything', { configPath });
+            expect(switched).toBe(false);
+        });
     });
 
-    test("uppercases cli name for env var prefix", () => {
-      process.env.MYAPP_URL = "https://upper.example.com";
-      process.env.MYAPP_USER = "upperuser";
-      process.env.MYAPP_PASS = "upperpass";
+    describe('listEnvironments()', () => {
+        test('returns all environments with active flag', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'admin',
+                password: 'pass',
+            }, true, { configPath });
 
-      const result = resolveAuth("MyApp", { configPath });
-      expect(result).not.toBeNull();
-      expect(result!.baseUrl).toBe("https://upper.example.com");
-    });
-  });
+            await saveEnvironment('myapp', 'staging', {
+                url: 'http://localhost:9091',
+                user: 'stage',
+                password: 'pass2',
+            }, false, { configPath });
 
-  describe("saveEnvironment()", () => {
-    test("creates config file with correct structure", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "secret",
-      }, true, { configPath });
+            const envs = await listEnvironments('myapp', { configPath });
+            expect(envs).toHaveLength(2);
 
-      expect(existsSync(configPath)).toBe(true);
+            const local = envs.find(e => e.name === 'local');
+            expect(local).toBeDefined();
+            expect(local!.active).toBe(true);
+            expect(local!.url).toBe('http://localhost');
+            expect(local!.user).toBe('admin');
 
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.active).toBe("local");
-      expect(raw.environments.local).toEqual({
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "secret",
-      });
-    });
+            const staging = envs.find(e => e.name === 'staging');
+            expect(staging).toBeDefined();
+            expect(staging!.active).toBe(false);
+        });
 
-    test("adds environment to existing config", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "secret",
-      }, true, { configPath });
-
-      await saveEnvironment("myapp", "staging", {
-        url: "http://localhost:9091",
-        user: "stageuser",
-        password: "stagepass",
-      }, false, { configPath });
-
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.active).toBe("local"); // didn't change active
-      expect(Object.keys(raw.environments)).toEqual(["local", "staging"]);
+        test('returns empty array when no config file exists', async () => {
+            const envs = await listEnvironments('myapp', { configPath });
+            expect(envs).toEqual([]);
+        });
     });
 
-    test("sets active when setActive is true (default)", async () => {
-      await saveEnvironment("myapp", "first", {
-        url: "http://first.example.com",
-        user: "u1",
-        password: "p1",
-      }, true, { configPath, allowInsecureStorage: true });
+    describe('getActiveEnvConfig()', () => {
+        test('returns full env object including extra fields', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'secret',
+                projectId: 99,
+                customField: 'hello',
+            } as any, true, { configPath });
 
-      await saveEnvironment("myapp", "second", {
-        url: "http://second.example.com",
-        user: "u2",
-        password: "p2",
-      }, true, { configPath, allowInsecureStorage: true });
+            const env = getActiveEnvConfig('myapp', { configPath });
+            expect(env).not.toBeNull();
+            expect(env!.url).toBe('http://localhost:8080');
+            expect(env!.user).toBe('admin');
+            expect(env!.password).toBe('secret');
+            expect(env!.projectId).toBe(99);
+            expect(env!.customField).toBe('hello');
+        });
 
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.active).toBe("second");
+        test('returns null when no config file exists', () => {
+            const env = getActiveEnvConfig('myapp', { configPath });
+            expect(env).toBeNull();
+        });
+
+        test('returns null when active environment is missing', async () => {
+            // Write a config with an active that doesn't exist
+            const { writeFileSync, mkdirSync } = await import('fs');
+            const { dirname } = await import('path');
+            mkdirSync(dirname(configPath), { recursive: true });
+            writeFileSync(configPath, JSON.stringify({
+                active: 'missing',
+                environments: {
+                    local: { url: 'http://localhost', user: 'u', password: 'p' },
+                },
+            }));
+
+            const env = getActiveEnvConfig('myapp', { configPath });
+            expect(env).toBeNull();
+        });
     });
 
-    test("preserves extra fields in environment object", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "secret",
-        projectId: 42,
-        region: "us-east-1",
-      } as any, true, { configPath });
+    describe('updateEnvironmentField()', () => {
+        test('sets arbitrary field on active environment', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'admin',
+                password: 'pass',
+            }, true, { configPath });
 
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.environments.local.projectId).toBe(42);
-      expect(raw.environments.local.region).toBe("us-east-1");
-    });
-  });
+            await updateEnvironmentField('myapp', 'projectId', 42, { configPath });
 
-  describe("switchEnvironment()", () => {
-    test("changes active environment", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "u",
-        password: "p",
-      }, true, { configPath });
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.environments.local.projectId).toBe(42);
+        });
 
-      await saveEnvironment("myapp", "prod", {
-        url: "https://prod.example.com",
-        user: "u2",
-        password: "p2",
-      }, false, { configPath, allowInsecureStorage: true });
+        test('overwrites existing field value', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'admin',
+                password: 'pass',
+                region: 'us-east-1',
+            } as any, true, { configPath });
 
-      const switched = await switchEnvironment("myapp", "prod", { configPath });
-      expect(switched).toBe(true);
+            await updateEnvironmentField('myapp', 'region', 'eu-west-1', { configPath });
 
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.active).toBe("prod");
-    });
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.environments.local.region).toBe('eu-west-1');
+        });
 
-    test("returns false for non-existent environment", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "u",
-        password: "p",
-      }, true, { configPath });
+        test('does nothing when no config exists', async () => {
+            // Should not throw
+            await updateEnvironmentField('myapp', 'key', 'value', { configPath });
+            expect(existsSync(configPath)).toBe(false);
+        });
 
-      const switched = await switchEnvironment("myapp", "missing", { configPath });
-      expect(switched).toBe(false);
-    });
+        test('does nothing when no active environment', async () => {
+            const { writeFileSync, mkdirSync } = await import('fs');
+            const { dirname } = await import('path');
+            mkdirSync(dirname(configPath), { recursive: true });
+            writeFileSync(configPath, JSON.stringify({
+                active: 'missing',
+                environments: {},
+            }));
 
-    test("returns false when no config file exists", async () => {
-      const switched = await switchEnvironment("myapp", "anything", { configPath });
-      expect(switched).toBe(false);
-    });
-  });
+            await updateEnvironmentField('myapp', 'key', 'value', { configPath });
 
-  describe("listEnvironments()", () => {
-    test("returns all environments with active flag", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "admin",
-        password: "pass",
-      }, true, { configPath });
-
-      await saveEnvironment("myapp", "staging", {
-        url: "http://localhost:9091",
-        user: "stage",
-        password: "pass2",
-      }, false, { configPath });
-
-      const envs = await listEnvironments("myapp", { configPath });
-      expect(envs).toHaveLength(2);
-
-      const local = envs.find((e) => e.name === "local");
-      expect(local).toBeDefined();
-      expect(local!.active).toBe(true);
-      expect(local!.url).toBe("http://localhost");
-      expect(local!.user).toBe("admin");
-
-      const staging = envs.find((e) => e.name === "staging");
-      expect(staging).toBeDefined();
-      expect(staging!.active).toBe(false);
+            const raw = JSON.parse(readFileSync(configPath, 'utf-8'));
+            expect(raw.environments).toEqual({});
+        });
     });
 
-    test("returns empty array when no config file exists", async () => {
-      const envs = await listEnvironments("myapp", { configPath });
-      expect(envs).toEqual([]);
-    });
-  });
-
-  describe("getActiveEnvConfig()", () => {
-    test("returns full env object including extra fields", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "secret",
-        projectId: 99,
-        customField: "hello",
-      } as any, true, { configPath });
-
-      const env = getActiveEnvConfig("myapp", { configPath });
-      expect(env).not.toBeNull();
-      expect(env!.url).toBe("http://localhost:8080");
-      expect(env!.user).toBe("admin");
-      expect(env!.password).toBe("secret");
-      expect(env!.projectId).toBe(99);
-      expect(env!.customField).toBe("hello");
+    describe('config paths', () => {
+        test('uses ~/.<name>/config.json by default', () => {
+            // We can't easily test the default path without side effects,
+            // but we can verify resolveAuth doesn't crash with a missing file at the default path
+            const result = resolveAuth('nonexistent_cli_test_xyz');
+            expect(result).toBeNull();
+        });
     });
 
-    test("returns null when no config file exists", () => {
-      const env = getActiveEnvConfig("myapp", { configPath });
-      expect(env).toBeNull();
+    describe('loadConfig()', () => {
+        test('returns null for missing file', async () => {
+            const config = await loadConfig('myapp', { configPath });
+            expect(config).toBeNull();
+        });
+
+        test('loads valid config', async () => {
+            await saveEnvironment('myapp', 'local', {
+                url: 'http://localhost',
+                user: 'u',
+                password: 'p',
+            }, true, { configPath });
+
+            const config = await loadConfig('myapp', { configPath });
+            expect(config).not.toBeNull();
+            expect(config!.active).toBe('local');
+            expect(config!.environments.local.url).toBe('http://localhost');
+        });
     });
 
-    test("returns null when active environment is missing", async () => {
-      // Write a config with an active that doesn't exist
-      const { writeFileSync, mkdirSync } = await import("fs");
-      const { dirname } = await import("path");
-      mkdirSync(dirname(configPath), { recursive: true });
-      writeFileSync(configPath, JSON.stringify({
-        active: "missing",
-        environments: {
-          local: { url: "http://localhost", user: "u", password: "p" },
-        },
-      }));
+    describe('saveEnvironment() URL classification', () => {
+        test('allows localhost URLs', async () => {
+            await saveEnvironment('testcli', 'local', {
+                url: 'http://localhost:8080',
+                user: 'admin',
+                password: 'pass',
+            }, true, { configPath });
 
-      const env = getActiveEnvConfig("myapp", { configPath });
-      expect(env).toBeNull();
+            const config = await loadConfig('testcli', { configPath });
+            expect(config!.environments.local.password).toBe('pass');
+        });
+
+        test('blocks production URLs by default', async () => {
+            expect(
+                saveEnvironment('testcli', 'prod', {
+                    url: 'https://api.example.com',
+                    user: 'admin',
+                    password: 'pass',
+                }, true, { configPath }),
+            ).rejects.toThrow('Production API detected');
+        });
+
+        test('allows production URLs with allowInsecureStorage', async () => {
+            await saveEnvironment('testcli', 'prod', {
+                url: 'https://api.example.com',
+                user: 'admin',
+                password: 'pass',
+            }, true, { configPath, allowInsecureStorage: true });
+
+            const config = await loadConfig('testcli', { configPath });
+            expect(config!.environments.prod.password).toBe('pass');
+        });
+
+        test('allows IPs in allowed CIDRs', async () => {
+            await saveEnvironment('testcli', 'internal', {
+                url: 'http://192.168.1.50:8080',
+                user: 'admin',
+                password: 'pass',
+            }, true, { configPath, allowedCidrs: ['192.168.1.0/24'] });
+
+            const config = await loadConfig('testcli', { configPath });
+            expect(config!.environments.internal.password).toBe('pass');
+        });
+
+        test('blocks IPs outside allowed CIDRs', async () => {
+            expect(
+                saveEnvironment('testcli', 'external', {
+                    url: 'http://54.231.10.5:8080',
+                    user: 'admin',
+                    password: 'pass',
+                }, true, { configPath, allowedCidrs: ['192.168.1.0/24'] }),
+            ).rejects.toThrow('Production API detected');
+        });
     });
-  });
-
-  describe("updateEnvironmentField()", () => {
-    test("sets arbitrary field on active environment", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "admin",
-        password: "pass",
-      }, true, { configPath });
-
-      await updateEnvironmentField("myapp", "projectId", 42, { configPath });
-
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.environments.local.projectId).toBe(42);
-    });
-
-    test("overwrites existing field value", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "admin",
-        password: "pass",
-        region: "us-east-1",
-      } as any, true, { configPath });
-
-      await updateEnvironmentField("myapp", "region", "eu-west-1", { configPath });
-
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.environments.local.region).toBe("eu-west-1");
-    });
-
-    test("does nothing when no config exists", async () => {
-      // Should not throw
-      await updateEnvironmentField("myapp", "key", "value", { configPath });
-      expect(existsSync(configPath)).toBe(false);
-    });
-
-    test("does nothing when no active environment", async () => {
-      const { writeFileSync, mkdirSync } = await import("fs");
-      const { dirname } = await import("path");
-      mkdirSync(dirname(configPath), { recursive: true });
-      writeFileSync(configPath, JSON.stringify({
-        active: "missing",
-        environments: {},
-      }));
-
-      await updateEnvironmentField("myapp", "key", "value", { configPath });
-
-      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
-      expect(raw.environments).toEqual({});
-    });
-  });
-
-  describe("config paths", () => {
-    test("uses ~/.<name>/config.json by default", () => {
-      const { homedir } = require("os");
-      // We can't easily test the default path without side effects,
-      // but we can verify resolveAuth doesn't crash with a missing file at the default path
-      const result = resolveAuth("nonexistent_cli_test_xyz");
-      expect(result).toBeNull();
-    });
-  });
-
-  describe("loadConfig()", () => {
-    test("returns null for missing file", async () => {
-      const config = await loadConfig("myapp", { configPath });
-      expect(config).toBeNull();
-    });
-
-    test("loads valid config", async () => {
-      await saveEnvironment("myapp", "local", {
-        url: "http://localhost",
-        user: "u",
-        password: "p",
-      }, true, { configPath });
-
-      const config = await loadConfig("myapp", { configPath });
-      expect(config).not.toBeNull();
-      expect(config!.active).toBe("local");
-      expect(config!.environments.local.url).toBe("http://localhost");
-    });
-  });
-
-  describe("saveEnvironment() URL classification", () => {
-    test("allows localhost URLs", async () => {
-      await saveEnvironment("testcli", "local", {
-        url: "http://localhost:8080",
-        user: "admin",
-        password: "pass",
-      }, true, { configPath });
-
-      const config = await loadConfig("testcli", { configPath });
-      expect(config!.environments.local.password).toBe("pass");
-    });
-
-    test("blocks production URLs by default", async () => {
-      expect(
-        saveEnvironment("testcli", "prod", {
-          url: "https://api.example.com",
-          user: "admin",
-          password: "pass",
-        }, true, { configPath }),
-      ).rejects.toThrow("Production API detected");
-    });
-
-    test("allows production URLs with allowInsecureStorage", async () => {
-      await saveEnvironment("testcli", "prod", {
-        url: "https://api.example.com",
-        user: "admin",
-        password: "pass",
-      }, true, { configPath, allowInsecureStorage: true });
-
-      const config = await loadConfig("testcli", { configPath });
-      expect(config!.environments.prod.password).toBe("pass");
-    });
-
-    test("allows IPs in allowed CIDRs", async () => {
-      await saveEnvironment("testcli", "internal", {
-        url: "http://192.168.1.50:8080",
-        user: "admin",
-        password: "pass",
-      }, true, { configPath, allowedCidrs: ["192.168.1.0/24"] });
-
-      const config = await loadConfig("testcli", { configPath });
-      expect(config!.environments.internal.password).toBe("pass");
-    });
-
-    test("blocks IPs outside allowed CIDRs", async () => {
-      expect(
-        saveEnvironment("testcli", "external", {
-          url: "http://54.231.10.5:8080",
-          user: "admin",
-          password: "pass",
-        }, true, { configPath, allowedCidrs: ["192.168.1.0/24"] }),
-      ).rejects.toThrow("Production API detected");
-    });
-  });
 });

--- a/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
+++ b/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
@@ -1,5 +1,10 @@
+import type { CustomResolverHelpers } from '../../../../../src/types';
+
 export const name = '_uppercase';
 
-export default function uppercase(argsStr?: string): string {
-    return (argsStr ?? '').toUpperCase();
+export default function uppercase(argsStr?: string, helpers?: CustomResolverHelpers): string {
+    const raw = argsStr ?? '';
+    const resolved = helpers ? String(helpers.resolve(raw)) : raw;
+
+    return resolved.toUpperCase();
 }

--- a/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
+++ b/tests/e2e-tutorial/tutorial-app/.apijack/resolvers/uppercase.ts
@@ -1,0 +1,5 @@
+export const name = '_uppercase';
+
+export default function uppercase(argsStr?: string): string {
+    return (argsStr ?? '').toUpperCase();
+}

--- a/tests/e2e-tutorial/tutorial-app/src/auth.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/auth.ts
@@ -1,20 +1,23 @@
-const USERNAME = "admin";
-const PASSWORD = "admin";
+const USERNAME = 'admin';
+const PASSWORD = 'admin';
 
 export function checkAuth(req: Request): boolean {
-  const header = req.headers.get("Authorization");
-  if (!header?.startsWith("Basic ")) return false;
-  const decoded = atob(header.slice(6));
-  const [user, pass] = decoded.split(":");
-  return user === USERNAME && pass === PASSWORD;
+    const header = req.headers.get('Authorization');
+
+    if (!header?.startsWith('Basic ')) return false;
+
+    const decoded = atob(header.slice(6));
+    const [user, pass] = decoded.split(':');
+
+    return user === USERNAME && pass === PASSWORD;
 }
 
 export function unauthorizedResponse(): Response {
-  return new Response(JSON.stringify({ error: "Unauthorized" }), {
-    status: 401,
-    headers: {
-      "Content-Type": "application/json",
-      "WWW-Authenticate": 'Basic realm="TODO API"',
-    },
-  });
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: {
+            'Content-Type': 'application/json',
+            'WWW-Authenticate': 'Basic realm="TODO API"',
+        },
+    });
 }

--- a/tests/e2e-tutorial/tutorial-app/src/openapi.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/openapi.ts
@@ -1,187 +1,187 @@
 export function getSpec() {
-  return {
-    openapi: "3.0.3",
-    info: {
-      title: "TODO API",
-      version: "1.0.0",
-      description: "A simple TODO API for the apijack tutorial",
-    },
-    servers: [{ url: "http://localhost:3456" }],
-    tags: [{ name: "todos", description: "TODO operations" }],
-    paths: {
-      "/todos": {
-        get: {
-          operationId: "listTodos",
-          tags: ["todos"],
-          summary: "List all TODOs",
-          responses: {
-            "200": {
-              description: "List of TODOs",
-              content: {
-                "application/json": {
-                  schema: {
-                    type: "array",
-                    items: { $ref: "#/components/schemas/Todo" },
-                  },
+    return {
+        openapi: '3.0.3',
+        info: {
+            title: 'TODO API',
+            version: '1.0.0',
+            description: 'A simple TODO API for the apijack tutorial',
+        },
+        servers: [{ url: 'http://localhost:3456' }],
+        tags: [{ name: 'todos', description: 'TODO operations' }],
+        paths: {
+            '/todos': {
+                get: {
+                    operationId: 'listTodos',
+                    tags: ['todos'],
+                    summary: 'List all TODOs',
+                    responses: {
+                        200: {
+                            description: 'List of TODOs',
+                            content: {
+                                'application/json': {
+                                    schema: {
+                                        type: 'array',
+                                        items: { $ref: '#/components/schemas/Todo' },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    security: [{ basicAuth: [] }],
                 },
-              },
-            },
-          },
-          security: [{ basicAuth: [] }],
-        },
-        post: {
-          operationId: "createTodo",
-          tags: ["todos"],
-          summary: "Create a TODO",
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/CreateTodo" },
-              },
-            },
-          },
-          responses: {
-            "201": {
-              description: "Created TODO",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Todo" },
+                post: {
+                    operationId: 'createTodo',
+                    tags: ['todos'],
+                    summary: 'Create a TODO',
+                    requestBody: {
+                        required: true,
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/CreateTodo' },
+                            },
+                        },
+                    },
+                    responses: {
+                        201: {
+                            description: 'Created TODO',
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/Todo' },
+                                },
+                            },
+                        },
+                    },
+                    security: [{ basicAuth: [] }],
                 },
-              },
             },
-          },
-          security: [{ basicAuth: [] }],
-        },
-      },
-      "/todos/{id}": {
-        get: {
-          operationId: "getTodo",
-          tags: ["todos"],
-          summary: "Get a TODO by ID",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-              description: "TODO ID",
-            },
-          ],
-          responses: {
-            "200": {
-              description: "TODO found",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Todo" },
+            '/todos/{id}': {
+                get: {
+                    operationId: 'getTodo',
+                    tags: ['todos'],
+                    summary: 'Get a TODO by ID',
+                    parameters: [
+                        {
+                            name: 'id',
+                            in: 'path',
+                            required: true,
+                            schema: { type: 'string' },
+                            description: 'TODO ID',
+                        },
+                    ],
+                    responses: {
+                        200: {
+                            description: 'TODO found',
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/Todo' },
+                                },
+                            },
+                        },
+                        404: { description: 'TODO not found' },
+                    },
+                    security: [{ basicAuth: [] }],
                 },
-              },
-            },
-            "404": { description: "TODO not found" },
-          },
-          security: [{ basicAuth: [] }],
-        },
-        patch: {
-          operationId: "updateTodo",
-          tags: ["todos"],
-          summary: "Update a TODO",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-              description: "TODO ID",
-            },
-          ],
-          requestBody: {
-            required: true,
-            content: {
-              "application/json": {
-                schema: { $ref: "#/components/schemas/UpdateTodo" },
-              },
-            },
-          },
-          responses: {
-            "200": {
-              description: "Updated TODO",
-              content: {
-                "application/json": {
-                  schema: { $ref: "#/components/schemas/Todo" },
+                patch: {
+                    operationId: 'updateTodo',
+                    tags: ['todos'],
+                    summary: 'Update a TODO',
+                    parameters: [
+                        {
+                            name: 'id',
+                            in: 'path',
+                            required: true,
+                            schema: { type: 'string' },
+                            description: 'TODO ID',
+                        },
+                    ],
+                    requestBody: {
+                        required: true,
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/UpdateTodo' },
+                            },
+                        },
+                    },
+                    responses: {
+                        200: {
+                            description: 'Updated TODO',
+                            content: {
+                                'application/json': {
+                                    schema: { $ref: '#/components/schemas/Todo' },
+                                },
+                            },
+                        },
+                        404: { description: 'TODO not found' },
+                    },
+                    security: [{ basicAuth: [] }],
                 },
-              },
+                delete: {
+                    operationId: 'deleteTodo',
+                    tags: ['todos'],
+                    summary: 'Delete a TODO',
+                    parameters: [
+                        {
+                            name: 'id',
+                            in: 'path',
+                            required: true,
+                            schema: { type: 'string' },
+                            description: 'TODO ID',
+                        },
+                    ],
+                    responses: {
+                        204: { description: 'TODO deleted' },
+                        404: { description: 'TODO not found' },
+                    },
+                    security: [{ basicAuth: [] }],
+                },
             },
-            "404": { description: "TODO not found" },
-          },
-          security: [{ basicAuth: [] }],
         },
-        delete: {
-          operationId: "deleteTodo",
-          tags: ["todos"],
-          summary: "Delete a TODO",
-          parameters: [
-            {
-              name: "id",
-              in: "path",
-              required: true,
-              schema: { type: "string" },
-              description: "TODO ID",
+        components: {
+            securitySchemes: {
+                basicAuth: {
+                    type: 'http',
+                    scheme: 'basic',
+                },
             },
-          ],
-          responses: {
-            "204": { description: "TODO deleted" },
-            "404": { description: "TODO not found" },
-          },
-          security: [{ basicAuth: [] }],
-        },
-      },
-    },
-    components: {
-      securitySchemes: {
-        basicAuth: {
-          type: "http",
-          scheme: "basic",
-        },
-      },
-      schemas: {
-        Todo: {
-          type: "object",
-          properties: {
-            id: { type: "string", description: "Unique identifier" },
-            title: { type: "string", description: "TODO title" },
-            completed: {
-              type: "boolean",
-              description: "Completion status",
+            schemas: {
+                Todo: {
+                    type: 'object',
+                    properties: {
+                        id: { type: 'string', description: 'Unique identifier' },
+                        title: { type: 'string', description: 'TODO title' },
+                        completed: {
+                            type: 'boolean',
+                            description: 'Completion status',
+                        },
+                        color: {
+                            type: 'string',
+                            description: 'Background color (hex string)',
+                        },
+                    },
+                    required: ['id', 'title', 'completed', 'color'],
+                },
+                CreateTodo: {
+                    type: 'object',
+                    properties: {
+                        title: { type: 'string', description: 'TODO title' },
+                    },
+                    required: ['title'],
+                },
+                UpdateTodo: {
+                    type: 'object',
+                    properties: {
+                        title: { type: 'string', description: 'TODO title' },
+                        completed: {
+                            type: 'boolean',
+                            description: 'Completion status',
+                        },
+                        color: {
+                            type: 'string',
+                            description: 'Background color (hex string)',
+                        },
+                    },
+                },
             },
-            color: {
-              type: "string",
-              description: "Background color (hex string)",
-            },
-          },
-          required: ["id", "title", "completed", "color"],
         },
-        CreateTodo: {
-          type: "object",
-          properties: {
-            title: { type: "string", description: "TODO title" },
-          },
-          required: ["title"],
-        },
-        UpdateTodo: {
-          type: "object",
-          properties: {
-            title: { type: "string", description: "TODO title" },
-            completed: {
-              type: "boolean",
-              description: "Completion status",
-            },
-            color: {
-              type: "string",
-              description: "Background color (hex string)",
-            },
-          },
-        },
-      },
-    },
-  };
+    };
 }

--- a/tests/e2e-tutorial/tutorial-app/src/routes/todos.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/routes/todos.ts
@@ -1,71 +1,85 @@
 import {
-  listTodos,
-  getTodo,
-  createTodo,
-  updateTodo,
-  deleteTodo,
-} from "../store";
-import { broadcast } from "../ws";
+    listTodos,
+    getTodo,
+    createTodo,
+    updateTodo,
+    deleteTodo,
+} from '../store';
+import { broadcast } from '../ws';
 
 export async function handleTodos(
-  req: Request,
-  pathname: string
+    req: Request,
+    pathname: string,
 ): Promise<Response> {
-  const match = pathname.match(/^\/todos(?:\/(.+))?$/);
-  if (!match) return Response.json({ error: "Not found" }, { status: 404 });
+    const match = pathname.match(/^\/todos(?:\/(.+))?$/);
 
-  const id = match[1];
-  const method = req.method;
+    if (!match) return Response.json({ error: 'Not found' }, { status: 404 });
 
-  // Collection routes: GET /todos, POST /todos
-  if (!id) {
-    if (method === "GET") {
-      return Response.json(listTodos());
-    }
-    if (method === "POST") {
-      const body = (await req.json()) as { title?: string };
-      if (!body.title) {
+    const id = match[1];
+    const method = req.method;
+
+    // Collection routes: GET /todos, POST /todos
+    if (!id) {
+        if (method === 'GET') {
+            return Response.json(listTodos());
+        }
+
+        if (method === 'POST') {
+            const body = (await req.json()) as { title?: string };
+
+            if (!body.title) {
+                return Response.json(
+                    { error: 'title is required' },
+                    { status: 400 },
+                );
+            }
+
+            const todo = await createTodo(body.title);
+            broadcast('todo:created', todo);
+
+            return Response.json(todo, { status: 201 });
+        }
+
         return Response.json(
-          { error: "title is required" },
-          { status: 400 }
+            { error: 'Method not allowed' },
+            { status: 405 },
         );
-      }
-      const todo = await createTodo(body.title);
-      broadcast("todo:created", todo);
-      return Response.json(todo, { status: 201 });
     }
-    return Response.json(
-      { error: "Method not allowed" },
-      { status: 405 }
-    );
-  }
 
-  // Item routes: GET/PATCH/DELETE /todos/:id
-  if (method === "GET") {
-    const todo = getTodo(id);
-    if (!todo) return Response.json({ error: "Not found" }, { status: 404 });
-    return Response.json(todo);
-  }
+    // Item routes: GET/PATCH/DELETE /todos/:id
+    if (method === 'GET') {
+        const todo = getTodo(id);
 
-  if (method === "PATCH") {
-    const body = (await req.json()) as {
-      title?: string;
-      completed?: boolean;
-      color?: string;
-    };
-    const todo = await updateTodo(id, body);
-    if (!todo) return Response.json({ error: "Not found" }, { status: 404 });
-    broadcast("todo:updated", todo);
-    return Response.json(todo);
-  }
+        if (!todo) return Response.json({ error: 'Not found' }, { status: 404 });
 
-  if (method === "DELETE") {
-    const deleted = await deleteTodo(id);
-    if (!deleted)
-      return Response.json({ error: "Not found" }, { status: 404 });
-    broadcast("todo:deleted", { id });
-    return new Response(null, { status: 204 });
-  }
+        return Response.json(todo);
+    }
 
-  return Response.json({ error: "Method not allowed" }, { status: 405 });
+    if (method === 'PATCH') {
+        const body = (await req.json()) as {
+            title?: string;
+            completed?: boolean;
+            color?: string;
+        };
+        const todo = await updateTodo(id, body);
+
+        if (!todo) return Response.json({ error: 'Not found' }, { status: 404 });
+
+        broadcast('todo:updated', todo);
+
+        return Response.json(todo);
+    }
+
+    if (method === 'DELETE') {
+        const deleted = await deleteTodo(id);
+
+        if (!deleted)
+            return Response.json({ error: 'Not found' }, { status: 404 });
+
+        broadcast('todo:deleted', { id });
+
+        return new Response(null, { status: 204 });
+    }
+
+    return Response.json({ error: 'Method not allowed' }, { status: 405 });
 }

--- a/tests/e2e-tutorial/tutorial-app/src/server.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/server.ts
@@ -1,49 +1,51 @@
-import { checkAuth, unauthorizedResponse } from "./auth";
-import { handleTodos } from "./routes/todos";
-import { getSpec } from "./openapi";
-import { addClient, removeClient } from "./ws";
+import { checkAuth, unauthorizedResponse } from './auth';
+import { handleTodos } from './routes/todos';
+import { getSpec } from './openapi';
+import { addClient, removeClient } from './ws';
 
 const server = Bun.serve({
-  port: 3456,
-  async fetch(req, server) {
-    const url = new URL(req.url);
-    const pathname = url.pathname;
+    port: 3456,
+    async fetch(req, server) {
+        const url = new URL(req.url);
+        const pathname = url.pathname;
 
-    // Serve UI
-    if (pathname === "/") {
-      return new Response(Bun.file("public/index.html"), {
-        headers: { "Content-Type": "text/html" },
-      });
-    }
+        // Serve UI
+        if (pathname === '/') {
+            return new Response(Bun.file('public/index.html'), {
+                headers: { 'Content-Type': 'text/html' },
+            });
+        }
 
-    // OpenAPI spec (no auth)
-    if (pathname === "/v3/api-docs") {
-      return Response.json(getSpec());
-    }
+        // OpenAPI spec (no auth)
+        if (pathname === '/v3/api-docs') {
+            return Response.json(getSpec());
+        }
 
-    // WebSocket upgrade (no auth)
-    if (pathname === "/ws") {
-      if (server.upgrade(req)) return undefined;
-      return new Response("WebSocket upgrade failed", { status: 500 });
-    }
+        // WebSocket upgrade (no auth)
+        if (pathname === '/ws') {
+            if (server.upgrade(req)) return undefined;
 
-    // Auth-protected API routes
-    if (pathname.startsWith("/todos")) {
-      if (!checkAuth(req)) return unauthorizedResponse();
-      return handleTodos(req, pathname);
-    }
+            return new Response('WebSocket upgrade failed', { status: 500 });
+        }
 
-    return Response.json({ error: "Not found" }, { status: 404 });
-  },
-  websocket: {
-    open(ws) {
-      addClient(ws);
+        // Auth-protected API routes
+        if (pathname.startsWith('/todos')) {
+            if (!checkAuth(req)) return unauthorizedResponse();
+
+            return handleTodos(req, pathname);
+        }
+
+        return Response.json({ error: 'Not found' }, { status: 404 });
     },
-    close(ws) {
-      removeClient(ws);
+    websocket: {
+        open(ws) {
+            addClient(ws);
+        },
+        close(ws) {
+            removeClient(ws);
+        },
+        message() {},
     },
-    message() {},
-  },
 });
 
 console.log(`TODO API running at http://localhost:${server.port}`);

--- a/tests/e2e-tutorial/tutorial-app/src/store.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/store.ts
@@ -1,53 +1,58 @@
 export interface Todo {
-  id: string;
-  title: string;
-  completed: boolean;
-  color: string;
+    id: string;
+    title: string;
+    completed: boolean;
+    color: string;
 }
 
 const todos = new Map<string, Todo>();
 const DELAY_MS = 200;
 
 function delay(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, DELAY_MS));
+    return new Promise(resolve => setTimeout(resolve, DELAY_MS));
 }
 
 export function listTodos(): Todo[] {
-  return Array.from(todos.values());
+    return Array.from(todos.values());
 }
 
 export function getTodo(id: string): Todo | undefined {
-  return todos.get(id);
+    return todos.get(id);
 }
 
 export async function createTodo(title: string): Promise<Todo> {
-  await delay();
-  const todo: Todo = {
-    id: crypto.randomUUID(),
-    title,
-    completed: false,
-    color: "#ffffff",
-  };
-  todos.set(todo.id, todo);
-  return todo;
+    await delay();
+    const todo: Todo = {
+        id: crypto.randomUUID(),
+        title,
+        completed: false,
+        color: '#ffffff',
+    };
+    todos.set(todo.id, todo);
+
+    return todo;
 }
 
 export async function updateTodo(
-  id: string,
-  updates: Partial<Pick<Todo, "title" | "completed" | "color">>
+    id: string,
+    updates: Partial<Pick<Todo, 'title' | 'completed' | 'color'>>,
 ): Promise<Todo | undefined> {
-  await delay();
-  const todo = todos.get(id);
-  if (!todo) return undefined;
-  Object.assign(todo, updates);
-  return todo;
+    await delay();
+    const todo = todos.get(id);
+
+    if (!todo) return undefined;
+
+    Object.assign(todo, updates);
+
+    return todo;
 }
 
 export async function deleteTodo(id: string): Promise<boolean> {
-  await delay();
-  return todos.delete(id);
+    await delay();
+
+    return todos.delete(id);
 }
 
 export function clearTodos(): void {
-  todos.clear();
+    todos.clear();
 }

--- a/tests/e2e-tutorial/tutorial-app/src/ws.ts
+++ b/tests/e2e-tutorial/tutorial-app/src/ws.ts
@@ -1,18 +1,19 @@
-import type { ServerWebSocket } from "bun";
+import type { ServerWebSocket } from 'bun';
 
 const clients = new Set<ServerWebSocket<unknown>>();
 
 export function addClient(ws: ServerWebSocket<unknown>): void {
-  clients.add(ws);
+    clients.add(ws);
 }
 
 export function removeClient(ws: ServerWebSocket<unknown>): void {
-  clients.delete(ws);
+    clients.delete(ws);
 }
 
 export function broadcast(event: string, todo: unknown): void {
-  const message = JSON.stringify({ event, todo });
-  for (const client of clients) {
-    client.send(message);
-  }
+    const message = JSON.stringify({ event, todo });
+
+    for (const client of clients) {
+        client.send(message);
+    }
 }

--- a/tests/e2e-tutorial/tutorial-e2e.yaml
+++ b/tests/e2e-tutorial/tutorial-e2e.yaml
@@ -1,10 +1,23 @@
 name: tutorial-e2e
 description: >
   End-to-end test of the full tutorial workflow:
+  verify custom resolver ($_uppercase) round-trips via a TODO,
   create 50 TODOs, color each randomly in shuffled order,
   delete all in reverse creation order, verify empty.
 
 steps:
+  - name: custom-resolver-create
+    command: todos create
+    args:
+      --title: "$_uppercase(hello-resolver)"
+    output: uppercased
+    assert: "$uppercased.title == HELLO-RESOLVER"
+
+  - name: custom-resolver-cleanup
+    command: todos delete
+    args:
+      --id: "$uppercased.id"
+
   - name: create-todos
     range: [1, 50]
     as: n

--- a/tests/e2e-tutorial/tutorial-e2e.yaml
+++ b/tests/e2e-tutorial/tutorial-e2e.yaml
@@ -5,18 +5,33 @@ description: >
   create 50 TODOs, color each randomly in shuffled order,
   delete all in reverse creation order, verify empty.
 
+variables:
+  greeting: "hello-from-variable"
+
 steps:
-  - name: custom-resolver-create
+  - name: custom-resolver-literal
     command: todos create
     args:
       --title: "$_uppercase(hello-resolver)"
-    output: uppercased
-    assert: "$uppercased.title == HELLO-RESOLVER"
+    output: literal
+    assert: "$literal.title == HELLO-RESOLVER"
 
-  - name: custom-resolver-cleanup
+  - name: custom-resolver-ref
+    command: todos create
+    args:
+      --title: "$_uppercase($greeting)"
+    output: resolved
+    assert: "$resolved.title == HELLO-FROM-VARIABLE"
+
+  - name: custom-resolver-cleanup-literal
     command: todos delete
     args:
-      --id: "$uppercased.id"
+      --id: "$literal.id"
+
+  - name: custom-resolver-cleanup-ref
+    command: todos delete
+    args:
+      --id: "$resolved.id"
 
   - name: create-todos
     range: [1, 50]

--- a/tests/fixtures/mcp/command-map.ts
+++ b/tests/fixtures/mcp/command-map.ts
@@ -1,6 +1,6 @@
 export const commandMap = {
-  "admin list": { operationId: "listAdmins", pathParams: [], queryParams: [], hasBody: false, description: "List admins" },
-  "admin create": { operationId: "createAdmin", pathParams: [], queryParams: [], hasBody: true },
-  "matters list": { operationId: "listMatters", pathParams: [], queryParams: ["page"], hasBody: false, description: "List matters" },
-  "matters get": { operationId: "getMatter", pathParams: ["id"], queryParams: [], hasBody: false },
+    'admin list': { operationId: 'listAdmins', pathParams: [], queryParams: [], hasBody: false, description: 'List admins' },
+    'admin create': { operationId: 'createAdmin', pathParams: [], queryParams: [], hasBody: true },
+    'matters list': { operationId: 'listMatters', pathParams: [], queryParams: ['page'], hasBody: false, description: 'List matters' },
+    'matters get': { operationId: 'getMatter', pathParams: ['id'], queryParams: [], hasBody: false },
 };

--- a/tests/fixtures/mcp/spec/types.ts
+++ b/tests/fixtures/mcp/spec/types.ts
@@ -1,11 +1,11 @@
 // Auto-generated
 export interface UserDto {
-  id: number;
-  name: string;
+    id: number;
+    name: string;
 }
 
 export interface MatterDto {
-  id: number;
+    id: number;
 }
 
 export type Status = 'active' | 'inactive';
@@ -13,5 +13,5 @@ export type Status = 'active' | 'inactive';
 export type Role = 'admin' | 'user';
 
 export interface LoadDto {
-  loadId: number;
+    loadId: number;
 }

--- a/tests/mcp-server-entry.test.ts
+++ b/tests/mcp-server-entry.test.ts
@@ -1,35 +1,35 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
-import { homedir } from "os";
-import { join } from "path";
-import { loadPluginConfig, type PluginConfig } from "../src/mcp-server-entry";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { loadPluginConfig, type PluginConfig } from '../src/mcp-server-entry';
 
-const testDir = join(homedir(), ".apijack-test-entry");
+const testDir = join(homedir(), '.apijack-test-entry');
 
-describe("loadPluginConfig()", () => {
-  beforeEach(() => {
-    mkdirSync(testDir, { recursive: true });
-  });
+describe('loadPluginConfig()', () => {
+    beforeEach(() => {
+        mkdirSync(testDir, { recursive: true });
+    });
 
-  afterEach(() => {
-    rmSync(testDir, { recursive: true, force: true });
-  });
+    afterEach(() => {
+        rmSync(testDir, { recursive: true, force: true });
+    });
 
-  test("reads CLI invocation from plugin config", () => {
-    const config: PluginConfig = {
-      cliInvocation: ["bun", "run", "/path/to/cli.ts"],
-      generatedDir: "/path/to/generated",
-    };
-    writeFileSync(join(testDir, "plugin.json"), JSON.stringify(config));
+    test('reads CLI invocation from plugin config', () => {
+        const config: PluginConfig = {
+            cliInvocation: ['bun', 'run', '/path/to/cli.ts'],
+            generatedDir: '/path/to/generated',
+        };
+        writeFileSync(join(testDir, 'plugin.json'), JSON.stringify(config));
 
-    const result = loadPluginConfig(testDir);
-    expect(result).not.toBeNull();
-    expect(result!.cliInvocation).toEqual(["bun", "run", "/path/to/cli.ts"]);
-    expect(result!.generatedDir).toBe("/path/to/generated");
-  });
+        const result = loadPluginConfig(testDir);
+        expect(result).not.toBeNull();
+        expect(result!.cliInvocation).toEqual(['bun', 'run', '/path/to/cli.ts']);
+        expect(result!.generatedDir).toBe('/path/to/generated');
+    });
 
-  test("returns null when config file missing", () => {
-    const result = loadPluginConfig(join(testDir, "nonexistent"));
-    expect(result).toBeNull();
-  });
+    test('returns null when config file missing', () => {
+        const result = loadPluginConfig(join(testDir, 'nonexistent'));
+        expect(result).toBeNull();
+    });
 });

--- a/tests/output-request.test.ts
+++ b/tests/output-request.test.ts
@@ -1,114 +1,114 @@
-import { describe, expect, test } from "bun:test";
-import { formatDryRun, formatCurl, type CapturedRequest } from "../src/output-request";
+import { describe, expect, test } from 'bun:test';
+import { formatDryRun, formatCurl, type CapturedRequest } from '../src/output-request';
 
-describe("formatDryRun", () => {
-  test("formats POST with body and masked auth", () => {
-    const req: CapturedRequest = {
-      method: "POST",
-      url: "https://api.example.com/v1/todos",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Basic dXNlcjpwYXNz",
-      },
-      body: { title: "My Task", description: "Details" },
-    };
-    const output = formatDryRun(req);
-    expect(output).toContain("POST https://api.example.com/v1/todos");
-    expect(output).toContain("Content-Type: application/json");
-    expect(output).toContain("Authorization: ****");
-    expect(output).not.toContain("dXNlcjpwYXNz");
-    expect(output).toContain('"title": "My Task"');
-  });
+describe('formatDryRun', () => {
+    test('formats POST with body and masked auth', () => {
+        const req: CapturedRequest = {
+            method: 'POST',
+            url: 'https://api.example.com/v1/todos',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Basic dXNlcjpwYXNz',
+            },
+            body: { title: 'My Task', description: 'Details' },
+        };
+        const output = formatDryRun(req);
+        expect(output).toContain('POST https://api.example.com/v1/todos');
+        expect(output).toContain('Content-Type: application/json');
+        expect(output).toContain('Authorization: ****');
+        expect(output).not.toContain('dXNlcjpwYXNz');
+        expect(output).toContain('"title": "My Task"');
+    });
 
-  test("formats GET without body section", () => {
-    const req: CapturedRequest = {
-      method: "GET",
-      url: "https://api.example.com/v1/todos",
-      headers: { "Content-Type": "application/json" },
-    };
-    const output = formatDryRun(req);
-    expect(output).toContain("GET https://api.example.com/v1/todos");
-    expect(output).not.toContain("Body:");
-  });
+    test('formats GET without body section', () => {
+        const req: CapturedRequest = {
+            method: 'GET',
+            url: 'https://api.example.com/v1/todos',
+            headers: { 'Content-Type': 'application/json' },
+        };
+        const output = formatDryRun(req);
+        expect(output).toContain('GET https://api.example.com/v1/todos');
+        expect(output).not.toContain('Body:');
+    });
 
-  test("masks authorization header case-insensitively", () => {
-    const req: CapturedRequest = {
-      method: "GET",
-      url: "https://api.example.com/test",
-      headers: { "authorization": "Bearer token123" },
-    };
-    const output = formatDryRun(req);
-    expect(output).toContain("authorization: ****");
-    expect(output).not.toContain("token123");
-  });
+    test('masks authorization header case-insensitively', () => {
+        const req: CapturedRequest = {
+            method: 'GET',
+            url: 'https://api.example.com/test',
+            headers: { authorization: 'Bearer token123' },
+        };
+        const output = formatDryRun(req);
+        expect(output).toContain('authorization: ****');
+        expect(output).not.toContain('token123');
+    });
 });
 
-describe("formatCurl", () => {
-  test("formats POST with body, excludes auth by default", () => {
-    const req: CapturedRequest = {
-      method: "POST",
-      url: "https://api.example.com/v1/todos",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Basic dXNlcjpwYXNz",
-      },
-      body: { title: "My Task" },
-    };
-    const output = formatCurl(req, { includeCreds: false });
-    expect(output).toContain("curl -X POST");
-    expect(output).toContain("'https://api.example.com/v1/todos'");
-    expect(output).toContain("-H 'Content-Type: application/json'");
-    expect(output).not.toContain("Authorization");
-    expect(output).toContain("-d ");
-    expect(output).toContain('"title":"My Task"');
-  });
+describe('formatCurl', () => {
+    test('formats POST with body, excludes auth by default', () => {
+        const req: CapturedRequest = {
+            method: 'POST',
+            url: 'https://api.example.com/v1/todos',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Basic dXNlcjpwYXNz',
+            },
+            body: { title: 'My Task' },
+        };
+        const output = formatCurl(req, { includeCreds: false });
+        expect(output).toContain('curl -X POST');
+        expect(output).toContain("'https://api.example.com/v1/todos'");
+        expect(output).toContain("-H 'Content-Type: application/json'");
+        expect(output).not.toContain('Authorization');
+        expect(output).toContain('-d ');
+        expect(output).toContain('"title":"My Task"');
+    });
 
-  test("includes auth header when includeCreds is true", () => {
-    const req: CapturedRequest = {
-      method: "POST",
-      url: "https://api.example.com/v1/todos",
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "Basic dXNlcjpwYXNz",
-      },
-      body: { title: "My Task" },
-    };
-    const output = formatCurl(req, { includeCreds: true });
-    expect(output).toContain("-H 'Authorization: Basic dXNlcjpwYXNz'");
-  });
+    test('includes auth header when includeCreds is true', () => {
+        const req: CapturedRequest = {
+            method: 'POST',
+            url: 'https://api.example.com/v1/todos',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': 'Basic dXNlcjpwYXNz',
+            },
+            body: { title: 'My Task' },
+        };
+        const output = formatCurl(req, { includeCreds: true });
+        expect(output).toContain("-H 'Authorization: Basic dXNlcjpwYXNz'");
+    });
 
-  test("GET request omits -X and -d", () => {
-    const req: CapturedRequest = {
-      method: "GET",
-      url: "https://api.example.com/v1/todos?page=1",
-      headers: { "Content-Type": "application/json" },
-    };
-    const output = formatCurl(req, { includeCreds: false });
-    expect(output).not.toContain("-X ");
-    expect(output).not.toContain("-d ");
-    expect(output).toStartWith("curl ");
-    expect(output).toContain("'https://api.example.com/v1/todos?page=1'");
-  });
+    test('GET request omits -X and -d', () => {
+        const req: CapturedRequest = {
+            method: 'GET',
+            url: 'https://api.example.com/v1/todos?page=1',
+            headers: { 'Content-Type': 'application/json' },
+        };
+        const output = formatCurl(req, { includeCreds: false });
+        expect(output).not.toContain('-X ');
+        expect(output).not.toContain('-d ');
+        expect(output).toStartWith('curl ');
+        expect(output).toContain("'https://api.example.com/v1/todos?page=1'");
+    });
 
-  test("uses line continuations for readability", () => {
-    const req: CapturedRequest = {
-      method: "POST",
-      url: "https://api.example.com/v1/todos",
-      headers: { "Content-Type": "application/json" },
-      body: { title: "test" },
-    };
-    const output = formatCurl(req, { includeCreds: false });
-    expect(output).toContain(" \\\n");
-  });
+    test('uses line continuations for readability', () => {
+        const req: CapturedRequest = {
+            method: 'POST',
+            url: 'https://api.example.com/v1/todos',
+            headers: { 'Content-Type': 'application/json' },
+            body: { title: 'test' },
+        };
+        const output = formatCurl(req, { includeCreds: false });
+        expect(output).toContain(' \\\n');
+    });
 
-  test("DELETE request includes -X DELETE, no body", () => {
-    const req: CapturedRequest = {
-      method: "DELETE",
-      url: "https://api.example.com/v1/todos/123",
-      headers: { "Content-Type": "application/json" },
-    };
-    const output = formatCurl(req, { includeCreds: false });
-    expect(output).toContain("curl -X DELETE");
-    expect(output).not.toContain("-d ");
-  });
+    test('DELETE request includes -X DELETE, no body', () => {
+        const req: CapturedRequest = {
+            method: 'DELETE',
+            url: 'https://api.example.com/v1/todos/123',
+            headers: { 'Content-Type': 'application/json' },
+        };
+        const output = formatCurl(req, { includeCreds: false });
+        expect(output).toContain('curl -X DELETE');
+        expect(output).not.toContain('-d ');
+    });
 });

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -1,39 +1,39 @@
-import { describe, expect, test } from "bun:test";
-import { formatOutput } from "../src/output";
+import { describe, expect, test } from 'bun:test';
+import { formatOutput } from '../src/output';
 
-describe("formatOutput", () => {
-  const sampleData = [
-    { id: 1, name: "Alice", role: "admin" },
-    { id: 2, name: "Bob", role: "user" },
-  ];
+describe('formatOutput', () => {
+    const sampleData = [
+        { id: 1, name: 'Alice', role: 'admin' },
+        { id: 2, name: 'Bob', role: 'user' },
+    ];
 
-  test("json mode returns pretty-printed JSON", () => {
-    const result = formatOutput(sampleData, "json");
-    expect(result).toBe(JSON.stringify(sampleData, null, 2));
-  });
+    test('json mode returns pretty-printed JSON', () => {
+        const result = formatOutput(sampleData, 'json');
+        expect(result).toBe(JSON.stringify(sampleData, null, 2));
+    });
 
-  test("table mode returns cli-table3 table for array of objects", () => {
-    const result = formatOutput(sampleData, "table");
-    // Table should contain the header keys and row values
-    expect(result).toContain("id");
-    expect(result).toContain("name");
-    expect(result).toContain("role");
-    expect(result).toContain("Alice");
-    expect(result).toContain("Bob");
-    expect(result).toContain("admin");
-    expect(result).toContain("user");
-    // Should not be JSON (tables use box-drawing characters)
-    expect(result).toContain("─");
-  });
+    test('table mode returns cli-table3 table for array of objects', () => {
+        const result = formatOutput(sampleData, 'table');
+        // Table should contain the header keys and row values
+        expect(result).toContain('id');
+        expect(result).toContain('name');
+        expect(result).toContain('role');
+        expect(result).toContain('Alice');
+        expect(result).toContain('Bob');
+        expect(result).toContain('admin');
+        expect(result).toContain('user');
+        // Should not be JSON (tables use box-drawing characters)
+        expect(result).toContain('─');
+    });
 
-  test("table mode falls back to JSON for non-array data", () => {
-    const obj = { id: 1, name: "Alice" };
-    const result = formatOutput(obj, "table");
-    expect(result).toBe(JSON.stringify(obj, null, 2));
-  });
+    test('table mode falls back to JSON for non-array data', () => {
+        const obj = { id: 1, name: 'Alice' };
+        const result = formatOutput(obj, 'table');
+        expect(result).toBe(JSON.stringify(obj, null, 2));
+    });
 
-  test("quiet mode returns empty string", () => {
-    const result = formatOutput(sampleData, "quiet");
-    expect(result).toBe("");
-  });
+    test('quiet mode returns empty string', () => {
+        const result = formatOutput(sampleData, 'quiet');
+        expect(result).toBe('');
+    });
 });

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -116,4 +116,47 @@ describe('installPlugin()', () => {
 
         expect(installPlugin(opts)).rejects.toThrow('boom');
     });
+
+    test('rolls back marketplace dir if claude CLI fails on a fresh install', async () => {
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('register failed');
+            },
+        });
+
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+        await installPlugin(opts).catch(() => {});
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
+
+    test('does not roll back a pre-existing marketplace dir on failure', async () => {
+        mkdirSync(testMarketplaceDir, { recursive: true });
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('register failed');
+            },
+        });
+
+        await installPlugin(opts).catch(() => {});
+        expect(existsSync(testMarketplaceDir)).toBe(true);
+    });
+
+    test('surfaces checkClaudeCli errors and does not touch filesystem', async () => {
+        const opts = {
+            version: '0.1.0',
+            userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
+            sourceDir: join(import.meta.dir, '../..'),
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+            checkClaudeCli: () => {
+                throw new Error('claude not found');
+            },
+        };
+
+        await installPlugin(opts).catch((err) => {
+            expect(err.message).toContain('claude not found');
+        });
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
 });

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -5,22 +5,30 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-plugin-test-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 
 function readJson(path: string): any {
     return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
 function makeOpts(overrides?: Record<string, unknown>) {
+    const claudeCalls: string[][] = [];
+
     return {
-        version: '0.1.0',
-        claudeDir: testClaudeDir,
-        userDataDir: testDataDir,
-        sourceDir: join(import.meta.dir, '../..'),
-        cliInvocation: ['bun', 'run', 'src/cli.ts'],
-        generatedDir: 'src/generated',
-        ...overrides,
+        opts: {
+            version: '0.1.0',
+            userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
+            sourceDir: join(import.meta.dir, '../..'),
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+            runClaude: async (args: string[]) => {
+                claudeCalls.push(args);
+            },
+            ...overrides,
+        },
+        claudeCalls,
     };
 }
 
@@ -33,78 +41,79 @@ describe('installPlugin()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('registers in local marketplace', async () => {
-        const result = await installPlugin(makeOpts());
+    test('writes marketplace.json with apijack plugin entry', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
         expect(result.success).toBe(true);
 
-        const marketplacePath = join(
-            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
-        );
+        const marketplacePath = join(testMarketplaceDir, '.claude-plugin', 'marketplace.json');
         expect(existsSync(marketplacePath)).toBe(true);
 
         const marketplace = readJson(marketplacePath);
+        expect(marketplace.name).toBe('apijack');
+        expect(marketplace.metadata?.description).toBeTruthy();
         const plugin = marketplace.plugins.find((p: any) => p.name === 'apijack');
         expect(plugin).toBeDefined();
         expect(plugin.source).toBe('./apijack');
     });
 
-    test('returns plugin dir inside local marketplace', async () => {
-        const result = await installPlugin(makeOpts());
-        expect(result.marketplaceDir).toContain(join('marketplaces', 'local', 'apijack'));
+    test('returns plugin dir nested in marketplace', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        expect(result.marketplaceDir).toBe(testMarketplaceDir);
+        expect(result.pluginDir).toBe(join(testMarketplaceDir, 'apijack'));
     });
 
-    test('copies skills to plugin dir', async () => {
-        const result = await installPlugin(makeOpts());
-        expect(existsSync(join(result.marketplaceDir, 'skills', 'write-routine', 'SKILL.md'))).toBe(true);
-        expect(existsSync(join(result.marketplaceDir, 'skills', 'setup-api', 'SKILL.md'))).toBe(true);
+    test('writes plugin.json manifest under plugin dir', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        const manifest = readJson(join(result.pluginDir, '.claude-plugin', 'plugin.json'));
+        expect(manifest.name).toBe('apijack');
+        expect(manifest.version).toBe('0.1.0');
     });
 
-    test('writes .mcp.json with CLAUDE_PLUGIN_ROOT', async () => {
-        const result = await installPlugin(makeOpts());
-        const mcpJson = readJson(join(result.marketplaceDir, '.mcp.json'));
+    test('copies skills into plugin dir', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        expect(existsSync(join(result.pluginDir, 'skills', 'write-routine', 'SKILL.md'))).toBe(true);
+        expect(existsSync(join(result.pluginDir, 'skills', 'setup-api', 'SKILL.md'))).toBe(true);
+    });
+
+    test('writes .mcp.json with CLAUDE_PLUGIN_ROOT reference', async () => {
+        const { opts } = makeOpts();
+        const result = await installPlugin(opts);
+        const mcpJson = readJson(join(result.pluginDir, '.mcp.json'));
         expect(mcpJson.mcpServers.apijack.args).toContain('${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js');
     });
 
-    test('creates user data directory', async () => {
-        await installPlugin(makeOpts());
+    test('creates user data directory and writes runtime plugin.json', async () => {
+        const { opts } = makeOpts();
+        await installPlugin(opts);
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
-    });
 
-    test('writes plugin.json with cliInvocation to user data dir', async () => {
-        await installPlugin(makeOpts());
         const pluginConfig = readJson(join(testDataDir, 'plugin.json'));
         expect(pluginConfig.cliInvocation).toEqual(['bun', 'run', 'src/cli.ts']);
         expect(pluginConfig.generatedDir).toBe('src/generated');
     });
 
-    test('registers in installed_plugins.json and settings.json', async () => {
-        await installPlugin(makeOpts());
+    test('invokes claude CLI to register marketplace and install plugin', async () => {
+        const { opts, claudeCalls } = makeOpts();
+        await installPlugin(opts);
 
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local']).toBeDefined();
-        expect(installed.plugins['apijack@local'][0].version).toBe('0.1.0');
-
-        const settings = readJson(join(testClaudeDir, 'settings.json'));
-        expect(settings.enabledPlugins['apijack@local']).toBe(true);
+        expect(claudeCalls).toEqual([
+            ['plugin', 'marketplace', 'add', testMarketplaceDir],
+            ['plugin', 'install', 'apijack@apijack'],
+        ]);
     });
 
-    test('preserves other plugins in local marketplace', async () => {
-        const localDir = join(testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin');
-        mkdirSync(localDir, { recursive: true });
-        await Bun.write(
-            join(localDir, 'marketplace.json'),
-            JSON.stringify({
-                name: 'local',
-                owner: { name: 'Local Plugins' },
-                plugins: [{ name: 'other-plugin', description: 'Other', source: './other-plugin' }],
-            }),
-        );
+    test('propagates errors from runClaude', async () => {
+        const { opts } = makeOpts({
+            runClaude: async () => {
+                throw new Error('boom');
+            },
+        });
 
-        await installPlugin(makeOpts());
-
-        const marketplace = readJson(join(localDir, 'marketplace.json'));
-        expect(marketplace.plugins.find((p: any) => p.name === 'other-plugin')).toBeDefined();
-        expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
+        expect(installPlugin(opts)).rejects.toThrow('boom');
     });
 });

--- a/tests/plugin/install.test.ts
+++ b/tests/plugin/install.test.ts
@@ -1,110 +1,110 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { installPlugin } from "../../src/plugin/install";
-import { mkdirSync, rmSync, existsSync, readFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { installPlugin } from '../../src/plugin/install';
+import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
-const testRoot = join(tmpdir(), "apijack-plugin-test-" + Date.now());
-const testClaudeDir = join(testRoot, ".claude");
-const testDataDir = join(testRoot, ".apijack");
+const testRoot = join(tmpdir(), 'apijack-plugin-test-' + Date.now());
+const testClaudeDir = join(testRoot, '.claude');
+const testDataDir = join(testRoot, '.apijack');
 
 function readJson(path: string): any {
-  return JSON.parse(readFileSync(path, "utf-8"));
+    return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
 function makeOpts(overrides?: Record<string, unknown>) {
-  return {
-    version: "0.1.0",
-    claudeDir: testClaudeDir,
-    userDataDir: testDataDir,
-    sourceDir: join(import.meta.dir, "../.."),
-    cliInvocation: ["bun", "run", "src/cli.ts"],
-    generatedDir: "src/generated",
-    ...overrides,
-  };
+    return {
+        version: '0.1.0',
+        claudeDir: testClaudeDir,
+        userDataDir: testDataDir,
+        sourceDir: join(import.meta.dir, '../..'),
+        cliInvocation: ['bun', 'run', 'src/cli.ts'],
+        generatedDir: 'src/generated',
+        ...overrides,
+    };
 }
 
-describe("installPlugin()", () => {
-  beforeEach(() => {
-    mkdirSync(testRoot, { recursive: true });
-  });
+describe('installPlugin()', () => {
+    beforeEach(() => {
+        mkdirSync(testRoot, { recursive: true });
+    });
 
-  afterEach(() => {
-    rmSync(testRoot, { recursive: true, force: true });
-  });
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
 
-  test("registers in local marketplace", async () => {
-    const result = await installPlugin(makeOpts());
-    expect(result.success).toBe(true);
+    test('registers in local marketplace', async () => {
+        const result = await installPlugin(makeOpts());
+        expect(result.success).toBe(true);
 
-    const marketplacePath = join(
-      testClaudeDir, "plugins", "marketplaces", "local", ".claude-plugin", "marketplace.json"
-    );
-    expect(existsSync(marketplacePath)).toBe(true);
+        const marketplacePath = join(
+            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
+        );
+        expect(existsSync(marketplacePath)).toBe(true);
 
-    const marketplace = readJson(marketplacePath);
-    const plugin = marketplace.plugins.find((p: any) => p.name === "apijack");
-    expect(plugin).toBeDefined();
-    expect(plugin.source).toBe("./apijack");
-  });
+        const marketplace = readJson(marketplacePath);
+        const plugin = marketplace.plugins.find((p: any) => p.name === 'apijack');
+        expect(plugin).toBeDefined();
+        expect(plugin.source).toBe('./apijack');
+    });
 
-  test("returns plugin dir inside local marketplace", async () => {
-    const result = await installPlugin(makeOpts());
-    expect(result.marketplaceDir).toContain(join("marketplaces", "local", "apijack"));
-  });
+    test('returns plugin dir inside local marketplace', async () => {
+        const result = await installPlugin(makeOpts());
+        expect(result.marketplaceDir).toContain(join('marketplaces', 'local', 'apijack'));
+    });
 
-  test("copies skills to plugin dir", async () => {
-    const result = await installPlugin(makeOpts());
-    expect(existsSync(join(result.marketplaceDir, "skills", "write-routine", "SKILL.md"))).toBe(true);
-    expect(existsSync(join(result.marketplaceDir, "skills", "setup-api", "SKILL.md"))).toBe(true);
-  });
+    test('copies skills to plugin dir', async () => {
+        const result = await installPlugin(makeOpts());
+        expect(existsSync(join(result.marketplaceDir, 'skills', 'write-routine', 'SKILL.md'))).toBe(true);
+        expect(existsSync(join(result.marketplaceDir, 'skills', 'setup-api', 'SKILL.md'))).toBe(true);
+    });
 
-  test("writes .mcp.json with CLAUDE_PLUGIN_ROOT", async () => {
-    const result = await installPlugin(makeOpts());
-    const mcpJson = readJson(join(result.marketplaceDir, ".mcp.json"));
-    expect(mcpJson.mcpServers.apijack.args).toContain("${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js");
-  });
+    test('writes .mcp.json with CLAUDE_PLUGIN_ROOT', async () => {
+        const result = await installPlugin(makeOpts());
+        const mcpJson = readJson(join(result.marketplaceDir, '.mcp.json'));
+        expect(mcpJson.mcpServers.apijack.args).toContain('${CLAUDE_PLUGIN_ROOT}/dist/mcp-server.bundle.js');
+    });
 
-  test("creates user data directory", async () => {
-    await installPlugin(makeOpts());
-    expect(existsSync(testDataDir)).toBe(true);
-    expect(existsSync(join(testDataDir, "routines"))).toBe(true);
-  });
+    test('creates user data directory', async () => {
+        await installPlugin(makeOpts());
+        expect(existsSync(testDataDir)).toBe(true);
+        expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
+    });
 
-  test("writes plugin.json with cliInvocation to user data dir", async () => {
-    await installPlugin(makeOpts());
-    const pluginConfig = readJson(join(testDataDir, "plugin.json"));
-    expect(pluginConfig.cliInvocation).toEqual(["bun", "run", "src/cli.ts"]);
-    expect(pluginConfig.generatedDir).toBe("src/generated");
-  });
+    test('writes plugin.json with cliInvocation to user data dir', async () => {
+        await installPlugin(makeOpts());
+        const pluginConfig = readJson(join(testDataDir, 'plugin.json'));
+        expect(pluginConfig.cliInvocation).toEqual(['bun', 'run', 'src/cli.ts']);
+        expect(pluginConfig.generatedDir).toBe('src/generated');
+    });
 
-  test("registers in installed_plugins.json and settings.json", async () => {
-    await installPlugin(makeOpts());
+    test('registers in installed_plugins.json and settings.json', async () => {
+        await installPlugin(makeOpts());
 
-    const installed = readJson(join(testClaudeDir, "plugins", "installed_plugins.json"));
-    expect(installed.plugins["apijack@local"]).toBeDefined();
-    expect(installed.plugins["apijack@local"][0].version).toBe("0.1.0");
+        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
+        expect(installed.plugins['apijack@local']).toBeDefined();
+        expect(installed.plugins['apijack@local'][0].version).toBe('0.1.0');
 
-    const settings = readJson(join(testClaudeDir, "settings.json"));
-    expect(settings.enabledPlugins["apijack@local"]).toBe(true);
-  });
+        const settings = readJson(join(testClaudeDir, 'settings.json'));
+        expect(settings.enabledPlugins['apijack@local']).toBe(true);
+    });
 
-  test("preserves other plugins in local marketplace", async () => {
-    const localDir = join(testClaudeDir, "plugins", "marketplaces", "local", ".claude-plugin");
-    mkdirSync(localDir, { recursive: true });
-    await Bun.write(
-      join(localDir, "marketplace.json"),
-      JSON.stringify({
-        name: "local",
-        owner: { name: "Local Plugins" },
-        plugins: [{ name: "other-plugin", description: "Other", source: "./other-plugin" }],
-      })
-    );
+    test('preserves other plugins in local marketplace', async () => {
+        const localDir = join(testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin');
+        mkdirSync(localDir, { recursive: true });
+        await Bun.write(
+            join(localDir, 'marketplace.json'),
+            JSON.stringify({
+                name: 'local',
+                owner: { name: 'Local Plugins' },
+                plugins: [{ name: 'other-plugin', description: 'Other', source: './other-plugin' }],
+            }),
+        );
 
-    await installPlugin(makeOpts());
+        await installPlugin(makeOpts());
 
-    const marketplace = readJson(join(localDir, "marketplace.json"));
-    expect(marketplace.plugins.find((p: any) => p.name === "other-plugin")).toBeDefined();
-    expect(marketplace.plugins.find((p: any) => p.name === "apijack")).toBeDefined();
-  });
+        const marketplace = readJson(join(localDir, 'marketplace.json'));
+        expect(marketplace.plugins.find((p: any) => p.name === 'other-plugin')).toBeDefined();
+        expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
+    });
 });

--- a/tests/plugin/integration.test.ts
+++ b/tests/plugin/integration.test.ts
@@ -6,8 +6,8 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-integration-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 const sourceDir = join(import.meta.dir, '../..');
 
 function readJson(path: string): any {
@@ -20,36 +20,41 @@ describe('plugin install → uninstall roundtrip', () => {
     });
 
     test('full lifecycle: install, verify, uninstall, verify preservation', async () => {
+        const installCalls: string[][] = [];
         const installResult = await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async (args) => {
+                installCalls.push(args);
+            },
         });
         expect(installResult.success).toBe(true);
+        expect(installCalls).toHaveLength(2);
 
-        // Verify marketplace
-        const marketplacePath = join(
-            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
-        );
-        const marketplace = readJson(marketplacePath);
+        // Marketplace + nested plugin manifest
+        const marketplace = readJson(join(testMarketplaceDir, '.claude-plugin', 'marketplace.json'));
         expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
 
-        // Verify installed
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local']).toBeDefined();
+        const manifest = readJson(join(testMarketplaceDir, 'apijack', '.claude-plugin', 'plugin.json'));
+        expect(manifest.name).toBe('apijack');
 
-        // Verify user data
+        // User data written
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
         expect(existsSync(join(testDataDir, 'plugin.json'))).toBe(true);
 
         // Uninstall
-        const uninstallResult = await uninstallPlugin({ claudeDir: testClaudeDir });
+        const uninstallResult = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
         expect(uninstallResult.success).toBe(true);
 
-        // Verify user data preserved
+        // Marketplace gone, user data preserved
+        expect(existsSync(testMarketplaceDir)).toBe(false);
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
     });
@@ -57,27 +62,32 @@ describe('plugin install → uninstall roundtrip', () => {
     test('reinstall after uninstall works cleanly', async () => {
         await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
 
         const result = await installPlugin({
             version: '0.2.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir,
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
 
         expect(result.success).toBe(true);
 
-        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
-        expect(installed.plugins['apijack@local'][0].version).toBe('0.2.0');
+        const manifest = readJson(join(testMarketplaceDir, 'apijack', '.claude-plugin', 'plugin.json'));
+        expect(manifest.version).toBe('0.2.0');
     });
 });

--- a/tests/plugin/integration.test.ts
+++ b/tests/plugin/integration.test.ts
@@ -1,83 +1,83 @@
-import { describe, test, expect, afterEach } from "bun:test";
-import { installPlugin } from "../../src/plugin/install";
-import { uninstallPlugin } from "../../src/plugin/uninstall";
-import { rmSync, existsSync, readFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, test, expect, afterEach } from 'bun:test';
+import { installPlugin } from '../../src/plugin/install';
+import { uninstallPlugin } from '../../src/plugin/uninstall';
+import { rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
-const testRoot = join(tmpdir(), "apijack-integration-" + Date.now());
-const testClaudeDir = join(testRoot, ".claude");
-const testDataDir = join(testRoot, ".apijack");
-const sourceDir = join(import.meta.dir, "../..");
+const testRoot = join(tmpdir(), 'apijack-integration-' + Date.now());
+const testClaudeDir = join(testRoot, '.claude');
+const testDataDir = join(testRoot, '.apijack');
+const sourceDir = join(import.meta.dir, '../..');
 
 function readJson(path: string): any {
-  return JSON.parse(readFileSync(path, "utf-8"));
+    return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
-describe("plugin install → uninstall roundtrip", () => {
-  afterEach(() => {
-    rmSync(testRoot, { recursive: true, force: true });
-  });
-
-  test("full lifecycle: install, verify, uninstall, verify preservation", async () => {
-    const installResult = await installPlugin({
-      version: "0.1.0",
-      claudeDir: testClaudeDir,
-      userDataDir: testDataDir,
-      sourceDir,
-      cliInvocation: ["bun", "run", "src/cli.ts"],
-      generatedDir: "src/generated",
-    });
-    expect(installResult.success).toBe(true);
-
-    // Verify marketplace
-    const marketplacePath = join(
-      testClaudeDir, "plugins", "marketplaces", "local", ".claude-plugin", "marketplace.json"
-    );
-    const marketplace = readJson(marketplacePath);
-    expect(marketplace.plugins.find((p: any) => p.name === "apijack")).toBeDefined();
-
-    // Verify installed
-    const installed = readJson(join(testClaudeDir, "plugins", "installed_plugins.json"));
-    expect(installed.plugins["apijack@local"]).toBeDefined();
-
-    // Verify user data
-    expect(existsSync(join(testDataDir, "routines"))).toBe(true);
-    expect(existsSync(join(testDataDir, "plugin.json"))).toBe(true);
-
-    // Uninstall
-    const uninstallResult = await uninstallPlugin({ claudeDir: testClaudeDir });
-    expect(uninstallResult.success).toBe(true);
-
-    // Verify user data preserved
-    expect(existsSync(testDataDir)).toBe(true);
-    expect(existsSync(join(testDataDir, "routines"))).toBe(true);
-  });
-
-  test("reinstall after uninstall works cleanly", async () => {
-    await installPlugin({
-      version: "0.1.0",
-      claudeDir: testClaudeDir,
-      userDataDir: testDataDir,
-      sourceDir,
-      cliInvocation: ["bun", "run", "src/cli.ts"],
-      generatedDir: "src/generated",
+describe('plugin install → uninstall roundtrip', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
     });
 
-    await uninstallPlugin({ claudeDir: testClaudeDir });
+    test('full lifecycle: install, verify, uninstall, verify preservation', async () => {
+        const installResult = await installPlugin({
+            version: '0.1.0',
+            claudeDir: testClaudeDir,
+            userDataDir: testDataDir,
+            sourceDir,
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+        });
+        expect(installResult.success).toBe(true);
 
-    const result = await installPlugin({
-      version: "0.2.0",
-      claudeDir: testClaudeDir,
-      userDataDir: testDataDir,
-      sourceDir,
-      cliInvocation: ["bun", "run", "src/cli.ts"],
-      generatedDir: "src/generated",
+        // Verify marketplace
+        const marketplacePath = join(
+            testClaudeDir, 'plugins', 'marketplaces', 'local', '.claude-plugin', 'marketplace.json',
+        );
+        const marketplace = readJson(marketplacePath);
+        expect(marketplace.plugins.find((p: any) => p.name === 'apijack')).toBeDefined();
+
+        // Verify installed
+        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
+        expect(installed.plugins['apijack@local']).toBeDefined();
+
+        // Verify user data
+        expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
+        expect(existsSync(join(testDataDir, 'plugin.json'))).toBe(true);
+
+        // Uninstall
+        const uninstallResult = await uninstallPlugin({ claudeDir: testClaudeDir });
+        expect(uninstallResult.success).toBe(true);
+
+        // Verify user data preserved
+        expect(existsSync(testDataDir)).toBe(true);
+        expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
     });
 
-    expect(result.success).toBe(true);
+    test('reinstall after uninstall works cleanly', async () => {
+        await installPlugin({
+            version: '0.1.0',
+            claudeDir: testClaudeDir,
+            userDataDir: testDataDir,
+            sourceDir,
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+        });
 
-    const installed = readJson(join(testClaudeDir, "plugins", "installed_plugins.json"));
-    expect(installed.plugins["apijack@local"][0].version).toBe("0.2.0");
-  });
+        await uninstallPlugin({ claudeDir: testClaudeDir });
+
+        const result = await installPlugin({
+            version: '0.2.0',
+            claudeDir: testClaudeDir,
+            userDataDir: testDataDir,
+            sourceDir,
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+        });
+
+        expect(result.success).toBe(true);
+
+        const installed = readJson(join(testClaudeDir, 'plugins', 'installed_plugins.json'));
+        expect(installed.plugins['apijack@local'][0].version).toBe('0.2.0');
+    });
 });

--- a/tests/plugin/paths.test.ts
+++ b/tests/plugin/paths.test.ts
@@ -1,32 +1,32 @@
-import { describe, test, expect } from "bun:test";
-import { getPluginPaths } from "../../src/plugin/paths";
-import { homedir } from "os";
-import { join } from "path";
+import { describe, test, expect } from 'bun:test';
+import { getPluginPaths } from '../../src/plugin/paths';
+import { homedir } from 'os';
+import { join } from 'path';
 
-describe("getPluginPaths()", () => {
-  const paths = getPluginPaths("0.1.0");
+describe('getPluginPaths()', () => {
+    const paths = getPluginPaths('0.1.0');
 
-  test("claudeDir points to ~/.claude", () => {
-    expect(paths.claudeDir).toBe(join(homedir(), ".claude"));
-  });
+    test('claudeDir points to ~/.claude', () => {
+        expect(paths.claudeDir).toBe(join(homedir(), '.claude'));
+    });
 
-  test("installedPluginsFile points to installed_plugins.json", () => {
-    expect(paths.installedPluginsFile).toBe(
-      join(homedir(), ".claude", "plugins", "installed_plugins.json"),
-    );
-  });
+    test('installedPluginsFile points to installed_plugins.json', () => {
+        expect(paths.installedPluginsFile).toBe(
+            join(homedir(), '.claude', 'plugins', 'installed_plugins.json'),
+        );
+    });
 
-  test("settingsFile points to settings.json", () => {
-    expect(paths.settingsFile).toBe(
-      join(homedir(), ".claude", "settings.json"),
-    );
-  });
+    test('settingsFile points to settings.json', () => {
+        expect(paths.settingsFile).toBe(
+            join(homedir(), '.claude', 'settings.json'),
+        );
+    });
 
-  test("userDataDir points to ~/.apijack", () => {
-    expect(paths.userDataDir).toBe(join(homedir(), ".apijack"));
-  });
+    test('userDataDir points to ~/.apijack', () => {
+        expect(paths.userDataDir).toBe(join(homedir(), '.apijack'));
+    });
 
-  test("sourceDir points to project root", () => {
-    expect(paths.sourceDir).toContain("apijack");
-  });
+    test('sourceDir points to project root', () => {
+        expect(paths.sourceDir).toContain('apijack');
+    });
 });

--- a/tests/plugin/paths.test.ts
+++ b/tests/plugin/paths.test.ts
@@ -6,24 +6,12 @@ import { join } from 'path';
 describe('getPluginPaths()', () => {
     const paths = getPluginPaths('0.1.0');
 
-    test('claudeDir points to ~/.claude', () => {
-        expect(paths.claudeDir).toBe(join(homedir(), '.claude'));
-    });
-
-    test('installedPluginsFile points to installed_plugins.json', () => {
-        expect(paths.installedPluginsFile).toBe(
-            join(homedir(), '.claude', 'plugins', 'installed_plugins.json'),
-        );
-    });
-
-    test('settingsFile points to settings.json', () => {
-        expect(paths.settingsFile).toBe(
-            join(homedir(), '.claude', 'settings.json'),
-        );
-    });
-
     test('userDataDir points to ~/.apijack', () => {
         expect(paths.userDataDir).toBe(join(homedir(), '.apijack'));
+    });
+
+    test('marketplaceDir points to ~/.apijack/plugin-marketplace', () => {
+        expect(paths.marketplaceDir).toBe(join(homedir(), '.apijack', 'plugin-marketplace'));
     });
 
     test('sourceDir points to project root', () => {

--- a/tests/plugin/uninstall.test.ts
+++ b/tests/plugin/uninstall.test.ts
@@ -1,28 +1,28 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { installPlugin } from '../../src/plugin/install';
 import { uninstallPlugin } from '../../src/plugin/uninstall';
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
 const testRoot = join(tmpdir(), 'apijack-uninstall-test-' + Date.now());
-const testClaudeDir = join(testRoot, '.claude');
 const testDataDir = join(testRoot, '.apijack');
-
-function readJson(path: string): any {
-    return JSON.parse(readFileSync(path, 'utf-8'));
-}
+const testMarketplaceDir = join(testDataDir, 'plugin-marketplace');
 
 describe('uninstallPlugin()', () => {
+    const claudeCalls: string[][] = [];
+
     beforeEach(async () => {
         mkdirSync(testRoot, { recursive: true });
+        claudeCalls.length = 0;
         await installPlugin({
             version: '0.1.0',
-            claudeDir: testClaudeDir,
             userDataDir: testDataDir,
+            marketplaceDir: testMarketplaceDir,
             sourceDir: join(import.meta.dir, '../..'),
             cliInvocation: ['bun', 'run', 'src/cli.ts'],
             generatedDir: 'src/generated',
+            runClaude: async () => {},
         });
     });
 
@@ -30,56 +30,63 @@ describe('uninstallPlugin()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('removes from installed_plugins.json when present', async () => {
-    // Set up legacy installed_plugins.json
-        const installedPath = join(testClaudeDir, 'plugins', 'installed_plugins.json');
-        mkdirSync(join(testClaudeDir, 'plugins'), { recursive: true });
-        writeFileSync(
-            installedPath,
-            JSON.stringify({ plugins: { 'apijack@local': [{ version: '0.1.0', scope: 'user' }] } }),
-        );
+    test('removes the marketplace directory', async () => {
+        expect(existsSync(testMarketplaceDir)).toBe(true);
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                claudeCalls.push(args);
+            },
+        });
 
-        const installed = readJson(installedPath);
-        expect(installed.plugins['apijack@local']).toBeUndefined();
+        expect(existsSync(testMarketplaceDir)).toBe(false);
     });
 
-    test('removes from enabledPlugins in settings.json when present', async () => {
-    // Set up settings.json with enabledPlugins
-        const settingsPath = join(testClaudeDir, 'settings.json');
-        writeFileSync(
-            settingsPath,
-            JSON.stringify({ enabledPlugins: { 'apijack@local': true } }),
-        );
+    test('invokes claude CLI to uninstall plugin and remove marketplace', async () => {
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                claudeCalls.push(args);
+            },
+        });
 
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-
-        const settings = readJson(settingsPath);
-        expect(settings.enabledPlugins['apijack@local']).toBeUndefined();
-    });
-
-    test('removes plugin cache directory when present', async () => {
-    // Set up cache directory
-        const cacheDir = join(testClaudeDir, 'plugins', 'cache', 'local', 'apijack');
-        mkdirSync(cacheDir, { recursive: true });
-        expect(existsSync(cacheDir)).toBe(true);
-
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-
-        expect(existsSync(cacheDir)).toBe(false);
+        expect(claudeCalls).toEqual([
+            ['plugin', 'uninstall', 'apijack@apijack'],
+            ['plugin', 'marketplace', 'remove', 'apijack'],
+        ]);
     });
 
     test('preserves user data directory', async () => {
-        await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
 
         expect(existsSync(testDataDir)).toBe(true);
         expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
     });
 
+    test('tolerates claude CLI failures and still cleans up files', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {
+                throw new Error('claude not found');
+            },
+        });
+
+        expect(result.success).toBe(true);
+        expect(existsSync(testMarketplaceDir)).toBe(false);
+    });
+
     test('handles already-uninstalled gracefully', async () => {
-        await uninstallPlugin({ claudeDir: testClaudeDir });
-        const result = await uninstallPlugin({ claudeDir: testClaudeDir });
+        rmSync(testMarketplaceDir, { recursive: true, force: true });
+
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
+
         expect(result.success).toBe(true);
     });
 });

--- a/tests/plugin/uninstall.test.ts
+++ b/tests/plugin/uninstall.test.ts
@@ -79,6 +79,30 @@ describe('uninstallPlugin()', () => {
         expect(existsSync(testMarketplaceDir)).toBe(false);
     });
 
+    test('surfaces claude CLI failures as warnings', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async (args) => {
+                throw new Error(`fake: ${args.join(' ')}`);
+            },
+        });
+
+        expect(result.warnings).toHaveLength(2);
+        expect(result.warnings[0]).toContain('plugin uninstall apijack@apijack');
+        expect(result.warnings[1]).toContain('plugin marketplace remove apijack');
+        expect(result.message).toContain('Warnings:');
+    });
+
+    test('no warnings when claude CLI succeeds', async () => {
+        const result = await uninstallPlugin({
+            marketplaceDir: testMarketplaceDir,
+            runClaude: async () => {},
+        });
+
+        expect(result.warnings).toHaveLength(0);
+        expect(result.message).not.toContain('Warnings:');
+    });
+
     test('handles already-uninstalled gracefully', async () => {
         rmSync(testMarketplaceDir, { recursive: true, force: true });
 

--- a/tests/plugin/uninstall.test.ts
+++ b/tests/plugin/uninstall.test.ts
@@ -1,85 +1,85 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { installPlugin } from "../../src/plugin/install";
-import { uninstallPlugin } from "../../src/plugin/uninstall";
-import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { installPlugin } from '../../src/plugin/install';
+import { uninstallPlugin } from '../../src/plugin/uninstall';
+import { mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
-const testRoot = join(tmpdir(), "apijack-uninstall-test-" + Date.now());
-const testClaudeDir = join(testRoot, ".claude");
-const testDataDir = join(testRoot, ".apijack");
+const testRoot = join(tmpdir(), 'apijack-uninstall-test-' + Date.now());
+const testClaudeDir = join(testRoot, '.claude');
+const testDataDir = join(testRoot, '.apijack');
 
 function readJson(path: string): any {
-  return JSON.parse(readFileSync(path, "utf-8"));
+    return JSON.parse(readFileSync(path, 'utf-8'));
 }
 
-describe("uninstallPlugin()", () => {
-  beforeEach(async () => {
-    mkdirSync(testRoot, { recursive: true });
-    await installPlugin({
-      version: "0.1.0",
-      claudeDir: testClaudeDir,
-      userDataDir: testDataDir,
-      sourceDir: join(import.meta.dir, "../.."),
-      cliInvocation: ["bun", "run", "src/cli.ts"],
-      generatedDir: "src/generated",
+describe('uninstallPlugin()', () => {
+    beforeEach(async () => {
+        mkdirSync(testRoot, { recursive: true });
+        await installPlugin({
+            version: '0.1.0',
+            claudeDir: testClaudeDir,
+            userDataDir: testDataDir,
+            sourceDir: join(import.meta.dir, '../..'),
+            cliInvocation: ['bun', 'run', 'src/cli.ts'],
+            generatedDir: 'src/generated',
+        });
     });
-  });
 
-  afterEach(() => {
-    rmSync(testRoot, { recursive: true, force: true });
-  });
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
 
-  test("removes from installed_plugins.json when present", async () => {
+    test('removes from installed_plugins.json when present', async () => {
     // Set up legacy installed_plugins.json
-    const installedPath = join(testClaudeDir, "plugins", "installed_plugins.json");
-    mkdirSync(join(testClaudeDir, "plugins"), { recursive: true });
-    writeFileSync(
-      installedPath,
-      JSON.stringify({ plugins: { "apijack@local": [{ version: "0.1.0", scope: "user" }] } })
-    );
+        const installedPath = join(testClaudeDir, 'plugins', 'installed_plugins.json');
+        mkdirSync(join(testClaudeDir, 'plugins'), { recursive: true });
+        writeFileSync(
+            installedPath,
+            JSON.stringify({ plugins: { 'apijack@local': [{ version: '0.1.0', scope: 'user' }] } }),
+        );
 
-    await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({ claudeDir: testClaudeDir });
 
-    const installed = readJson(installedPath);
-    expect(installed.plugins["apijack@local"]).toBeUndefined();
-  });
+        const installed = readJson(installedPath);
+        expect(installed.plugins['apijack@local']).toBeUndefined();
+    });
 
-  test("removes from enabledPlugins in settings.json when present", async () => {
+    test('removes from enabledPlugins in settings.json when present', async () => {
     // Set up settings.json with enabledPlugins
-    const settingsPath = join(testClaudeDir, "settings.json");
-    writeFileSync(
-      settingsPath,
-      JSON.stringify({ enabledPlugins: { "apijack@local": true } })
-    );
+        const settingsPath = join(testClaudeDir, 'settings.json');
+        writeFileSync(
+            settingsPath,
+            JSON.stringify({ enabledPlugins: { 'apijack@local': true } }),
+        );
 
-    await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({ claudeDir: testClaudeDir });
 
-    const settings = readJson(settingsPath);
-    expect(settings.enabledPlugins["apijack@local"]).toBeUndefined();
-  });
+        const settings = readJson(settingsPath);
+        expect(settings.enabledPlugins['apijack@local']).toBeUndefined();
+    });
 
-  test("removes plugin cache directory when present", async () => {
+    test('removes plugin cache directory when present', async () => {
     // Set up cache directory
-    const cacheDir = join(testClaudeDir, "plugins", "cache", "local", "apijack");
-    mkdirSync(cacheDir, { recursive: true });
-    expect(existsSync(cacheDir)).toBe(true);
+        const cacheDir = join(testClaudeDir, 'plugins', 'cache', 'local', 'apijack');
+        mkdirSync(cacheDir, { recursive: true });
+        expect(existsSync(cacheDir)).toBe(true);
 
-    await uninstallPlugin({ claudeDir: testClaudeDir });
+        await uninstallPlugin({ claudeDir: testClaudeDir });
 
-    expect(existsSync(cacheDir)).toBe(false);
-  });
+        expect(existsSync(cacheDir)).toBe(false);
+    });
 
-  test("preserves user data directory", async () => {
-    await uninstallPlugin({ claudeDir: testClaudeDir });
+    test('preserves user data directory', async () => {
+        await uninstallPlugin({ claudeDir: testClaudeDir });
 
-    expect(existsSync(testDataDir)).toBe(true);
-    expect(existsSync(join(testDataDir, "routines"))).toBe(true);
-  });
+        expect(existsSync(testDataDir)).toBe(true);
+        expect(existsSync(join(testDataDir, 'routines'))).toBe(true);
+    });
 
-  test("handles already-uninstalled gracefully", async () => {
-    await uninstallPlugin({ claudeDir: testClaudeDir });
-    const result = await uninstallPlugin({ claudeDir: testClaudeDir });
-    expect(result.success).toBe(true);
-  });
+    test('handles already-uninstalled gracefully', async () => {
+        await uninstallPlugin({ claudeDir: testClaudeDir });
+        const result = await uninstallPlugin({ claudeDir: testClaudeDir });
+        expect(result.success).toBe(true);
+    });
 });

--- a/tests/pre-request.test.ts
+++ b/tests/pre-request.test.ts
@@ -1,16 +1,17 @@
-import { describe, test, expect, afterAll } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
-import { join } from "path";
-import { loadPreRequestHook, type PreRequestHookConfig } from "../src/pre-request";
+import { describe, test, expect, afterAll } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { loadPreRequestHook, type PreRequestHookConfig } from '../src/pre-request';
 
 // Each test uses a unique directory to avoid Bun's module cache
 // returning stale imports for the same file path.
-const baseDir = join(import.meta.dir, ".tmp-pre-request");
+const baseDir = join(import.meta.dir, '.tmp-pre-request');
 let testCounter = 0;
 
 function createTestDir(): string {
     const dir = join(baseDir, `test-${++testCounter}`);
     mkdirSync(dir, { recursive: true });
+
     return dir;
 }
 
@@ -18,39 +19,39 @@ afterAll(() => {
     rmSync(baseDir, { recursive: true, force: true });
 });
 
-describe("loadPreRequestHook", () => {
-    test("returns null when no hook file exists", async () => {
+describe('loadPreRequestHook', () => {
+    test('returns null when no hook file exists', async () => {
         const tmpDir = createTestDir();
         const result = await loadPreRequestHook(tmpDir);
         expect(result).toBeNull();
     });
 
-    test("loads .ts hook with default export function", async () => {
+    test('loads .ts hook with default export function', async () => {
         const tmpDir = createTestDir();
-        writeFileSync(join(tmpDir, "pre-request.ts"), `
+        writeFileSync(join(tmpDir, 'pre-request.ts'), `
             export default function handler(req: { method: string; url: string }) {
                 // noop
             }
         `);
         const result = await loadPreRequestHook(tmpDir);
         expect(result).not.toBeNull();
-        expect(typeof result!.handler).toBe("function");
+        expect(typeof result!.handler).toBe('function');
         expect(result!.beforeDryRun).toBe(false);
     });
 
-    test("loads .js hook as fallback when .ts does not exist", async () => {
+    test('loads .js hook as fallback when .ts does not exist', async () => {
         const tmpDir = createTestDir();
-        writeFileSync(join(tmpDir, "pre-request.js"), `
+        writeFileSync(join(tmpDir, 'pre-request.js'), `
             export default function handler(req) {}
         `);
         const result = await loadPreRequestHook(tmpDir);
         expect(result).not.toBeNull();
-        expect(typeof result!.handler).toBe("function");
+        expect(typeof result!.handler).toBe('function');
     });
 
-    test("reads beforeDryRun named export", async () => {
+    test('reads beforeDryRun named export', async () => {
         const tmpDir = createTestDir();
-        writeFileSync(join(tmpDir, "pre-request.ts"), `
+        writeFileSync(join(tmpDir, 'pre-request.ts'), `
             export default function handler(req: { method: string; url: string }) {}
             export const beforeDryRun = true;
         `);
@@ -59,9 +60,9 @@ describe("loadPreRequestHook", () => {
         expect(result!.beforeDryRun).toBe(true);
     });
 
-    test("returns null if default export is not a function", async () => {
+    test('returns null if default export is not a function', async () => {
         const tmpDir = createTestDir();
-        writeFileSync(join(tmpDir, "pre-request.ts"), `
+        writeFileSync(join(tmpDir, 'pre-request.ts'), `
             export default "not a function";
         `);
         const result = await loadPreRequestHook(tmpDir);

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -125,5 +125,79 @@ describe('loadProjectDispatchers()', () => {
         expect(result.size).toBe(1);
         expect(result.has('notify')).toBe(true);
         expect(typeof result.get('notify')).toBe('function');
+    });
+});
+
+describe('loadProjectResolvers()', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('returns empty map when no resolvers/ dir exists', async () => {
+        mkdirSync(testRoot, { recursive: true });
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('loads resolver functions from resolvers/*.ts (name from export)', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'lookup.ts'), `
+            export const name = '_my_lookup';
+            export default (argsStr) => 'resolved:' + argsStr;
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(1);
+        expect(result.has('_my_lookup')).toBe(true);
+        expect(result.get('_my_lookup')!('hello')).toBe('resolved:hello');
+    });
+
+    test('falls back to filename when export name is missing', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, '_from_file.ts'), `
+            export default () => 42;
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(1);
+        expect(result.has('_from_file')).toBe(true);
+        expect(result.get('_from_file')!()).toBe(42);
+    });
+
+    test('skips resolvers whose name does not start with "_"', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'bad.ts'), `
+            export const name = 'no_underscore';
+            export default () => 'x';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('skips resolvers whose filename does not start with "_" when no export name', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'plainname.ts'), `
+            export default () => 'x';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
+    });
+
+    test('skips resolvers whose name collides with a built-in', async () => {
+        const resDir = join(testRoot, 'resolvers');
+        mkdirSync(resDir, { recursive: true });
+        writeFileSync(join(resDir, 'uuid.ts'), `
+            export const name = '_uuid';
+            export default () => 'overridden';
+        `);
+
+        const result = await loadProjectResolvers(testRoot);
+        expect(result.size).toBe(0);
     });
 });

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -11,10 +11,11 @@ describe('loadProjectAuth()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('returns null when no auth.ts exists', async () => {
+    test('returns null strategy and onChallenge when no auth.ts exists', async () => {
         mkdirSync(testRoot, { recursive: true });
         const result = await loadProjectAuth(testRoot);
-        expect(result).toBeNull();
+        expect(result.strategy).toBeNull();
+        expect(result.onChallenge).toBeNull();
     });
 
     test('loads auth strategy from auth.ts', async () => {
@@ -31,8 +32,27 @@ describe('loadProjectAuth()', () => {
         `);
 
         const result = await loadProjectAuth(testRoot);
-        expect(result).not.toBeNull();
-        expect(typeof result!.authenticate).toBe('function');
+        expect(result.strategy).not.toBeNull();
+        expect(typeof result.strategy!.authenticate).toBe('function');
+        expect(result.onChallenge).toBeNull();
+    });
+
+    test('loads onChallenge from auth.ts', async () => {
+        const root = join(tmpdir(), 'apijack-loader-onchallenge-' + Date.now());
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'auth.ts'), `
+            export async function onChallenge(status, body) {
+                return { retry: 'true' };
+            }
+        `);
+
+        try {
+            const result = await loadProjectAuth(root);
+            expect(result.strategy).toBeNull();
+            expect(typeof result.onChallenge).toBe('function');
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
     });
 });
 

--- a/tests/routine/condition.test.ts
+++ b/tests/routine/condition.test.ts
@@ -1,58 +1,58 @@
-import { describe, expect, test } from "bun:test";
-import { evaluateCondition } from "../../src/routine/condition";
-import type { RoutineContext } from "../../src/routine/types";
+import { describe, expect, test } from 'bun:test';
+import { evaluateCondition } from '../../src/routine/condition';
+import type { RoutineContext } from '../../src/routine/types';
 
 function makeCtx(overrides: Partial<RoutineContext> = {}): RoutineContext {
-  return {
-    variables: {},
-    stepOutputs: new Map(),
-    ...overrides,
-  };
+    return {
+        variables: {},
+        stepOutputs: new Map(),
+        ...overrides,
+    };
 }
 
-describe("evaluateCondition", () => {
-  test("undefined condition returns true", () => {
-    const ctx = makeCtx();
-    expect(evaluateCondition(undefined, ctx)).toBe(true);
-  });
+describe('evaluateCondition', () => {
+    test('undefined condition returns true', () => {
+        const ctx = makeCtx();
+        expect(evaluateCondition(undefined, ctx)).toBe(true);
+    });
 
-  test('"true" string returns true', () => {
-    const ctx = makeCtx();
-    expect(evaluateCondition("true", ctx)).toBe(true);
-  });
+    test('"true" string returns true', () => {
+        const ctx = makeCtx();
+        expect(evaluateCondition('true', ctx)).toBe(true);
+    });
 
-  test('"false" string returns false', () => {
-    const ctx = makeCtx();
-    expect(evaluateCondition("false", ctx)).toBe(false);
-  });
+    test('"false" string returns false', () => {
+        const ctx = makeCtx();
+        expect(evaluateCondition('false', ctx)).toBe(false);
+    });
 
-  test("equality check: $var == value", () => {
-    const ctx = makeCtx({ variables: { status: "active" } });
-    expect(evaluateCondition("$status == active", ctx)).toBe(true);
-    expect(evaluateCondition("$status == inactive", ctx)).toBe(false);
-  });
+    test('equality check: $var == value', () => {
+        const ctx = makeCtx({ variables: { status: 'active' } });
+        expect(evaluateCondition('$status == active', ctx)).toBe(true);
+        expect(evaluateCondition('$status == inactive', ctx)).toBe(false);
+    });
 
-  test("inequality check: $var != value", () => {
-    const ctx = makeCtx({ variables: { status: "active" } });
-    expect(evaluateCondition("$status != inactive", ctx)).toBe(true);
-    expect(evaluateCondition("$status != active", ctx)).toBe(false);
-  });
+    test('inequality check: $var != value', () => {
+        const ctx = makeCtx({ variables: { status: 'active' } });
+        expect(evaluateCondition('$status != inactive', ctx)).toBe(true);
+        expect(evaluateCondition('$status != active', ctx)).toBe(false);
+    });
 
-  test("truthy check: $var", () => {
-    const ctx = makeCtx({ variables: { enabled: true, disabled: false, empty: "" } });
-    expect(evaluateCondition("$enabled", ctx)).toBe(true);
-    expect(evaluateCondition("$disabled", ctx)).toBe(false);
-    expect(evaluateCondition("$empty", ctx)).toBe(false);
-  });
+    test('truthy check: $var', () => {
+        const ctx = makeCtx({ variables: { enabled: true, disabled: false, empty: '' } });
+        expect(evaluateCondition('$enabled', ctx)).toBe(true);
+        expect(evaluateCondition('$disabled', ctx)).toBe(false);
+        expect(evaluateCondition('$empty', ctx)).toBe(false);
+    });
 
-  test("RHS can be a $ref: $var == $other", () => {
-    const ctx = makeCtx({ variables: { a: "hello", b: "hello", c: "world" } });
-    expect(evaluateCondition("$a == $b", ctx)).toBe(true);
-    expect(evaluateCondition("$a == $c", ctx)).toBe(false);
-  });
+    test('RHS can be a $ref: $var == $other', () => {
+        const ctx = makeCtx({ variables: { a: 'hello', b: 'hello', c: 'world' } });
+        expect(evaluateCondition('$a == $b', ctx)).toBe(true);
+        expect(evaluateCondition('$a == $c', ctx)).toBe(false);
+    });
 
-  test("RHS $ref works with inequality: $var != $other", () => {
-    const ctx = makeCtx({ variables: { a: "hello", b: "world" } });
-    expect(evaluateCondition("$a != $b", ctx)).toBe(true);
-  });
+    test('RHS $ref works with inequality: $var != $other', () => {
+        const ctx = makeCtx({ variables: { a: 'hello', b: 'world' } });
+        expect(evaluateCondition('$a != $b', ctx)).toBe(true);
+    });
 });

--- a/tests/routine/condition.test.ts
+++ b/tests/routine/condition.test.ts
@@ -55,4 +55,52 @@ describe('evaluateCondition', () => {
         const ctx = makeCtx({ variables: { a: 'hello', b: 'world' } });
         expect(evaluateCondition('$a != $b', ctx)).toBe(true);
     });
+
+    test('$_find == undefined: true when array is empty', () => {
+        const ctx = makeCtx({ variables: { name: 'bob' } });
+        ctx.stepOutputs.set('items', { name: 'items', success: true, output: [] });
+        expect(evaluateCondition('$_find($items, name, $name) == undefined', ctx)).toBe(true);
+    });
+
+    test('$_find == undefined: true when value missing', () => {
+        const ctx = makeCtx({ variables: { name: 'carol' } });
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: [{ name: 'alice' }, { name: 'bob' }],
+        });
+        expect(evaluateCondition('$_find($items, name, $name) == undefined', ctx)).toBe(true);
+    });
+
+    test('$_find == undefined: false when value is present', () => {
+        const ctx = makeCtx({ variables: { name: 'alice' } });
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: [{ name: 'alice' }, { name: 'bob' }],
+        });
+        expect(evaluateCondition('$_find($items, name, $name) == undefined', ctx)).toBe(false);
+    });
+
+    test('$_contains == "true" when present', () => {
+        const ctx = makeCtx({ variables: { name: 'alice' } });
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: [{ name: 'alice' }, { name: 'bob' }],
+        });
+        expect(evaluateCondition('$_contains($items, name, $name) == "true"', ctx)).toBe(true);
+        expect(evaluateCondition('$_contains($items, name, $name) == "false"', ctx)).toBe(false);
+    });
+
+    test('$_contains == "false" when absent', () => {
+        const ctx = makeCtx({ variables: { name: 'carol' } });
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: [{ name: 'alice' }, { name: 'bob' }],
+        });
+        expect(evaluateCondition('$_contains($items, name, $name) == "false"', ctx)).toBe(true);
+        expect(evaluateCondition('$_contains($items, name, $name) == "true"', ctx)).toBe(false);
+    });
 });

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -437,6 +437,42 @@ describe('buildDispatcher', () => {
         expect(client.updateItem).toHaveBeenCalledWith(5, { title: 'New' }, { force: true });
     });
 
+    test('command-map body keeps field that is both a path param and a body field', async () => {
+        // Regression: fetch-agent takes agentId as a path param AND requires it in the request body.
+        // Previously the dispatcher stripped any flag whose name matched a path param, dropping agentId from the body.
+        const client = {
+            fetchAgent: mock(async (..._args: unknown[]) => ({ ok: true })),
+        };
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: {
+                'fetch-agent': {
+                    operationId: 'fetchAgent',
+                    pathParams: ['agentId'],
+                    queryParams: [],
+                    hasBody: true,
+                    bodyFields: [
+                        { name: 'authenticationId', type: 'number', required: true },
+                        { name: 'agentId', type: 'string', required: true },
+                    ],
+                },
+            },
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        await dispatch('fetch-agent', {
+            '--agentId': 'v2_agt_abc',
+            '--authenticationId': 1,
+        });
+
+        expect(client.fetchAgent).toHaveBeenCalledWith(
+            'v2_agt_abc',
+            { authenticationId: 1, agentId: 'v2_agt_abc' },
+        );
+    });
+
     test('command-map throws if client method not found', async () => {
         const client = {}; // no methods
         const ctx = makeCtx({ client });

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, mock, beforeEach } from 'bun:test';
 import { buildDispatcher, type DispatcherConfig } from '../../src/routine/dispatcher';
-import type { CliContext, DispatcherHandler, CommandDispatcher } from '../../src/types';
+import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../../src/types';
 
 function makeCtx(overrides: Partial<CliContext> = {}): CliContext {
     return {
@@ -299,6 +299,41 @@ describe('buildDispatcher', () => {
             stepsSkipped: 0,
             stepsFailed: 0,
         });
+    });
+
+    test('routine run forwards customResolvers from DispatcherConfig into executor', async () => {
+        const ctx = makeCtx();
+        const customResolvers = new Map<string, CustomResolver>([
+            ['_my_fn', () => 'hi'],
+        ]);
+
+        const mockLoadRoutineFile = mock(() => ({
+            name: 'sub-routine',
+            steps: [{ name: 'step-1', command: 'cmd-a' }],
+            variables: {},
+        }));
+        const mockValidateRoutine = mock(() => []);
+        const mockExecuteRoutine = mock(async () => ({
+            success: true,
+            stepsRun: 1,
+            stepsSkipped: 0,
+            stepsFailed: 0,
+        }));
+
+        const dispatch = buildDispatcher({
+            ctx,
+            routinesDir: '/tmp/routines',
+            customResolvers,
+            _loadRoutineFile: mockLoadRoutineFile as any,
+            _validateRoutine: mockValidateRoutine as any,
+            _executeRoutine: mockExecuteRoutine as any,
+        } as any);
+
+        await dispatch('routine run', {}, ['my-sub']);
+
+        const executeCall = mockExecuteRoutine.mock.calls[0]!;
+        // 4th arg is the options object — customResolvers should be forwarded
+        expect(executeCall[3]).toEqual({ customResolvers });
     });
 
     test('routine run throws on validation errors', async () => {

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -1,475 +1,478 @@
-import { describe, expect, test, mock, beforeEach } from "bun:test";
-import { buildDispatcher, type DispatcherConfig } from "../../src/routine/dispatcher";
-import type { CliContext, DispatcherHandler, CommandDispatcher } from "../../src/types";
+import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import { buildDispatcher, type DispatcherConfig } from '../../src/routine/dispatcher';
+import type { CliContext, DispatcherHandler, CommandDispatcher } from '../../src/types';
 
 function makeCtx(overrides: Partial<CliContext> = {}): CliContext {
-  return {
-    client: {},
-    session: {} as any,
-    auth: {} as any,
-    strategy: {} as any,
-    refreshSession: mock(async () => {}),
-    ...overrides,
-  };
+    return {
+        client: {},
+        session: {} as any,
+        auth: {} as any,
+        strategy: {} as any,
+        refreshSession: mock(async () => {}),
+        ...overrides,
+    };
 }
 
 function makeCommandMap() {
-  return {
-    "get-user": {
-      operationId: "getUserById",
-      pathParams: ["userId"],
-      queryParams: [],
-      hasBody: false,
-    },
-    "create-user": {
-      operationId: "createUser",
-      pathParams: [],
-      queryParams: [],
-      hasBody: true,
-    },
-    "search-users": {
-      operationId: "searchUsers",
-      pathParams: [],
-      queryParams: ["name", "pageSize"],
-      hasBody: false,
-    },
-    "update-item": {
-      operationId: "updateItem",
-      pathParams: ["itemId"],
-      queryParams: ["force"],
-      hasBody: true,
-    },
-  };
+    return {
+        'get-user': {
+            operationId: 'getUserById',
+            pathParams: ['userId'],
+            queryParams: [],
+            hasBody: false,
+        },
+        'create-user': {
+            operationId: 'createUser',
+            pathParams: [],
+            queryParams: [],
+            hasBody: true,
+        },
+        'search-users': {
+            operationId: 'searchUsers',
+            pathParams: [],
+            queryParams: ['name', 'pageSize'],
+            hasBody: false,
+        },
+        'update-item': {
+            operationId: 'updateItem',
+            pathParams: ['itemId'],
+            queryParams: ['force'],
+            hasBody: true,
+        },
+    };
 }
 
 function makeClient() {
-  return {
-    getUserById: mock(async (userId: unknown) => ({ id: userId, name: "Alice" })),
-    createUser: mock(async (body: unknown) => ({ id: 1, ...body as object })),
-    searchUsers: mock(async (query: unknown) => [{ id: 1, name: "Alice" }]),
-    updateItem: mock(async (...args: unknown[]) => ({ updated: true })),
-  };
+    return {
+        getUserById: mock(async (userId: unknown) => ({ id: userId, name: 'Alice' })),
+        createUser: mock(async (body: unknown) => ({ id: 1, ...body as object })),
+        searchUsers: mock(async (query: unknown) => [{ id: 1, name: 'Alice' }]),
+        updateItem: mock(async (...args: unknown[]) => ({ updated: true })),
+    };
 }
 
-describe("buildDispatcher", () => {
-  test("dispatches to command-map (calls correct client method with path params)", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+describe('buildDispatcher', () => {
+    test('dispatches to command-map (calls correct client method with path params)', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        const result = await dispatch('get-user', {}, [42]);
+
+        expect(client.getUserById).toHaveBeenCalledTimes(1);
+        expect(client.getUserById).toHaveBeenCalledWith(42);
+        expect(result).toEqual({ id: 42, name: 'Alice' });
     });
 
-    const result = await dispatch("get-user", {}, [42]);
+    test('dispatches to command-map with path params from flags (camelCase)', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    expect(client.getUserById).toHaveBeenCalledTimes(1);
-    expect(client.getUserById).toHaveBeenCalledWith(42);
-    expect(result).toEqual({ id: 42, name: "Alice" });
-  });
+        const result = await dispatch('get-user', { '--userId': 99 }, []);
 
-  test("dispatches to command-map with path params from flags (camelCase)", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(client.getUserById).toHaveBeenCalledWith(99);
     });
 
-    const result = await dispatch("get-user", { "--userId": 99 }, []);
+    test('dispatches to command-map with body args', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    expect(client.getUserById).toHaveBeenCalledWith(99);
-  });
+        const result = await dispatch('create-user', { '--name': 'Bob', '--email': 'bob@test.com' });
 
-  test("dispatches to command-map with body args", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(client.createUser).toHaveBeenCalledTimes(1);
+        expect(client.createUser).toHaveBeenCalledWith({ name: 'Bob', email: 'bob@test.com' });
     });
 
-    const result = await dispatch("create-user", { "--name": "Bob", "--email": "bob@test.com" });
+    test('dispatches to command-map with query params', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    expect(client.createUser).toHaveBeenCalledTimes(1);
-    expect(client.createUser).toHaveBeenCalledWith({ name: "Bob", email: "bob@test.com" });
-  });
+        await dispatch('search-users', { '--name': 'Alice', '--pageSize': 10 });
 
-  test("dispatches to command-map with query params", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(client.searchUsers).toHaveBeenCalledTimes(1);
+        expect(client.searchUsers).toHaveBeenCalledWith({ name: 'Alice', pageSize: 10 });
     });
 
-    await dispatch("search-users", { "--name": "Alice", "--pageSize": 10 });
+    test('dispatches to command-map with path params, body, and query params', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    expect(client.searchUsers).toHaveBeenCalledTimes(1);
-    expect(client.searchUsers).toHaveBeenCalledWith({ name: "Alice", pageSize: 10 });
-  });
+        await dispatch('update-item', { '--title': 'New Title', '--force': true }, [7]);
 
-  test("dispatches to command-map with path params, body, and query params", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(client.updateItem).toHaveBeenCalledTimes(1);
+        // Path param, then body, then query params
+        expect(client.updateItem).toHaveBeenCalledWith(7, { title: 'New Title' }, { force: true });
     });
 
-    await dispatch("update-item", { "--title": "New Title", "--force": true }, [7]);
+    test('dispatches to consumer-registered handler', async () => {
+        const ctx = makeCtx();
+        const handler: DispatcherHandler = mock(async (args, positionalArgs, ctx) => {
+            return { custom: true, val: args['--key'] };
+        });
+        const consumerHandlers = new Map<string, DispatcherHandler>();
+        consumerHandlers.set('custom-cmd', handler);
 
-    expect(client.updateItem).toHaveBeenCalledTimes(1);
-    // Path param, then body, then query params
-    expect(client.updateItem).toHaveBeenCalledWith(7, { title: "New Title" }, { force: true });
-  });
+        const dispatch = buildDispatcher({
+            consumerHandlers,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-  test("dispatches to consumer-registered handler", async () => {
-    const ctx = makeCtx();
-    const handler: DispatcherHandler = mock(async (args, positionalArgs, ctx) => {
-      return { custom: true, val: args["--key"] };
-    });
-    const consumerHandlers = new Map<string, DispatcherHandler>();
-    consumerHandlers.set("custom-cmd", handler);
+        const result = await dispatch('custom-cmd', { '--key': 'value' }, ['pos1']);
 
-    const dispatch = buildDispatcher({
-      consumerHandlers,
-      ctx,
-      routinesDir: "/tmp/routines",
-    });
-
-    const result = await dispatch("custom-cmd", { "--key": "value" }, ["pos1"]);
-
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenCalledWith({ "--key": "value" }, ["pos1"], ctx);
-    expect(result).toEqual({ custom: true, val: "value" });
-  });
-
-  test("wait-until polls until truthy result", async () => {
-    let callCount = 0;
-    const client = {
-      checkStatus: mock(async () => {
-        callCount++;
-        if (callCount < 3) return null;
-        return { done: true };
-      }),
-    };
-    const commandMap = {
-      "check-status": {
-        operationId: "checkStatus",
-        pathParams: [],
-        queryParams: [],
-        hasBody: false,
-      },
-    };
-    const ctx = makeCtx({ client });
-
-    const dispatch = buildDispatcher({
-      commandMap,
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith({ '--key': 'value' }, ['pos1'], ctx);
+        expect(result).toEqual({ custom: true, val: 'value' });
     });
 
-    const result = await dispatch("wait-until", { "--interval": 0.01, "--timeout": 5 }, ["check-status"]);
+    test('wait-until polls until truthy result', async () => {
+        let callCount = 0;
+        const client = {
+            checkStatus: mock(async () => {
+                callCount++;
 
-    expect(result).toEqual({ done: true });
-    expect(callCount).toBe(3);
-  });
+                if (callCount < 3) return null;
 
-  test("wait-until times out and throws", async () => {
-    const client = {
-      checkStatus: mock(async () => null),
-    };
-    const commandMap = {
-      "check-status": {
-        operationId: "checkStatus",
-        pathParams: [],
-        queryParams: [],
-        hasBody: false,
-      },
-    };
-    const ctx = makeCtx({ client });
+                return { done: true };
+            }),
+        };
+        const commandMap = {
+            'check-status': {
+                operationId: 'checkStatus',
+                pathParams: [],
+                queryParams: [],
+                hasBody: false,
+            },
+        };
+        const ctx = makeCtx({ client });
 
-    const dispatch = buildDispatcher({
-      commandMap,
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        const dispatch = buildDispatcher({
+            commandMap,
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        const result = await dispatch('wait-until', { '--interval': 0.01, '--timeout': 5 }, ['check-status']);
+
+        expect(result).toEqual({ done: true });
+        expect(callCount).toBe(3);
     });
 
-    await expect(
-      dispatch("wait-until", { "--interval": 0.01, "--timeout": 0.05 }, ["check-status"]),
-    ).rejects.toThrow(/wait-until timed out/);
-  });
+    test('wait-until times out and throws', async () => {
+        const client = {
+            checkStatus: mock(async () => null),
+        };
+        const commandMap = {
+            'check-status': {
+                operationId: 'checkStatus',
+                pathParams: [],
+                queryParams: [],
+                hasBody: false,
+            },
+        };
+        const ctx = makeCtx({ client });
 
-  test("wait-until passes through non-interval/timeout args to sub-command", async () => {
-    let receivedArgs: Record<string, unknown> = {};
-    const client = {
-      checkStatus: mock(async () => {
-        return { ready: true };
-      }),
-    };
-    const commandMap = {
-      "check-status": {
-        operationId: "checkStatus",
-        pathParams: [],
-        queryParams: ["filter"],
-        hasBody: false,
-      },
-    };
-    const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap,
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    const dispatch = buildDispatcher({
-      commandMap,
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        await expect(
+            dispatch('wait-until', { '--interval': 0.01, '--timeout': 0.05 }, ['check-status']),
+        ).rejects.toThrow(/wait-until timed out/);
     });
 
-    await dispatch("wait-until", { "--interval": 0.01, "--timeout": 5, "--filter": "active" }, ["check-status"]);
+    test('wait-until passes through non-interval/timeout args to sub-command', async () => {
+        const receivedArgs: Record<string, unknown> = {};
+        const client = {
+            checkStatus: mock(async () => {
+                return { ready: true };
+            }),
+        };
+        const commandMap = {
+            'check-status': {
+                operationId: 'checkStatus',
+                pathParams: [],
+                queryParams: ['filter'],
+                hasBody: false,
+            },
+        };
+        const ctx = makeCtx({ client });
 
-    expect(client.checkStatus).toHaveBeenCalledWith({ filter: "active" });
-  });
+        const dispatch = buildDispatcher({
+            commandMap,
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-  test("session refresh calls ctx.refreshSession()", async () => {
-    const ctx = makeCtx();
+        await dispatch('wait-until', { '--interval': 0.01, '--timeout': 5, '--filter': 'active' }, ['check-status']);
 
-    const dispatch = buildDispatcher({
-      ctx,
-      routinesDir: "/tmp/routines",
+        expect(client.checkStatus).toHaveBeenCalledWith({ filter: 'active' });
     });
 
-    const result = await dispatch("session refresh", {});
+    test('session refresh calls ctx.refreshSession()', async () => {
+        const ctx = makeCtx();
 
-    expect(ctx.refreshSession).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ refreshed: true });
-  });
+        const dispatch = buildDispatcher({
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-  test("routine run loads and executes sub-routine", async () => {
-    const ctx = makeCtx();
+        const result = await dispatch('session refresh', {});
 
-    // We'll mock the loader and executor at the module level
-    const mockLoadRoutineFile = mock(() => ({
-      name: "sub-routine",
-      steps: [{ name: "step-1", command: "cmd-a" }],
-      variables: {},
-    }));
-    const mockValidateRoutine = mock(() => []);
-    const mockExecuteRoutine = mock(async () => ({
-      success: true,
-      stepsRun: 1,
-      stepsSkipped: 0,
-      stepsFailed: 0,
-    }));
-
-    // Import the module to use the real buildDispatcher but with injected dependencies
-    const { buildDispatcher: buildDispatcherReal } = await import("../../src/routine/dispatcher");
-
-    const dispatch = buildDispatcherReal({
-      ctx,
-      routinesDir: "/tmp/routines",
-      _loadRoutineFile: mockLoadRoutineFile as any,
-      _validateRoutine: mockValidateRoutine as any,
-      _executeRoutine: mockExecuteRoutine as any,
-    } as any);
-
-    const result = await dispatch("routine run", { "--set-env": "test" }, ["my-sub"]);
-
-    expect(mockLoadRoutineFile).toHaveBeenCalledWith("my-sub", "/tmp/routines", undefined);
-    expect(mockValidateRoutine).toHaveBeenCalled();
-    expect(mockExecuteRoutine).toHaveBeenCalled();
-    // Check overrides were passed through
-    const executeCall = mockExecuteRoutine.mock.calls[0]!;
-    expect(executeCall[1]).toEqual({ env: "test" });
-    expect(result).toEqual({
-      success: true,
-      stepsRun: 1,
-      stepsSkipped: 0,
-      stepsFailed: 0,
-    });
-  });
-
-  test("routine run throws on validation errors", async () => {
-    const ctx = makeCtx();
-
-    const { buildDispatcher: buildDispatcherReal } = await import("../../src/routine/dispatcher");
-
-    const dispatch = buildDispatcherReal({
-      ctx,
-      routinesDir: "/tmp/routines",
-      _loadRoutineFile: mock(() => ({
-        name: "bad-routine",
-        steps: [{ name: "step-1" }],
-        variables: {},
-      })) as any,
-      _validateRoutine: mock(() => ["Step missing command"]) as any,
-      _executeRoutine: mock(async () => ({})) as any,
-    } as any);
-
-    await expect(
-      dispatch("routine run", {}, ["bad-routine"]),
-    ).rejects.toThrow(/validation failed/);
-  });
-
-  test("routine run throws on failed sub-routine", async () => {
-    const ctx = makeCtx();
-
-    const { buildDispatcher: buildDispatcherReal } = await import("../../src/routine/dispatcher");
-
-    const dispatch = buildDispatcherReal({
-      ctx,
-      routinesDir: "/tmp/routines",
-      _loadRoutineFile: mock(() => ({
-        name: "failing-routine",
-        steps: [{ name: "step-1", command: "fail" }],
-        variables: {},
-      })) as any,
-      _validateRoutine: mock(() => []) as any,
-      _executeRoutine: mock(async () => ({
-        success: false,
-        stepsRun: 1,
-        stepsSkipped: 0,
-        stepsFailed: 1,
-      })) as any,
-    } as any);
-
-    await expect(
-      dispatch("routine run", {}, ["failing-routine"]),
-    ).rejects.toThrow(/failed/);
-  });
-
-  test("pre-dispatch hook is called before dispatch", async () => {
-    const callOrder: string[] = [];
-    const client = makeClient();
-    const originalGetUserById = client.getUserById;
-    client.getUserById = mock(async (...args: unknown[]) => {
-      callOrder.push("dispatch");
-      return originalGetUserById(...args);
+        expect(ctx.refreshSession).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ refreshed: true });
     });
 
-    const preDispatch = mock(async (command: string, args: Record<string, unknown>, ctx: CliContext) => {
-      callOrder.push("preDispatch");
+    test('routine run loads and executes sub-routine', async () => {
+        const ctx = makeCtx();
+
+        // We'll mock the loader and executor at the module level
+        const mockLoadRoutineFile = mock(() => ({
+            name: 'sub-routine',
+            steps: [{ name: 'step-1', command: 'cmd-a' }],
+            variables: {},
+        }));
+        const mockValidateRoutine = mock(() => []);
+        const mockExecuteRoutine = mock(async () => ({
+            success: true,
+            stepsRun: 1,
+            stepsSkipped: 0,
+            stepsFailed: 0,
+        }));
+
+        // Import the module to use the real buildDispatcher but with injected dependencies
+        const { buildDispatcher: buildDispatcherReal } = await import('../../src/routine/dispatcher');
+
+        const dispatch = buildDispatcherReal({
+            ctx,
+            routinesDir: '/tmp/routines',
+            _loadRoutineFile: mockLoadRoutineFile as any,
+            _validateRoutine: mockValidateRoutine as any,
+            _executeRoutine: mockExecuteRoutine as any,
+        } as any);
+
+        const result = await dispatch('routine run', { '--set-env': 'test' }, ['my-sub']);
+
+        expect(mockLoadRoutineFile).toHaveBeenCalledWith('my-sub', '/tmp/routines', undefined);
+        expect(mockValidateRoutine).toHaveBeenCalled();
+        expect(mockExecuteRoutine).toHaveBeenCalled();
+        // Check overrides were passed through
+        const executeCall = mockExecuteRoutine.mock.calls[0]!;
+        expect(executeCall[1]).toEqual({ env: 'test' });
+        expect(result).toEqual({
+            success: true,
+            stepsRun: 1,
+            stepsSkipped: 0,
+            stepsFailed: 0,
+        });
     });
 
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      preDispatch,
-      ctx,
-      routinesDir: "/tmp/routines",
+    test('routine run throws on validation errors', async () => {
+        const ctx = makeCtx();
+
+        const { buildDispatcher: buildDispatcherReal } = await import('../../src/routine/dispatcher');
+
+        const dispatch = buildDispatcherReal({
+            ctx,
+            routinesDir: '/tmp/routines',
+            _loadRoutineFile: mock(() => ({
+                name: 'bad-routine',
+                steps: [{ name: 'step-1' }],
+                variables: {},
+            })) as any,
+            _validateRoutine: mock(() => ['Step missing command']) as any,
+            _executeRoutine: mock(async () => ({})) as any,
+        } as any);
+
+        await expect(
+            dispatch('routine run', {}, ['bad-routine']),
+        ).rejects.toThrow(/validation failed/);
     });
 
-    await dispatch("get-user", {}, [1]);
+    test('routine run throws on failed sub-routine', async () => {
+        const ctx = makeCtx();
 
-    expect(preDispatch).toHaveBeenCalledTimes(1);
-    expect(preDispatch).toHaveBeenCalledWith("get-user", {}, ctx);
-    expect(callOrder).toEqual(["preDispatch", "dispatch"]);
-  });
+        const { buildDispatcher: buildDispatcherReal } = await import('../../src/routine/dispatcher');
 
-  test("unknown command throws", async () => {
-    const ctx = makeCtx();
-    const dispatch = buildDispatcher({
-      ctx,
-      routinesDir: "/tmp/routines",
+        const dispatch = buildDispatcherReal({
+            ctx,
+            routinesDir: '/tmp/routines',
+            _loadRoutineFile: mock(() => ({
+                name: 'failing-routine',
+                steps: [{ name: 'step-1', command: 'fail' }],
+                variables: {},
+            })) as any,
+            _validateRoutine: mock(() => []) as any,
+            _executeRoutine: mock(async () => ({
+                success: false,
+                stepsRun: 1,
+                stepsSkipped: 0,
+                stepsFailed: 1,
+            })) as any,
+        } as any);
+
+        await expect(
+            dispatch('routine run', {}, ['failing-routine']),
+        ).rejects.toThrow(/failed/);
     });
 
-    await expect(
-      dispatch("nonexistent-command", {}),
-    ).rejects.toThrow(/Unknown command: "nonexistent-command"/);
-  });
+    test('pre-dispatch hook is called before dispatch', async () => {
+        const callOrder: string[] = [];
+        const client = makeClient();
+        const originalGetUserById = client.getUserById;
+        client.getUserById = mock(async (...args: unknown[]) => {
+            callOrder.push('dispatch');
 
-  test("dispatch order: command-map wins over consumer handler for same name", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
+            return originalGetUserById(...args);
+        });
 
-    const consumerHandler: DispatcherHandler = mock(async () => ({ fromConsumer: true }));
-    const consumerHandlers = new Map<string, DispatcherHandler>();
-    consumerHandlers.set("get-user", consumerHandler);
+        const preDispatch = mock(async (command: string, args: Record<string, unknown>, ctx: CliContext) => {
+            callOrder.push('preDispatch');
+        });
 
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      consumerHandlers,
-      ctx,
-      routinesDir: "/tmp/routines",
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            preDispatch,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        await dispatch('get-user', {}, [1]);
+
+        expect(preDispatch).toHaveBeenCalledTimes(1);
+        expect(preDispatch).toHaveBeenCalledWith('get-user', {}, ctx);
+        expect(callOrder).toEqual(['preDispatch', 'dispatch']);
     });
 
-    const result = await dispatch("get-user", {}, [42]);
+    test('unknown command throws', async () => {
+        const ctx = makeCtx();
+        const dispatch = buildDispatcher({
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    // Command-map should win
-    expect(client.getUserById).toHaveBeenCalledTimes(1);
-    expect(consumerHandler).not.toHaveBeenCalled();
-    expect(result).toEqual({ id: 42, name: "Alice" });
-  });
-
-  test("command-map body skips path params and query params", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        await expect(
+            dispatch('nonexistent-command', {}),
+        ).rejects.toThrow(/Unknown command: "nonexistent-command"/);
     });
 
-    // update-item has pathParams: ["itemId"], queryParams: ["force"], hasBody: true
-    await dispatch("update-item", {
-      "--itemId": 5,    // path param (should NOT end up in body)
-      "--force": true,  // query param (should NOT end up in body)
-      "--title": "New", // body param
+    test('dispatch order: command-map wins over consumer handler for same name', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+
+        const consumerHandler: DispatcherHandler = mock(async () => ({ fromConsumer: true }));
+        const consumerHandlers = new Map<string, DispatcherHandler>();
+        consumerHandlers.set('get-user', consumerHandler);
+
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            consumerHandlers,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
+
+        const result = await dispatch('get-user', {}, [42]);
+
+        // Command-map should win
+        expect(client.getUserById).toHaveBeenCalledTimes(1);
+        expect(consumerHandler).not.toHaveBeenCalled();
+        expect(result).toEqual({ id: 42, name: 'Alice' });
     });
 
-    // itemId from flag, body without itemId/force, query with force
-    expect(client.updateItem).toHaveBeenCalledWith(5, { title: "New" }, { force: true });
-  });
+    test('command-map body skips path params and query params', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-  test("command-map throws if client method not found", async () => {
-    const client = {}; // no methods
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: {
-        "missing-method": {
-          operationId: "doesNotExist",
-          pathParams: [],
-          queryParams: [],
-          hasBody: false,
-        },
-      },
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        // update-item has pathParams: ["itemId"], queryParams: ["force"], hasBody: true
+        await dispatch('update-item', {
+            '--itemId': 5,    // path param (should NOT end up in body)
+            '--force': true,  // query param (should NOT end up in body)
+            '--title': 'New', // body param
+        });
+
+        // itemId from flag, body without itemId/force, query with force
+        expect(client.updateItem).toHaveBeenCalledWith(5, { title: 'New' }, { force: true });
     });
 
-    await expect(
-      dispatch("missing-method", {}),
-    ).rejects.toThrow(/Client method "doesNotExist" not found/);
-  });
+    test('command-map throws if client method not found', async () => {
+        const client = {}; // no methods
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: {
+                'missing-method': {
+                    operationId: 'doesNotExist',
+                    pathParams: [],
+                    queryParams: [],
+                    hasBody: false,
+                },
+            },
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-  test("command-map does not pass empty body when hasBody but no args", async () => {
-    const client = makeClient();
-    const ctx = makeCtx({ client });
-    const dispatch = buildDispatcher({
-      commandMap: makeCommandMap(),
-      client,
-      ctx,
-      routinesDir: "/tmp/routines",
+        await expect(
+            dispatch('missing-method', {}),
+        ).rejects.toThrow(/Client method "doesNotExist" not found/);
     });
 
-    await dispatch("create-user", {});
+    test('command-map does not pass empty body when hasBody but no args', async () => {
+        const client = makeClient();
+        const ctx = makeCtx({ client });
+        const dispatch = buildDispatcher({
+            commandMap: makeCommandMap(),
+            client,
+            ctx,
+            routinesDir: '/tmp/routines',
+        });
 
-    // Should be called with no arguments (no empty body object)
-    expect(client.createUser).toHaveBeenCalledTimes(1);
-    expect(client.createUser.mock.calls[0]!.length).toBe(0);
-  });
+        await dispatch('create-user', {});
+
+        // Should be called with no arguments (no empty body object)
+        expect(client.createUser).toHaveBeenCalledTimes(1);
+        expect(client.createUser.mock.calls[0]!.length).toBe(0);
+    });
 });

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -1,434 +1,447 @@
-import { describe, expect, test, mock } from "bun:test";
-import { executeRoutine } from "../../src/routine/executor";
-import type { RoutineDefinition, RoutineStep } from "../../src/routine/types";
-import type { CommandDispatcher } from "../../src/types";
+import { describe, expect, test, mock } from 'bun:test';
+import { executeRoutine } from '../../src/routine/executor';
+import type { RoutineDefinition, RoutineStep } from '../../src/routine/types';
+import type { CommandDispatcher } from '../../src/types';
 
 function makeRoutine(overrides: Partial<RoutineDefinition> = {}): RoutineDefinition {
-  return {
-    name: "test-routine",
-    steps: [],
-    variables: {},
-    ...overrides,
-  };
+    return {
+        name: 'test-routine',
+        steps: [],
+        variables: {},
+        ...overrides,
+    };
 }
 
 function makeMockDispatcher(results: Record<string, unknown> = {}) {
-  const calls: { command: string; args: Record<string, unknown>; positionalArgs?: unknown[] }[] = [];
-  const dispatcher: CommandDispatcher = async (command, args, positionalArgs) => {
-    calls.push({ command, args, positionalArgs });
-    if (command in results) return results[command];
-    return { ok: true };
-  };
-  return { dispatcher, calls };
+    const calls: { command: string; args: Record<string, unknown>; positionalArgs?: unknown[] }[] = [];
+    const dispatcher: CommandDispatcher = async (command, args, positionalArgs) => {
+        calls.push({ command, args, positionalArgs });
+
+        if (command in results) return results[command];
+
+        return { ok: true };
+    };
+
+    return { dispatcher, calls };
 }
 
-describe("executeRoutine", () => {
-  test("runs steps sequentially, calls dispatcher for each", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "step-1", command: "cmd-a", args: { key: "val1" } },
-        { name: "step-2", command: "cmd-b", args: { key: "val2" } },
-      ],
-    });
-    const { dispatcher, calls } = makeMockDispatcher();
-    const result = await executeRoutine(routine, {}, dispatcher);
+describe('executeRoutine', () => {
+    test('runs steps sequentially, calls dispatcher for each', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'step-1', command: 'cmd-a', args: { key: 'val1' } },
+                { name: 'step-2', command: 'cmd-b', args: { key: 'val2' } },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
 
-    expect(result.success).toBe(true);
-    expect(result.stepsRun).toBe(2);
-    expect(result.stepsSkipped).toBe(0);
-    expect(result.stepsFailed).toBe(0);
-    expect(calls.length).toBe(2);
-    expect(calls[0]!.command).toBe("cmd-a");
-    expect(calls[1]!.command).toBe("cmd-b");
-  });
-
-  test("skips steps where condition is false", async () => {
-    const routine = makeRoutine({
-      variables: { enabled: false },
-      steps: [
-        { name: "skipped", command: "cmd-a", condition: "$enabled" },
-        { name: "run", command: "cmd-b" },
-      ],
-    });
-    const { dispatcher, calls } = makeMockDispatcher();
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(result.stepsRun).toBe(1);
-    expect(result.stepsSkipped).toBe(1);
-    expect(calls.length).toBe(1);
-    expect(calls[0]!.command).toBe("cmd-b");
-  });
-
-  test("forEach iterates over array", async () => {
-    const routine = makeRoutine({
-      variables: { items: ["a", "b", "c"] },
-      steps: [
-        {
-          name: "loop",
-          forEach: "$items",
-          as: "item",
-          steps: [
-            { name: "inner", command: "process", args: { value: "$item" } },
-          ],
-        },
-      ],
-    });
-    const { dispatcher, calls } = makeMockDispatcher();
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(calls.length).toBe(3);
-    expect(calls[0]!.args.value).toBe("a");
-    expect(calls[1]!.args.value).toBe("b");
-    expect(calls[2]!.args.value).toBe("c");
-  });
-
-  test("assertions pass correctly", async () => {
-    const routine = makeRoutine({
-      steps: [
-        {
-          name: "check",
-          command: "cmd-a",
-          assert: "$check.success == true",
-        },
-      ],
-    });
-    const { dispatcher } = makeMockDispatcher({ "cmd-a": { status: "ok" } });
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(result.stepsFailed).toBe(0);
-  });
-
-  test("assertions fail correctly", async () => {
-    const routine = makeRoutine({
-      steps: [
-        {
-          name: "check",
-          command: "cmd-a",
-          assert: "$check.success == false",
-        },
-      ],
-    });
-    const { dispatcher } = makeMockDispatcher({ "cmd-a": { status: "ok" } });
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(false);
-    expect(result.stepsFailed).toBe(1);
-  });
-
-  test("continueOnError allows continued execution", async () => {
-    const failDispatcher: CommandDispatcher = async (command) => {
-      if (command === "fail-cmd") throw new Error("boom");
-      return { ok: true };
-    };
-
-    const routine = makeRoutine({
-      steps: [
-        { name: "will-fail", command: "fail-cmd", continueOnError: true },
-        { name: "will-run", command: "ok-cmd" },
-      ],
-    });
-    const result = await executeRoutine(routine, {}, failDispatcher);
-
-    expect(result.success).toBe(false); // stepsFailed > 0
-    expect(result.stepsRun).toBe(2);
-    expect(result.stepsFailed).toBe(1);
-  });
-
-  test("dry run prints without executing", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "step-1", command: "cmd-a", args: { key: "val" } },
-        { name: "step-2", command: "cmd-b" },
-      ],
-    });
-    const { dispatcher, calls } = makeMockDispatcher();
-    const result = await executeRoutine(routine, {}, dispatcher, { dryRun: true });
-
-    expect(result.stepsRun).toBe(2);
-    expect(calls.length).toBe(0); // dispatcher never called
-  });
-
-  test("step outputs accessible via $stepName", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "create", command: "create-thing" },
-        { name: "use", command: "use-thing", args: { id: "$create.id" } },
-      ],
-    });
-    const callIndex = { i: 0 };
-    const dispatcher: CommandDispatcher = async (command) => {
-      callIndex.i++;
-      if (command === "create-thing") return { id: 42 };
-      return { ok: true };
-    };
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(result.stepsRun).toBe(2);
-  });
-
-  test("step outputs accessible via output alias", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "create", command: "create-thing", output: "created" },
-        { name: "use", command: "use-thing", args: { id: "$created.id" } },
-      ],
-    });
-    const dispatched: Record<string, unknown>[] = [];
-    const dispatcher: CommandDispatcher = async (command, args) => {
-      dispatched.push(args);
-      if (command === "create-thing") return { id: 99 };
-      return { ok: true };
-    };
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(dispatched[1]!.id).toBe(99);
-  });
-
-  test("variable overrides merge with defaults", async () => {
-    const routine = makeRoutine({
-      variables: { greeting: "hello", target: "world" },
-      steps: [
-        { name: "greet", command: "say", args: { msg: "$greeting $target" } },
-      ],
-    });
-    const dispatched: Record<string, unknown>[] = [];
-    const dispatcher: CommandDispatcher = async (_cmd, args) => {
-      dispatched.push(args);
-      return {};
-    };
-    const result = await executeRoutine(routine, { target: "universe" }, dispatcher);
-
-    expect(result.success).toBe(true);
-    expect(dispatched[0]!.msg).toBe("hello universe");
-  });
-
-  test("built-in $_timestamp and $_date available", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "check", command: "cmd", args: { ts: "$_timestamp", dt: "$_date" } },
-      ],
-    });
-    const dispatched: Record<string, unknown>[] = [];
-    const dispatcher: CommandDispatcher = async (_cmd, args) => {
-      dispatched.push(args);
-      return {};
-    };
-    const result = await executeRoutine(routine, {}, dispatcher);
-
-    expect(result.success).toBe(true);
-    const ts = dispatched[0]!.ts as number;
-    const dt = dispatched[0]!.dt as string;
-    // Timestamp should be a reasonable Unix epoch (seconds)
-    expect(typeof ts).toBe("number");
-    expect(ts).toBeGreaterThan(1700000000);
-    // Date should be ISO format YYYY-MM-DD
-    expect(dt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-  });
-
-  test("onStep callback is called for each step", async () => {
-    const routine = makeRoutine({
-      steps: [
-        { name: "a", command: "cmd-a" },
-        { name: "b", command: "cmd-b" },
-      ],
-    });
-    const { dispatcher } = makeMockDispatcher();
-    const stepCalls: { name: string; index: number; total: number }[] = [];
-    const result = await executeRoutine(routine, {}, dispatcher, {
-      onStep: (step, index, total) => {
-        stepCalls.push({ name: step.name, index, total });
-      },
+        expect(result.success).toBe(true);
+        expect(result.stepsRun).toBe(2);
+        expect(result.stepsSkipped).toBe(0);
+        expect(result.stepsFailed).toBe(0);
+        expect(calls.length).toBe(2);
+        expect(calls[0]!.command).toBe('cmd-a');
+        expect(calls[1]!.command).toBe('cmd-b');
     });
 
-    expect(result.success).toBe(true);
-    expect(stepCalls.length).toBe(2);
-    expect(stepCalls[0]).toEqual({ name: "a", index: 0, total: 2 });
-    expect(stepCalls[1]).toEqual({ name: "b", index: 1, total: 2 });
-  });
+    test('skips steps where condition is false', async () => {
+        const routine = makeRoutine({
+            variables: { enabled: false },
+            steps: [
+                { name: 'skipped', command: 'cmd-a', condition: '$enabled' },
+                { name: 'run', command: 'cmd-b' },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
 
-  test("error without continueOnError stops execution", async () => {
-    const failDispatcher: CommandDispatcher = async (command) => {
-      if (command === "fail-cmd") throw new Error("boom");
-      return { ok: true };
-    };
-
-    const routine = makeRoutine({
-      steps: [
-        { name: "will-fail", command: "fail-cmd" },
-        { name: "wont-run", command: "ok-cmd" },
-      ],
+        expect(result.success).toBe(true);
+        expect(result.stepsRun).toBe(1);
+        expect(result.stepsSkipped).toBe(1);
+        expect(calls.length).toBe(1);
+        expect(calls[0]!.command).toBe('cmd-b');
     });
-    const result = await executeRoutine(routine, {}, failDispatcher);
 
-    expect(result.success).toBe(false);
-    expect(result.stepsRun).toBe(1);
-    expect(result.stepsFailed).toBe(1);
-  });
+    test('forEach iterates over array', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b', 'c'] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { value: '$item' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
 
-  test("forEach with reverse iterates in reverse order", async () => {
-    const routine = makeRoutine({
-      variables: { items: ["a", "b", "c", "d"] },
-      steps: [
-        {
-          name: "loop",
-          forEach: "$items",
-          reverse: true,
-          as: "item",
-          steps: [
-            { name: "inner", command: "process", args: { value: "$item" } },
-          ],
-        },
-      ],
+        expect(result.success).toBe(true);
+        expect(calls.length).toBe(3);
+        expect(calls[0]!.args.value).toBe('a');
+        expect(calls[1]!.args.value).toBe('b');
+        expect(calls[2]!.args.value).toBe('c');
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(4);
-    expect(calls[0]!.args.value).toBe("d");
-    expect(calls[1]!.args.value).toBe("c");
-    expect(calls[2]!.args.value).toBe("b");
-    expect(calls[3]!.args.value).toBe("a");
-  });
+    test('assertions pass correctly', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'check',
+                    command: 'cmd-a',
+                    assert: '$check.success == true',
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher({ 'cmd-a': { status: 'ok' } });
+        const result = await executeRoutine(routine, {}, dispatcher);
 
-  test("forEach with shuffle produces all items (just reordered)", async () => {
-    const items = Array.from({ length: 20 }, (_, i) => i);
-    const routine = makeRoutine({
-      variables: { items },
-      steps: [
-        {
-          name: "loop",
-          forEach: "$items",
-          shuffle: true,
-          as: "item",
-          steps: [
-            { name: "inner", command: "process", args: { value: "$item" } },
-          ],
-        },
-      ],
+        expect(result.success).toBe(true);
+        expect(result.stepsFailed).toBe(0);
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(20);
-    const values = calls.map(c => c.args.value as number).sort((a, b) => a - b);
-    expect(values).toEqual(items);
-  });
+    test('assertions fail correctly', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'check',
+                    command: 'cmd-a',
+                    assert: '$check.success == false',
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher({ 'cmd-a': { status: 'ok' } });
+        const result = await executeRoutine(routine, {}, dispatcher);
 
-  test("range with reverse iterates high to low", async () => {
-    const routine = makeRoutine({
-      steps: [
-        {
-          name: "loop",
-          range: [1, 5] as [number, number],
-          reverse: true,
-          as: "n",
-          steps: [
-            { name: "inner", command: "process", args: { num: "$n" } },
-          ],
-        },
-      ],
+        expect(result.success).toBe(false);
+        expect(result.stepsFailed).toBe(1);
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(5);
-    expect(calls[0]!.args.num).toBe(5);
-    expect(calls[1]!.args.num).toBe(4);
-    expect(calls[2]!.args.num).toBe(3);
-    expect(calls[3]!.args.num).toBe(2);
-    expect(calls[4]!.args.num).toBe(1);
-  });
+    test('continueOnError allows continued execution', async () => {
+        const failDispatcher: CommandDispatcher = async (command) => {
+            if (command === 'fail-cmd') throw new Error('boom');
 
-  test("range with shuffle produces all numbers (just reordered)", async () => {
-    const routine = makeRoutine({
-      steps: [
-        {
-          name: "loop",
-          range: [1, 10] as [number, number],
-          shuffle: true,
-          as: "n",
-          steps: [
-            { name: "inner", command: "process", args: { num: "$n" } },
-          ],
-        },
-      ],
+            return { ok: true };
+        };
+
+        const routine = makeRoutine({
+            steps: [
+                { name: 'will-fail', command: 'fail-cmd', continueOnError: true },
+                { name: 'will-run', command: 'ok-cmd' },
+            ],
+        });
+        const result = await executeRoutine(routine, {}, failDispatcher);
+
+        expect(result.success).toBe(false); // stepsFailed > 0
+        expect(result.stepsRun).toBe(2);
+        expect(result.stepsFailed).toBe(1);
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(10);
-    const nums = calls.map(c => c.args.num as number).sort((a, b) => a - b);
-    expect(nums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-  });
+    test('dry run prints without executing', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'step-1', command: 'cmd-a', args: { key: 'val' } },
+                { name: 'step-2', command: 'cmd-b' },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher, { dryRun: true });
 
-  test("$_random_hex_color produces valid colors in routine steps", async () => {
-    const routine = makeRoutine({
-      steps: [
-        {
-          name: "loop",
-          range: [1, 5] as [number, number],
-          steps: [
-            { name: "inner", command: "colorize", args: { color: "$_random_hex_color" } },
-          ],
-        },
-      ],
+        expect(result.stepsRun).toBe(2);
+        expect(calls.length).toBe(0); // dispatcher never called
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(5);
-    for (const call of calls) {
-      const color = call.args.color as string;
-      expect(color).toMatch(/^#[0-9a-f]{6}$/);
-    }
-  });
+    test('step outputs accessible via $stepName', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'create', command: 'create-thing' },
+                { name: 'use', command: 'use-thing', args: { id: '$create.id' } },
+            ],
+        });
+        const callIndex = { i: 0 };
+        const dispatcher: CommandDispatcher = async (command) => {
+            callIndex.i++;
 
-  test("$_random_distinct_from produces no repeats within a forEach", async () => {
-    const routine = makeRoutine({
-      variables: { items: [1, 2, 3] },
-      steps: [
-        {
-          name: "loop",
-          forEach: "$items",
-          as: "item",
-          steps: [
-            {
-              name: "inner",
-              command: "assign",
-              args: { value: "$_random_distinct_from(x,y,z)" },
+            if (command === 'create-thing') return { id: 42 };
+
+            return { ok: true };
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.success).toBe(true);
+        expect(result.stepsRun).toBe(2);
+    });
+
+    test('step outputs accessible via output alias', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'create', command: 'create-thing', output: 'created' },
+                { name: 'use', command: 'use-thing', args: { id: '$created.id' } },
+            ],
+        });
+        const dispatched: Record<string, unknown>[] = [];
+        const dispatcher: CommandDispatcher = async (command, args) => {
+            dispatched.push(args);
+
+            if (command === 'create-thing') return { id: 99 };
+
+            return { ok: true };
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.success).toBe(true);
+        expect(dispatched[1]!.id).toBe(99);
+    });
+
+    test('variable overrides merge with defaults', async () => {
+        const routine = makeRoutine({
+            variables: { greeting: 'hello', target: 'world' },
+            steps: [
+                { name: 'greet', command: 'say', args: { msg: '$greeting $target' } },
+            ],
+        });
+        const dispatched: Record<string, unknown>[] = [];
+        const dispatcher: CommandDispatcher = async (_cmd, args) => {
+            dispatched.push(args);
+
+            return {};
+        };
+        const result = await executeRoutine(routine, { target: 'universe' }, dispatcher);
+
+        expect(result.success).toBe(true);
+        expect(dispatched[0]!.msg).toBe('hello universe');
+    });
+
+    test('built-in $_timestamp and $_date available', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'check', command: 'cmd', args: { ts: '$_timestamp', dt: '$_date' } },
+            ],
+        });
+        const dispatched: Record<string, unknown>[] = [];
+        const dispatcher: CommandDispatcher = async (_cmd, args) => {
+            dispatched.push(args);
+
+            return {};
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.success).toBe(true);
+        const ts = dispatched[0]!.ts as number;
+        const dt = dispatched[0]!.dt as string;
+        // Timestamp should be a reasonable Unix epoch (seconds)
+        expect(typeof ts).toBe('number');
+        expect(ts).toBeGreaterThan(1700000000);
+        // Date should be ISO format YYYY-MM-DD
+        expect(dt).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    test('onStep callback is called for each step', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'a', command: 'cmd-a' },
+                { name: 'b', command: 'cmd-b' },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const stepCalls: { name: string; index: number; total: number }[] = [];
+        const result = await executeRoutine(routine, {}, dispatcher, {
+            onStep: (step, index, total) => {
+                stepCalls.push({ name: step.name, index, total });
             },
-          ],
-        },
-      ],
+        });
+
+        expect(result.success).toBe(true);
+        expect(stepCalls.length).toBe(2);
+        expect(stepCalls[0]).toEqual({ name: 'a', index: 0, total: 2 });
+        expect(stepCalls[1]).toEqual({ name: 'b', index: 1, total: 2 });
     });
-    const { dispatcher, calls } = makeMockDispatcher();
-    await executeRoutine(routine, {}, dispatcher);
 
-    expect(calls.length).toBe(3);
-    const values = calls.map(c => c.args.value as string).sort();
-    expect(values).toEqual(["x", "y", "z"]);
-  });
+    test('error without continueOnError stops execution', async () => {
+        const failDispatcher: CommandDispatcher = async (command) => {
+            if (command === 'fail-cmd') throw new Error('boom');
 
-  test("$_timestamp resolved in default variables", async () => {
-    const routine = makeRoutine({
-      variables: { label: "run-$_timestamp" },
-      steps: [
-        { name: "check", command: "cmd", args: { label: "$label" } },
-      ],
+            return { ok: true };
+        };
+
+        const routine = makeRoutine({
+            steps: [
+                { name: 'will-fail', command: 'fail-cmd' },
+                { name: 'wont-run', command: 'ok-cmd' },
+            ],
+        });
+        const result = await executeRoutine(routine, {}, failDispatcher);
+
+        expect(result.success).toBe(false);
+        expect(result.stepsRun).toBe(1);
+        expect(result.stepsFailed).toBe(1);
     });
-    const dispatched: Record<string, unknown>[] = [];
-    const dispatcher: CommandDispatcher = async (_cmd, args) => {
-      dispatched.push(args);
-      return {};
-    };
-    await executeRoutine(routine, {}, dispatcher);
 
-    const label = dispatched[0]!.label as string;
-    expect(label).toMatch(/^run-\d+$/);
-  });
+    test('forEach with reverse iterates in reverse order', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b', 'c', 'd'] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    reverse: true,
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { value: '$item' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(4);
+        expect(calls[0]!.args.value).toBe('d');
+        expect(calls[1]!.args.value).toBe('c');
+        expect(calls[2]!.args.value).toBe('b');
+        expect(calls[3]!.args.value).toBe('a');
+    });
+
+    test('forEach with shuffle produces all items (just reordered)', async () => {
+        const items = Array.from({ length: 20 }, (_, i) => i);
+        const routine = makeRoutine({
+            variables: { items },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    shuffle: true,
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { value: '$item' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(20);
+        const values = calls.map(c => c.args.value as number).sort((a, b) => a - b);
+        expect(values).toEqual(items);
+    });
+
+    test('range with reverse iterates high to low', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'loop',
+                    range: [1, 5] as [number, number],
+                    reverse: true,
+                    as: 'n',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { num: '$n' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(5);
+        expect(calls[0]!.args.num).toBe(5);
+        expect(calls[1]!.args.num).toBe(4);
+        expect(calls[2]!.args.num).toBe(3);
+        expect(calls[3]!.args.num).toBe(2);
+        expect(calls[4]!.args.num).toBe(1);
+    });
+
+    test('range with shuffle produces all numbers (just reordered)', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'loop',
+                    range: [1, 10] as [number, number],
+                    shuffle: true,
+                    as: 'n',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { num: '$n' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(10);
+        const nums = calls.map(c => c.args.num as number).sort((a, b) => a - b);
+        expect(nums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    test('$_random_hex_color produces valid colors in routine steps', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'loop',
+                    range: [1, 5] as [number, number],
+                    steps: [
+                        { name: 'inner', command: 'colorize', args: { color: '$_random_hex_color' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(5);
+
+        for (const call of calls) {
+            const color = call.args.color as string;
+            expect(color).toMatch(/^#[0-9a-f]{6}$/);
+        }
+    });
+
+    test('$_random_distinct_from produces no repeats within a forEach', async () => {
+        const routine = makeRoutine({
+            variables: { items: [1, 2, 3] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    steps: [
+                        {
+                            name: 'inner',
+                            command: 'assign',
+                            args: { value: '$_random_distinct_from(x,y,z)' },
+                        },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher);
+
+        expect(calls.length).toBe(3);
+        const values = calls.map(c => c.args.value as string).sort();
+        expect(values).toEqual(['x', 'y', 'z']);
+    });
+
+    test('$_timestamp resolved in default variables', async () => {
+        const routine = makeRoutine({
+            variables: { label: 'run-$_timestamp' },
+            steps: [
+                { name: 'check', command: 'cmd', args: { label: '$label' } },
+            ],
+        });
+        const dispatched: Record<string, unknown>[] = [];
+        const dispatcher: CommandDispatcher = async (_cmd, args) => {
+            dispatched.push(args);
+
+            return {};
+        };
+        await executeRoutine(routine, {}, dispatcher);
+
+        const label = dispatched[0]!.label as string;
+        expect(label).toMatch(/^run-\d+$/);
+    });
 });

--- a/tests/routine/loader.test.ts
+++ b/tests/routine/loader.test.ts
@@ -1,32 +1,32 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
-  parseRoutine,
-  validateRoutine,
-  loadRoutineFile,
-  listRoutines,
-  formatRoutineTree,
-  formatRoutineList,
-  loadSpecFile,
-} from "../../src/routine/loader";
+    parseRoutine,
+    validateRoutine,
+    loadRoutineFile,
+    listRoutines,
+    formatRoutineTree,
+    formatRoutineList,
+    loadSpecFile,
+} from '../../src/routine/loader';
 
 const TEST_DIR = join(tmpdir(), `loader-test-${Date.now()}`);
 
 function makeTestDir() {
-  mkdirSync(TEST_DIR, { recursive: true });
+    mkdirSync(TEST_DIR, { recursive: true });
 }
 
 function cleanTestDir() {
-  try {
-    rmSync(TEST_DIR, { recursive: true, force: true });
-  } catch {}
+    try {
+        rmSync(TEST_DIR, { recursive: true, force: true });
+    } catch {}
 }
 
-describe("parseRoutine", () => {
-  test("parses valid YAML", () => {
-    const yaml = `
+describe('parseRoutine', () => {
+    test('parses valid YAML', () => {
+        const yaml = `
 name: test-routine
 description: A test routine
 variables:
@@ -37,58 +37,58 @@ steps:
     args:
       key: value
 `;
-    const routine = parseRoutine(yaml);
-    expect(routine.name).toBe("test-routine");
-    expect(routine.description).toBe("A test routine");
-    expect(routine.variables).toEqual({ foo: "bar" });
-    expect(routine.steps.length).toBe(1);
-    expect(routine.steps[0]!.name).toBe("step-1");
-    expect(routine.steps[0]!.command).toBe("do-something");
-  });
+        const routine = parseRoutine(yaml);
+        expect(routine.name).toBe('test-routine');
+        expect(routine.description).toBe('A test routine');
+        expect(routine.variables).toEqual({ foo: 'bar' });
+        expect(routine.steps.length).toBe(1);
+        expect(routine.steps[0]!.name).toBe('step-1');
+        expect(routine.steps[0]!.command).toBe('do-something');
+    });
 
-  test("throws on missing name", () => {
-    const yaml = `
+    test('throws on missing name', () => {
+        const yaml = `
 steps:
   - name: step-1
     command: do-something
 `;
-    expect(() => parseRoutine(yaml)).toThrow("Routine must have a 'name' field");
-  });
+        expect(() => parseRoutine(yaml)).toThrow("Routine must have a 'name' field");
+    });
 
-  test("throws on missing steps", () => {
-    const yaml = `
+    test('throws on missing steps', () => {
+        const yaml = `
 name: test-routine
 `;
-    expect(() => parseRoutine(yaml)).toThrow("Routine must have 'steps' array");
-  });
+        expect(() => parseRoutine(yaml)).toThrow("Routine must have 'steps' array");
+    });
 
-  test("throws on empty steps", () => {
-    const yaml = `
+    test('throws on empty steps', () => {
+        const yaml = `
 name: test-routine
 steps: []
 `;
-    expect(() => parseRoutine(yaml)).toThrow("Routine must have 'steps' array");
-  });
+        expect(() => parseRoutine(yaml)).toThrow("Routine must have 'steps' array");
+    });
 
-  test("throws on invalid YAML", () => {
-    expect(() => parseRoutine("")).toThrow("Invalid YAML");
-  });
+    test('throws on invalid YAML', () => {
+        expect(() => parseRoutine('')).toThrow('Invalid YAML');
+    });
 });
 
-describe("validateRoutine", () => {
-  test("returns empty array for valid routine", () => {
-    const routine = parseRoutine(`
+describe('validateRoutine', () => {
+    test('returns empty array for valid routine', () => {
+        const routine = parseRoutine(`
 name: valid
 steps:
   - name: step-1
     command: do-something
 `);
-    const errors = validateRoutine(routine);
-    expect(errors).toEqual([]);
-  });
+        const errors = validateRoutine(routine);
+        expect(errors).toEqual([]);
+    });
 
-  test("catches duplicate step names", () => {
-    const routine = parseRoutine(`
+    test('catches duplicate step names', () => {
+        const routine = parseRoutine(`
 name: dupes
 steps:
   - name: step-1
@@ -96,14 +96,14 @@ steps:
   - name: step-1
     command: do-b
 `);
-    const errors = validateRoutine(routine);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("Duplicate step name");
-    expect(errors[0]).toContain("step-1");
-  });
+        const errors = validateRoutine(routine);
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain('Duplicate step name');
+        expect(errors[0]).toContain('step-1');
+    });
 
-  test("catches output alias collisions", () => {
-    const routine = parseRoutine(`
+    test('catches output alias collisions', () => {
+        const routine = parseRoutine(`
 name: collision
 steps:
   - name: step-1
@@ -113,14 +113,14 @@ steps:
     command: do-b
     output: result
 `);
-    const errors = validateRoutine(routine);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("Output alias collision");
-    expect(errors[0]).toContain("result");
-  });
+        const errors = validateRoutine(routine);
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain('Output alias collision');
+        expect(errors[0]).toContain('result');
+    });
 
-  test("catches output alias collision with step name", () => {
-    const routine = parseRoutine(`
+    test('catches output alias collision with step name', () => {
+        const routine = parseRoutine(`
 name: collision
 steps:
   - name: step-1
@@ -129,26 +129,26 @@ steps:
     command: do-b
     output: step-1
 `);
-    const errors = validateRoutine(routine);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("Output alias collision");
-  });
+        const errors = validateRoutine(routine);
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain('Output alias collision');
+    });
 
-  test("catches steps without command or forEach", () => {
-    const routine = parseRoutine(`
+    test('catches steps without command or forEach', () => {
+        const routine = parseRoutine(`
 name: no-cmd
 steps:
   - name: step-1
     args:
       key: value
 `);
-    const errors = validateRoutine(routine);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("must have 'command', 'forEach', or 'range'");
-  });
+        const errors = validateRoutine(routine);
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain("must have 'command', 'forEach', or 'range'");
+    });
 
-  test("validates nested forEach steps", () => {
-    const routine = parseRoutine(`
+    test('validates nested forEach steps', () => {
+        const routine = parseRoutine(`
 name: nested
 steps:
   - name: loop
@@ -159,226 +159,226 @@ steps:
       - name: inner-a
         command: do-b
 `);
-    const errors = validateRoutine(routine);
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("Duplicate step name");
-  });
+        const errors = validateRoutine(routine);
+        expect(errors.length).toBe(1);
+        expect(errors[0]).toContain('Duplicate step name');
+    });
 });
 
-describe("loadRoutineFile", () => {
-  beforeEach(makeTestDir);
-  afterEach(cleanTestDir);
+describe('loadRoutineFile', () => {
+    beforeEach(makeTestDir);
+    afterEach(cleanTestDir);
 
-  test("loads from folder-based path", () => {
-    const routineDir = join(TEST_DIR, "my-routine");
-    mkdirSync(routineDir, { recursive: true });
-    writeFileSync(
-      join(routineDir, "routine.yaml"),
-      `name: my-routine\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
+    test('loads from folder-based path', () => {
+        const routineDir = join(TEST_DIR, 'my-routine');
+        mkdirSync(routineDir, { recursive: true });
+        writeFileSync(
+            join(routineDir, 'routine.yaml'),
+            'name: my-routine\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
 
-    const routine = loadRoutineFile("my-routine", TEST_DIR);
-    expect(routine.name).toBe("my-routine");
-    expect(routine.steps.length).toBe(1);
-  });
+        const routine = loadRoutineFile('my-routine', TEST_DIR);
+        expect(routine.name).toBe('my-routine');
+        expect(routine.steps.length).toBe(1);
+    });
 
-  test("loads from flat file", () => {
-    writeFileSync(
-      join(TEST_DIR, "flat-routine.yaml"),
-      `name: flat-routine\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
+    test('loads from flat file', () => {
+        writeFileSync(
+            join(TEST_DIR, 'flat-routine.yaml'),
+            'name: flat-routine\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
 
-    const routine = loadRoutineFile("flat-routine", TEST_DIR);
-    expect(routine.name).toBe("flat-routine");
-  });
+        const routine = loadRoutineFile('flat-routine', TEST_DIR);
+        expect(routine.name).toBe('flat-routine');
+    });
 
-  test("loads from .yml extension", () => {
-    writeFileSync(
-      join(TEST_DIR, "yml-routine.yml"),
-      `name: yml-routine\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
+    test('loads from .yml extension', () => {
+        writeFileSync(
+            join(TEST_DIR, 'yml-routine.yml'),
+            'name: yml-routine\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
 
-    const routine = loadRoutineFile("yml-routine", TEST_DIR);
-    expect(routine.name).toBe("yml-routine");
-  });
+        const routine = loadRoutineFile('yml-routine', TEST_DIR);
+        expect(routine.name).toBe('yml-routine');
+    });
 
-  test("loads from absolute path with extension", () => {
-    const filePath = join(TEST_DIR, "direct.yaml");
-    writeFileSync(
-      filePath,
-      `name: direct\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
+    test('loads from absolute path with extension', () => {
+        const filePath = join(TEST_DIR, 'direct.yaml');
+        writeFileSync(
+            filePath,
+            'name: direct\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
 
-    const routine = loadRoutineFile(filePath, TEST_DIR);
-    expect(routine.name).toBe("direct");
-  });
+        const routine = loadRoutineFile(filePath, TEST_DIR);
+        expect(routine.name).toBe('direct');
+    });
 
-  test("throws for non-existent routine", () => {
-    expect(() => loadRoutineFile("nonexistent", TEST_DIR)).toThrow("Routine not found");
-  });
+    test('throws for non-existent routine', () => {
+        expect(() => loadRoutineFile('nonexistent', TEST_DIR)).toThrow('Routine not found');
+    });
 
-  test("loads from builtinsMap when provided", () => {
-    const builtinsMap: Record<string, string> = {
-      "builtin-test/routine.yaml": `name: builtin-test\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    };
-    const routine = loadRoutineFile("builtin-test", TEST_DIR, builtinsMap);
-    expect(routine.name).toBe("builtin-test");
-  });
+    test('loads from builtinsMap when provided', () => {
+        const builtinsMap: Record<string, string> = {
+            'builtin-test/routine.yaml': 'name: builtin-test\nsteps:\n  - name: s1\n    command: cmd1\n',
+        };
+        const routine = loadRoutineFile('builtin-test', TEST_DIR, builtinsMap);
+        expect(routine.name).toBe('builtin-test');
+    });
 
-  test("disk routines take precedence over builtinsMap", () => {
-    const routineDir = join(TEST_DIR, "my-routine");
-    mkdirSync(routineDir, { recursive: true });
-    writeFileSync(
-      join(routineDir, "routine.yaml"),
-      `name: disk-version\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
-    const builtinsMap: Record<string, string> = {
-      "my-routine/routine.yaml": `name: builtin-version\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    };
-    const routine = loadRoutineFile("my-routine", TEST_DIR, builtinsMap);
-    expect(routine.name).toBe("disk-version");
-  });
+    test('disk routines take precedence over builtinsMap', () => {
+        const routineDir = join(TEST_DIR, 'my-routine');
+        mkdirSync(routineDir, { recursive: true });
+        writeFileSync(
+            join(routineDir, 'routine.yaml'),
+            'name: disk-version\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
+        const builtinsMap: Record<string, string> = {
+            'my-routine/routine.yaml': 'name: builtin-version\nsteps:\n  - name: s1\n    command: cmd1\n',
+        };
+        const routine = loadRoutineFile('my-routine', TEST_DIR, builtinsMap);
+        expect(routine.name).toBe('disk-version');
+    });
 });
 
-describe("loadSpecFile", () => {
-  beforeEach(makeTestDir);
-  afterEach(cleanTestDir);
+describe('loadSpecFile', () => {
+    beforeEach(makeTestDir);
+    afterEach(cleanTestDir);
 
-  test("loads spec file from disk", () => {
-    const routineDir = join(TEST_DIR, "my-routine");
-    mkdirSync(routineDir, { recursive: true });
-    writeFileSync(
-      join(routineDir, "spec.yaml"),
-      `name: my-spec\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    );
-    const spec = loadSpecFile("my-routine", TEST_DIR);
-    expect(spec).not.toBeNull();
-    expect(spec!.name).toBe("my-spec");
-  });
+    test('loads spec file from disk', () => {
+        const routineDir = join(TEST_DIR, 'my-routine');
+        mkdirSync(routineDir, { recursive: true });
+        writeFileSync(
+            join(routineDir, 'spec.yaml'),
+            'name: my-spec\nsteps:\n  - name: s1\n    command: cmd1\n',
+        );
+        const spec = loadSpecFile('my-routine', TEST_DIR);
+        expect(spec).not.toBeNull();
+        expect(spec!.name).toBe('my-spec');
+    });
 
-  test("returns null for non-existent spec", () => {
-    const spec = loadSpecFile("nonexistent", TEST_DIR);
-    expect(spec).toBeNull();
-  });
+    test('returns null for non-existent spec', () => {
+        const spec = loadSpecFile('nonexistent', TEST_DIR);
+        expect(spec).toBeNull();
+    });
 
-  test("loads spec from builtinsMap", () => {
-    const builtinsMap: Record<string, string> = {
-      "builtin-test/spec.yaml": `name: builtin-spec\nsteps:\n  - name: s1\n    command: cmd1\n`,
-    };
-    const spec = loadSpecFile("builtin-test", TEST_DIR, builtinsMap);
-    expect(spec).not.toBeNull();
-    expect(spec!.name).toBe("builtin-spec");
-  });
+    test('loads spec from builtinsMap', () => {
+        const builtinsMap: Record<string, string> = {
+            'builtin-test/spec.yaml': 'name: builtin-spec\nsteps:\n  - name: s1\n    command: cmd1\n',
+        };
+        const spec = loadSpecFile('builtin-test', TEST_DIR, builtinsMap);
+        expect(spec).not.toBeNull();
+        expect(spec!.name).toBe('builtin-spec');
+    });
 });
 
-describe("listRoutines", () => {
-  beforeEach(makeTestDir);
-  afterEach(cleanTestDir);
+describe('listRoutines', () => {
+    beforeEach(makeTestDir);
+    afterEach(cleanTestDir);
 
-  test("discovers routines", () => {
+    test('discovers routines', () => {
     // Folder-based
-    const folderRoutine = join(TEST_DIR, "folder-routine");
-    mkdirSync(folderRoutine, { recursive: true });
-    writeFileSync(join(folderRoutine, "routine.yaml"), "name: folder\nsteps:\n  - name: s\n    command: c\n");
+        const folderRoutine = join(TEST_DIR, 'folder-routine');
+        mkdirSync(folderRoutine, { recursive: true });
+        writeFileSync(join(folderRoutine, 'routine.yaml'), 'name: folder\nsteps:\n  - name: s\n    command: c\n');
 
-    // Flat file
-    writeFileSync(join(TEST_DIR, "flat.yaml"), "name: flat\nsteps:\n  - name: s\n    command: c\n");
+        // Flat file
+        writeFileSync(join(TEST_DIR, 'flat.yaml'), 'name: flat\nsteps:\n  - name: s\n    command: c\n');
 
-    const routines = listRoutines(TEST_DIR);
-    expect(routines.length).toBe(2);
-    // Should find both folder-based and flat routines
-    const cleaned = routines.map((r) => r.replace(/\x1b\[[0-9;]*m/g, "").trim());
-    expect(cleaned).toContain("folder-routine");
-    expect(cleaned).toContain("flat");
-  });
+        const routines = listRoutines(TEST_DIR);
+        expect(routines.length).toBe(2);
+        // Should find both folder-based and flat routines
+        const cleaned = routines.map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim());
+        expect(cleaned).toContain('folder-routine');
+        expect(cleaned).toContain('flat');
+    });
 
-  test("discovers nested routines", () => {
-    const nested = join(TEST_DIR, "group", "sub-routine");
-    mkdirSync(nested, { recursive: true });
-    writeFileSync(join(nested, "routine.yaml"), "name: sub\nsteps:\n  - name: s\n    command: c\n");
+    test('discovers nested routines', () => {
+        const nested = join(TEST_DIR, 'group', 'sub-routine');
+        mkdirSync(nested, { recursive: true });
+        writeFileSync(join(nested, 'routine.yaml'), 'name: sub\nsteps:\n  - name: s\n    command: c\n');
 
-    const routines = listRoutines(TEST_DIR);
-    const cleaned = routines.map((r) => r.replace(/\x1b\[[0-9;]*m/g, "").trim());
-    expect(cleaned).toContain("group/sub-routine");
-  });
+        const routines = listRoutines(TEST_DIR);
+        const cleaned = routines.map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim());
+        expect(cleaned).toContain('group/sub-routine');
+    });
 
-  test("returns empty array for non-existent directory", () => {
-    const routines = listRoutines(join(TEST_DIR, "nonexistent"));
-    expect(routines).toEqual([]);
-  });
+    test('returns empty array for non-existent directory', () => {
+        const routines = listRoutines(join(TEST_DIR, 'nonexistent'));
+        expect(routines).toEqual([]);
+    });
 
-  test("merges disk and builtin routines", () => {
-    writeFileSync(join(TEST_DIR, "disk.yaml"), "name: disk\nsteps:\n  - name: s\n    command: c\n");
-    const builtinsMap: Record<string, string> = {
-      "builtin.yaml": `name: builtin\nsteps:\n  - name: s\n    command: c\n`,
-    };
-    const routines = listRoutines(TEST_DIR, builtinsMap);
-    const cleaned = routines.map((r) => r.replace(/\x1b\[[0-9;]*m/g, "").trim());
-    expect(cleaned).toContain("disk");
-    expect(cleaned).toContain("builtin");
-  });
+    test('merges disk and builtin routines', () => {
+        writeFileSync(join(TEST_DIR, 'disk.yaml'), 'name: disk\nsteps:\n  - name: s\n    command: c\n');
+        const builtinsMap: Record<string, string> = {
+            'builtin.yaml': 'name: builtin\nsteps:\n  - name: s\n    command: c\n',
+        };
+        const routines = listRoutines(TEST_DIR, builtinsMap);
+        const cleaned = routines.map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim());
+        expect(cleaned).toContain('disk');
+        expect(cleaned).toContain('builtin');
+    });
 
-  test("disk routines take precedence over builtins with same name", () => {
-    writeFileSync(join(TEST_DIR, "shared.yaml"), "name: shared\nsteps:\n  - name: s\n    command: c\n");
-    const builtinsMap: Record<string, string> = {
-      "shared.yaml": `name: shared-builtin\nsteps:\n  - name: s\n    command: c\n`,
-    };
-    const routines = listRoutines(TEST_DIR, builtinsMap);
-    const cleaned = routines.map((r) => r.replace(/\x1b\[[0-9;]*m/g, "").trim());
-    // Should only appear once
-    const count = cleaned.filter((r) => r === "shared").length;
-    expect(count).toBe(1);
-  });
+    test('disk routines take precedence over builtins with same name', () => {
+        writeFileSync(join(TEST_DIR, 'shared.yaml'), 'name: shared\nsteps:\n  - name: s\n    command: c\n');
+        const builtinsMap: Record<string, string> = {
+            'shared.yaml': 'name: shared-builtin\nsteps:\n  - name: s\n    command: c\n',
+        };
+        const routines = listRoutines(TEST_DIR, builtinsMap);
+        const cleaned = routines.map(r => r.replace(/\x1b\[[0-9;]*m/g, '').trim());
+        // Should only appear once
+        const count = cleaned.filter(r => r === 'shared').length;
+        expect(count).toBe(1);
+    });
 });
 
-describe("formatRoutineTree", () => {
-  test("renders tree structure", () => {
-    const routines = [
-      "e2e/matter/create",
-      "e2e/matter/delete",
-      "e2e/load/upload",
-      "smoke-test",
-    ];
-    const tree = formatRoutineTree(routines);
+describe('formatRoutineTree', () => {
+    test('renders tree structure', () => {
+        const routines = [
+            'e2e/matter/create',
+            'e2e/matter/delete',
+            'e2e/load/upload',
+            'smoke-test',
+        ];
+        const tree = formatRoutineTree(routines);
 
-    // Should have tree connectors
-    expect(tree).toContain("├──");
-    expect(tree).toContain("└──");
-    // Should contain routine names
-    expect(tree).toContain("smoke-test");
-    expect(tree).toContain("e2e");
-    expect(tree).toContain("create");
-    expect(tree).toContain("delete");
-    expect(tree).toContain("upload");
-  });
+        // Should have tree connectors
+        expect(tree).toContain('├──');
+        expect(tree).toContain('└──');
+        // Should contain routine names
+        expect(tree).toContain('smoke-test');
+        expect(tree).toContain('e2e');
+        expect(tree).toContain('create');
+        expect(tree).toContain('delete');
+        expect(tree).toContain('upload');
+    });
 
-  test("renders single routine", () => {
-    const tree = formatRoutineTree(["my-routine"]);
-    expect(tree).toContain("my-routine");
-    expect(tree).toContain("└──");
-  });
+    test('renders single routine', () => {
+        const tree = formatRoutineTree(['my-routine']);
+        expect(tree).toContain('my-routine');
+        expect(tree).toContain('└──');
+    });
 
-  test("renders empty list", () => {
-    const tree = formatRoutineTree([]);
-    expect(tree).toBe("");
-  });
+    test('renders empty list', () => {
+        const tree = formatRoutineTree([]);
+        expect(tree).toBe('');
+    });
 
-  test("directories shown with trailing slash", () => {
-    const routines = ["group/routine-a", "group/routine-b"];
-    const tree = formatRoutineTree(routines);
-    expect(tree).toContain("group/");
-  });
+    test('directories shown with trailing slash', () => {
+        const routines = ['group/routine-a', 'group/routine-b'];
+        const tree = formatRoutineTree(routines);
+        expect(tree).toContain('group/');
+    });
 });
 
-describe("formatRoutineList", () => {
-  test("groups directories and top-level routines", () => {
-    const routines = [
-      "e2e/matter/create",
-      "e2e/load/upload",
-      "smoke-test",
-    ];
-    const list = formatRoutineList(routines);
-    expect(list).toContain("e2e/");
-    expect(list).toContain("smoke-test");
-  });
+describe('formatRoutineList', () => {
+    test('groups directories and top-level routines', () => {
+        const routines = [
+            'e2e/matter/create',
+            'e2e/load/upload',
+            'smoke-test',
+        ];
+        const list = formatRoutineList(routines);
+        expect(list).toContain('e2e/');
+        expect(list).toContain('smoke-test');
+    });
 });

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -7,6 +7,7 @@ import {
     resetDistinctPools,
 } from '../../src/routine/resolver';
 import type { RoutineContext } from '../../src/routine/types';
+import type { CustomResolver } from '../../src/types';
 
 function makeCtx(overrides: Partial<RoutineContext> = {}): RoutineContext {
     return {
@@ -422,5 +423,44 @@ describe('$_contains', () => {
         const ctx = ctxWithItems([{ name: 'alice' }, { name: 'bob' }]);
 
         expect(resolveValue('$_contains($items, name, carol)', ctx)).toBe('false');
+    });
+});
+
+describe('custom resolvers via ctx.customResolvers', () => {
+    test('invokes custom resolver with args as exact match', () => {
+        const custom: CustomResolver = argsStr => `lookup:${argsStr}`;
+        const customResolvers = new Map<string, CustomResolver>([['_my_lookup', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_my_lookup(foo)', ctx)).toBe('lookup:foo');
+    });
+
+    test('invokes custom no-arg resolver as exact match', () => {
+        const custom: CustomResolver = () => 42;
+        const customResolvers = new Map<string, CustomResolver>([['_constant', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_constant', ctx)).toBe(42);
+    });
+
+    test('interpolates custom resolver inline in a string', () => {
+        const custom: CustomResolver = argsStr => `[${argsStr}]`;
+        const customResolvers = new Map<string, CustomResolver>([['_wrap', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('value: $_wrap(abc)', ctx)).toBe('value: [abc]');
+    });
+
+    test('built-in wins over custom with colliding name', () => {
+        // _uuid is built-in; a custom resolver with the same name should be ignored by evalBuiltinFunc
+        const custom: CustomResolver = () => 'custom-override';
+        const customResolvers = new Map<string, CustomResolver>([['_uuid', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        const result = resolveValue('$_uuid', ctx) as string;
+        expect(result).not.toBe('custom-override');
+        expect(result).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test('custom resolver name takes effect only when registered', () => {
+        const ctx = makeCtx();
+        // Without registration the exact-match form returns undefined (unknown function)
+        expect(resolveValue('$_not_defined(x)', ctx)).toBeUndefined();
     });
 });

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -463,4 +463,32 @@ describe('custom resolvers via ctx.customResolvers', () => {
         // Without registration the exact-match form returns undefined (unknown function)
         expect(resolveValue('$_not_defined(x)', ctx)).toBeUndefined();
     });
+
+    test('helpers.resolve resolves $refs inside custom resolver args', () => {
+        const custom: CustomResolver = (argsStr, helpers) => {
+            const value = helpers ? String(helpers.resolve(argsStr ?? '')) : argsStr;
+
+            return String(value).toUpperCase();
+        };
+        const customResolvers = new Map<string, CustomResolver>([['_upper', custom]]);
+        const ctx = makeCtx({ variables: { greeting: 'hello' }, customResolvers });
+        expect(resolveValue('$_upper($greeting)', ctx)).toBe('HELLO');
+    });
+
+    test('helpers.resolve resolves built-in functions inside custom resolver args', () => {
+        const custom: CustomResolver = (argsStr, helpers) =>
+            (helpers ? helpers.resolve(argsStr ?? '') : argsStr);
+        const customResolvers = new Map<string, CustomResolver>([['_passthrough', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        const result = resolveValue('$_passthrough($_uuid)', ctx) as string;
+        expect(result).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    test('legacy (argsStr-only) resolvers still work without helpers', () => {
+        // Backwards-compat: existing resolvers that ignore the second arg keep working.
+        const custom: CustomResolver = argsStr => `legacy:${argsStr}`;
+        const customResolvers = new Map<string, CustomResolver>([['_legacy', custom]]);
+        const ctx = makeCtx({ customResolvers });
+        expect(resolveValue('$_legacy(anything)', ctx)).toBe('legacy:anything');
+    });
 });

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -1,329 +1,339 @@
-import { describe, expect, test, beforeEach } from "bun:test";
+import { describe, expect, test, beforeEach } from 'bun:test';
 import {
-  resolveRef,
-  resolveValue,
-  resolveArgs,
-  resolvePositionalArgs,
-  resetDistinctPools,
-} from "../../src/routine/resolver";
-import type { RoutineContext } from "../../src/routine/types";
+    resolveRef,
+    resolveValue,
+    resolveArgs,
+    resolvePositionalArgs,
+    resetDistinctPools,
+} from '../../src/routine/resolver';
+import type { RoutineContext } from '../../src/routine/types';
 
 function makeCtx(overrides: Partial<RoutineContext> = {}): RoutineContext {
-  return {
-    variables: {},
-    stepOutputs: new Map(),
-    ...overrides,
-  };
+    return {
+        variables: {},
+        stepOutputs: new Map(),
+        ...overrides,
+    };
 }
 
-describe("resolveRef", () => {
-  test("resolves variables: $myVar returns variable value", () => {
-    const ctx = makeCtx({ variables: { myVar: "hello" } });
-    expect(resolveRef("myVar", ctx)).toBe("hello");
-  });
-
-  test("resolves step outputs: $stepName returns step output", () => {
-    const ctx = makeCtx();
-    ctx.stepOutputs.set("login", {
-      name: "login",
-      success: true,
-      output: { token: "abc123" },
+describe('resolveRef', () => {
+    test('resolves variables: $myVar returns variable value', () => {
+        const ctx = makeCtx({ variables: { myVar: 'hello' } });
+        expect(resolveRef('myVar', ctx)).toBe('hello');
     });
-    expect(resolveRef("login", ctx)).toEqual({ token: "abc123" });
-  });
 
-  test("resolves dot paths: $stepName.field", () => {
-    const ctx = makeCtx();
-    ctx.stepOutputs.set("login", {
-      name: "login",
-      success: true,
-      output: { token: "abc123", user: { id: 42 } },
+    test('resolves step outputs: $stepName returns step output', () => {
+        const ctx = makeCtx();
+        ctx.stepOutputs.set('login', {
+            name: 'login',
+            success: true,
+            output: { token: 'abc123' },
+        });
+        expect(resolveRef('login', ctx)).toEqual({ token: 'abc123' });
     });
-    expect(resolveRef("login.token", ctx)).toBe("abc123");
-    expect(resolveRef("login.user.id", ctx)).toBe(42);
-  });
 
-  test("resolves step success via dot path: $stepName.success", () => {
-    const ctx = makeCtx();
-    ctx.stepOutputs.set("login", {
-      name: "login",
-      success: true,
-      output: "done",
+    test('resolves dot paths: $stepName.field', () => {
+        const ctx = makeCtx();
+        ctx.stepOutputs.set('login', {
+            name: 'login',
+            success: true,
+            output: { token: 'abc123', user: { id: 42 } },
+        });
+        expect(resolveRef('login.token', ctx)).toBe('abc123');
+        expect(resolveRef('login.user.id', ctx)).toBe(42);
     });
-    expect(resolveRef("login.success", ctx)).toBe(true);
-  });
 
-  test("resolves forEach item: $item.name", () => {
-    const ctx = makeCtx({
-      forEachItem: { name: "item", value: { name: "Alice", age: 30 } },
+    test('resolves step success via dot path: $stepName.success', () => {
+        const ctx = makeCtx();
+        ctx.stepOutputs.set('login', {
+            name: 'login',
+            success: true,
+            output: 'done',
+        });
+        expect(resolveRef('login.success', ctx)).toBe(true);
     });
-    expect(resolveRef("item", ctx)).toEqual({ name: "Alice", age: 30 });
-    expect(resolveRef("item.name", ctx)).toBe("Alice");
-    expect(resolveRef("item.age", ctx)).toBe(30);
-  });
 
-  test("returns undefined for unknown refs", () => {
-    const ctx = makeCtx();
-    expect(resolveRef("unknown", ctx)).toBeUndefined();
-  });
+    test('resolves forEach item: $item.name', () => {
+        const ctx = makeCtx({
+            forEachItem: { name: 'item', value: { name: 'Alice', age: 30 } },
+        });
+        expect(resolveRef('item', ctx)).toEqual({ name: 'Alice', age: 30 });
+        expect(resolveRef('item.name', ctx)).toBe('Alice');
+        expect(resolveRef('item.age', ctx)).toBe(30);
+    });
 
-  test("forEach item takes priority over step outputs", () => {
-    const ctx = makeCtx({
-      forEachItem: { name: "item", value: "forEach-value" },
+    test('returns undefined for unknown refs', () => {
+        const ctx = makeCtx();
+        expect(resolveRef('unknown', ctx)).toBeUndefined();
     });
-    ctx.stepOutputs.set("item", {
-      name: "item",
-      success: true,
-      output: "step-value",
+
+    test('forEach item takes priority over step outputs', () => {
+        const ctx = makeCtx({
+            forEachItem: { name: 'item', value: 'forEach-value' },
+        });
+        ctx.stepOutputs.set('item', {
+            name: 'item',
+            success: true,
+            output: 'step-value',
+        });
+        expect(resolveRef('item', ctx)).toBe('forEach-value');
     });
-    expect(resolveRef("item", ctx)).toBe("forEach-value");
-  });
 });
 
-describe("resolveValue", () => {
-  test("returns native type for exact $ref match", () => {
-    const ctx = makeCtx({ variables: { count: 42 } });
-    expect(resolveValue("$count", ctx)).toBe(42);
-  });
+describe('resolveValue', () => {
+    test('returns native type for exact $ref match', () => {
+        const ctx = makeCtx({ variables: { count: 42 } });
+        expect(resolveValue('$count', ctx)).toBe(42);
+    });
 
-  test("returns native type for object $ref", () => {
-    const obj = { a: 1, b: 2 };
-    const ctx = makeCtx({ variables: { data: obj } });
-    expect(resolveValue("$data", ctx)).toEqual(obj);
-  });
+    test('returns native type for object $ref', () => {
+        const obj = { a: 1, b: 2 };
+        const ctx = makeCtx({ variables: { data: obj } });
+        expect(resolveValue('$data', ctx)).toEqual(obj);
+    });
 
-  test("interpolates $refs embedded in strings", () => {
-    const ctx = makeCtx({ variables: { name: "world", greeting: "Hello" } });
-    expect(resolveValue("$greeting, $name!", ctx)).toBe("Hello, world!");
-  });
+    test('interpolates $refs embedded in strings', () => {
+        const ctx = makeCtx({ variables: { name: 'world', greeting: 'Hello' } });
+        expect(resolveValue('$greeting, $name!', ctx)).toBe('Hello, world!');
+    });
 
-  test("returns non-string values as-is", () => {
-    const ctx = makeCtx();
-    expect(resolveValue(42, ctx)).toBe(42);
-    expect(resolveValue(true, ctx)).toBe(true);
-    expect(resolveValue(null, ctx)).toBeNull();
-  });
+    test('returns non-string values as-is', () => {
+        const ctx = makeCtx();
+        expect(resolveValue(42, ctx)).toBe(42);
+        expect(resolveValue(true, ctx)).toBe(true);
+        expect(resolveValue(null, ctx)).toBeNull();
+    });
 
-  test("returns strings without $ as-is", () => {
-    const ctx = makeCtx();
-    expect(resolveValue("no refs here", ctx)).toBe("no refs here");
-  });
+    test('returns strings without $ as-is', () => {
+        const ctx = makeCtx();
+        expect(resolveValue('no refs here', ctx)).toBe('no refs here');
+    });
 });
 
-describe("resolveArgs", () => {
-  test("resolves all arg values", () => {
-    const ctx = makeCtx({ variables: { host: "localhost", port: 8080 } });
-    const args = { url: "http://$host:$port", verbose: true };
-    const result = resolveArgs(args, ctx);
-    expect(result.url).toBe("http://localhost:8080");
-    expect(result.verbose).toBe(true);
-  });
+describe('resolveArgs', () => {
+    test('resolves all arg values', () => {
+        const ctx = makeCtx({ variables: { host: 'localhost', port: 8080 } });
+        const args = { url: 'http://$host:$port', verbose: true };
+        const result = resolveArgs(args, ctx);
+        expect(result.url).toBe('http://localhost:8080');
+        expect(result.verbose).toBe(true);
+    });
 
-  test("returns empty object for undefined args", () => {
-    const ctx = makeCtx();
-    expect(resolveArgs(undefined, ctx)).toEqual({});
-  });
+    test('returns empty object for undefined args', () => {
+        const ctx = makeCtx();
+        expect(resolveArgs(undefined, ctx)).toEqual({});
+    });
 });
 
-describe("resolvePositionalArgs", () => {
-  test("resolves all positional arg values", () => {
-    const ctx = makeCtx({ variables: { dir: "/tmp" } });
-    const args: (string | number)[] = ["$dir", 42, "literal"];
-    const result = resolvePositionalArgs(args, ctx);
-    expect(result).toEqual(["/tmp", 42, "literal"]);
-  });
+describe('resolvePositionalArgs', () => {
+    test('resolves all positional arg values', () => {
+        const ctx = makeCtx({ variables: { dir: '/tmp' } });
+        const args: (string | number)[] = ['$dir', 42, 'literal'];
+        const result = resolvePositionalArgs(args, ctx);
+        expect(result).toEqual(['/tmp', 42, 'literal']);
+    });
 
-  test("returns empty array for undefined args", () => {
-    const ctx = makeCtx();
-    expect(resolvePositionalArgs(undefined, ctx)).toEqual([]);
-  });
+    test('returns empty array for undefined args', () => {
+        const ctx = makeCtx();
+        expect(resolvePositionalArgs(undefined, ctx)).toEqual([]);
+    });
 });
 
 // ── Built-in functions ──────────────────────────────────────────────
 
-describe("$_random_hex_color", () => {
-  const ctx = makeCtx();
+describe('$_random_hex_color', () => {
+    const ctx = makeCtx();
 
-  test("returns a valid hex color as exact match", () => {
-    const result = resolveValue("$_random_hex_color", ctx);
-    expect(typeof result).toBe("string");
-    expect(result).toMatch(/^#[0-9a-f]{6}$/);
-  });
+    test('returns a valid hex color as exact match', () => {
+        const result = resolveValue('$_random_hex_color', ctx);
+        expect(typeof result).toBe('string');
+        expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    });
 
-  test("interpolates inline in a string", () => {
-    const result = resolveValue("color: $_random_hex_color", ctx) as string;
-    expect(result).toMatch(/^color: #[0-9a-f]{6}$/);
-  });
+    test('interpolates inline in a string', () => {
+        const result = resolveValue('color: $_random_hex_color', ctx) as string;
+        expect(result).toMatch(/^color: #[0-9a-f]{6}$/);
+    });
 
-  test("generates different values on repeated calls", () => {
-    const results = new Set<unknown>();
-    for (let i = 0; i < 20; i++) {
-      results.add(resolveValue("$_random_hex_color", ctx));
-    }
-    // With 20 random colors, we should get at least 2 distinct values
-    expect(results.size).toBeGreaterThan(1);
-  });
+    test('generates different values on repeated calls', () => {
+        const results = new Set<unknown>();
+
+        for (let i = 0; i < 20; i++) {
+            results.add(resolveValue('$_random_hex_color', ctx));
+        }
+
+        // With 20 random colors, we should get at least 2 distinct values
+        expect(results.size).toBeGreaterThan(1);
+    });
 });
 
-describe("$_uuid", () => {
-  const ctx = makeCtx();
+describe('$_uuid', () => {
+    const ctx = makeCtx();
 
-  test("returns a valid UUID", () => {
-    const result = resolveValue("$_uuid", ctx) as string;
-    expect(result).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
-    );
-  });
+    test('returns a valid UUID', () => {
+        const result = resolveValue('$_uuid', ctx) as string;
+        expect(result).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+    });
 
-  test("generates unique values each call", () => {
-    const a = resolveValue("$_uuid", ctx);
-    const b = resolveValue("$_uuid", ctx);
-    expect(a).not.toBe(b);
-  });
+    test('generates unique values each call', () => {
+        const a = resolveValue('$_uuid', ctx);
+        const b = resolveValue('$_uuid', ctx);
+        expect(a).not.toBe(b);
+    });
 });
 
-describe("$_random_int", () => {
-  const ctx = makeCtx();
+describe('$_random_int', () => {
+    const ctx = makeCtx();
 
-  test("returns an integer in range", () => {
-    for (let i = 0; i < 50; i++) {
-      const result = resolveValue("$_random_int(1,10)", ctx) as number;
-      expect(typeof result).toBe("number");
-      expect(result).toBeGreaterThanOrEqual(1);
-      expect(result).toBeLessThanOrEqual(10);
-      expect(Number.isInteger(result)).toBe(true);
-    }
-  });
+    test('returns an integer in range', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = resolveValue('$_random_int(1,10)', ctx) as number;
+            expect(typeof result).toBe('number');
+            expect(result).toBeGreaterThanOrEqual(1);
+            expect(result).toBeLessThanOrEqual(10);
+            expect(Number.isInteger(result)).toBe(true);
+        }
+    });
 
-  test("returns 0 with no args", () => {
-    const result = resolveValue("$_random_int()", ctx);
-    expect(result).toBe(0);
-  });
+    test('returns 0 with no args', () => {
+        const result = resolveValue('$_random_int()', ctx);
+        expect(result).toBe(0);
+    });
 
-  test("handles single-value range", () => {
-    const result = resolveValue("$_random_int(5,5)", ctx);
-    expect(result).toBe(5);
-  });
+    test('handles single-value range', () => {
+        const result = resolveValue('$_random_int(5,5)', ctx);
+        expect(result).toBe(5);
+    });
 
-  test("interpolates inline", () => {
-    const result = resolveValue("count-$_random_int(1,100)", ctx) as string;
-    expect(result).toMatch(/^count-\d+$/);
-  });
+    test('interpolates inline', () => {
+        const result = resolveValue('count-$_random_int(1,100)', ctx) as string;
+        expect(result).toMatch(/^count-\d+$/);
+    });
 
-  test("returns 0 for non-numeric args", () => {
-    const result = resolveValue("$_random_int(foo,bar)", ctx);
-    expect(result).toBe(0);
-  });
+    test('returns 0 for non-numeric args', () => {
+        const result = resolveValue('$_random_int(foo,bar)', ctx);
+        expect(result).toBe(0);
+    });
 });
 
-describe("$_random_from", () => {
-  const ctx = makeCtx();
+describe('$_random_from', () => {
+    const ctx = makeCtx();
 
-  test("returns one of the provided options", () => {
-    for (let i = 0; i < 30; i++) {
-      const result = resolveValue("$_random_from(red,green,blue)", ctx);
-      expect(["red", "green", "blue"]).toContain(result);
-    }
-  });
+    test('returns one of the provided options', () => {
+        for (let i = 0; i < 30; i++) {
+            const result = resolveValue('$_random_from(red,green,blue)', ctx);
+            expect(['red', 'green', 'blue']).toContain(result);
+        }
+    });
 
-  test("returns empty string with no args", () => {
-    expect(resolveValue("$_random_from()", ctx)).toBe("");
-  });
+    test('returns empty string with no args', () => {
+        expect(resolveValue('$_random_from()', ctx)).toBe('');
+    });
 
-  test("handles single option", () => {
-    expect(resolveValue("$_random_from(only)", ctx)).toBe("only");
-  });
+    test('handles single option', () => {
+        expect(resolveValue('$_random_from(only)', ctx)).toBe('only');
+    });
 
-  test("handles spaces in args", () => {
-    const result = resolveValue("$_random_from( a , b , c )", ctx);
-    expect(["a", "b", "c"]).toContain(result);
-  });
+    test('handles spaces in args', () => {
+        const result = resolveValue('$_random_from( a , b , c )', ctx);
+        expect(['a', 'b', 'c']).toContain(result);
+    });
 
-  test("can produce different values (not deterministic)", () => {
-    const results = new Set<unknown>();
-    for (let i = 0; i < 50; i++) {
-      results.add(resolveValue("$_random_from(x,y,z)", ctx));
-    }
-    expect(results.size).toBeGreaterThan(1);
-  });
+    test('can produce different values (not deterministic)', () => {
+        const results = new Set<unknown>();
+
+        for (let i = 0; i < 50; i++) {
+            results.add(resolveValue('$_random_from(x,y,z)', ctx));
+        }
+
+        expect(results.size).toBeGreaterThan(1);
+    });
 });
 
-describe("$_random_distinct_from", () => {
-  const ctx = makeCtx();
+describe('$_random_distinct_from', () => {
+    const ctx = makeCtx();
 
-  beforeEach(() => {
-    resetDistinctPools();
-  });
+    beforeEach(() => {
+        resetDistinctPools();
+    });
 
-  test("returns each value exactly once before repeating", () => {
-    const values = ["a", "b", "c"];
-    const results: unknown[] = [];
-    for (let i = 0; i < 3; i++) {
-      results.push(resolveValue("$_random_distinct_from(a,b,c)", ctx));
-    }
-    // All three values should appear exactly once
-    expect(results.sort()).toEqual(["a", "b", "c"]);
-  });
+    test('returns each value exactly once before repeating', () => {
+        const values = ['a', 'b', 'c'];
+        const results: unknown[] = [];
 
-  test("cycles after exhaustion", () => {
-    const results: unknown[] = [];
-    for (let i = 0; i < 6; i++) {
-      results.push(resolveValue("$_random_distinct_from(x,y)", ctx));
-    }
-    // First 2 should be x,y in some order; next 2 should be x,y again
-    const firstBatch = results.slice(0, 2).sort();
-    const secondBatch = results.slice(2, 4).sort();
-    const thirdBatch = results.slice(4, 6).sort();
-    expect(firstBatch).toEqual(["x", "y"]);
-    expect(secondBatch).toEqual(["x", "y"]);
-    expect(thirdBatch).toEqual(["x", "y"]);
-  });
+        for (let i = 0; i < 3; i++) {
+            results.push(resolveValue('$_random_distinct_from(a,b,c)', ctx));
+        }
 
-  test("separate pools for different arg lists", () => {
-    const pool1: unknown[] = [];
-    const pool2: unknown[] = [];
-    for (let i = 0; i < 2; i++) {
-      pool1.push(resolveValue("$_random_distinct_from(a,b)", ctx));
-      pool2.push(resolveValue("$_random_distinct_from(x,y)", ctx));
-    }
-    expect(pool1.sort()).toEqual(["a", "b"]);
-    expect(pool2.sort()).toEqual(["x", "y"]);
-  });
+        // All three values should appear exactly once
+        expect(results.sort()).toEqual(['a', 'b', 'c']);
+    });
 
-  test("returns empty string with no args", () => {
-    expect(resolveValue("$_random_distinct_from()", ctx)).toBe("");
-  });
+    test('cycles after exhaustion', () => {
+        const results: unknown[] = [];
 
-  test("handles single value", () => {
-    const result = resolveValue("$_random_distinct_from(only)", ctx);
-    expect(result).toBe("only");
-  });
+        for (let i = 0; i < 6; i++) {
+            results.push(resolveValue('$_random_distinct_from(x,y)', ctx));
+        }
+
+        // First 2 should be x,y in some order; next 2 should be x,y again
+        const firstBatch = results.slice(0, 2).sort();
+        const secondBatch = results.slice(2, 4).sort();
+        const thirdBatch = results.slice(4, 6).sort();
+        expect(firstBatch).toEqual(['x', 'y']);
+        expect(secondBatch).toEqual(['x', 'y']);
+        expect(thirdBatch).toEqual(['x', 'y']);
+    });
+
+    test('separate pools for different arg lists', () => {
+        const pool1: unknown[] = [];
+        const pool2: unknown[] = [];
+
+        for (let i = 0; i < 2; i++) {
+            pool1.push(resolveValue('$_random_distinct_from(a,b)', ctx));
+            pool2.push(resolveValue('$_random_distinct_from(x,y)', ctx));
+        }
+
+        expect(pool1.sort()).toEqual(['a', 'b']);
+        expect(pool2.sort()).toEqual(['x', 'y']);
+    });
+
+    test('returns empty string with no args', () => {
+        expect(resolveValue('$_random_distinct_from()', ctx)).toBe('');
+    });
+
+    test('handles single value', () => {
+        const result = resolveValue('$_random_distinct_from(only)', ctx);
+        expect(result).toBe('only');
+    });
 });
 
-describe("$_env", () => {
-  const ctx = makeCtx();
+describe('$_env', () => {
+    const ctx = makeCtx();
 
-  test("resolves env var value when set", () => {
-    process.env.APIJACK_TEST_KEY = "secret";
-    expect(resolveValue("$_env(APIJACK_TEST_KEY)", ctx)).toBe("secret");
-    delete process.env.APIJACK_TEST_KEY;
-  });
+    test('resolves env var value when set', () => {
+        process.env.APIJACK_TEST_KEY = 'secret';
+        expect(resolveValue('$_env(APIJACK_TEST_KEY)', ctx)).toBe('secret');
+        delete process.env.APIJACK_TEST_KEY;
+    });
 
-  test("falls back to default when var unset", () => {
-    expect(resolveValue("$_env(APIJACK_MISSING_VAR, fallback)", ctx)).toBe("fallback");
-  });
+    test('falls back to default when var unset', () => {
+        expect(resolveValue('$_env(APIJACK_MISSING_VAR, fallback)', ctx)).toBe('fallback');
+    });
 
-  test("returns empty string when var unset and no default", () => {
-    expect(resolveValue("$_env(APIJACK_MISSING_VAR)", ctx)).toBe("");
-  });
+    test('returns empty string when var unset and no default', () => {
+        expect(resolveValue('$_env(APIJACK_MISSING_VAR)', ctx)).toBe('');
+    });
 
-  test("interpolates within larger string", () => {
-    process.env.APIJACK_TEST_KEY = "xyz";
-    expect(resolveValue("key=$_env(APIJACK_TEST_KEY)", ctx)).toBe("key=xyz");
-    delete process.env.APIJACK_TEST_KEY;
-  });
+    test('interpolates within larger string', () => {
+        process.env.APIJACK_TEST_KEY = 'xyz';
+        expect(resolveValue('key=$_env(APIJACK_TEST_KEY)', ctx)).toBe('key=xyz');
+        delete process.env.APIJACK_TEST_KEY;
+    });
 
-  test("default value preserves commas", () => {
-    expect(resolveValue("$_env(APIJACK_MISSING, a,b,c)", ctx)).toBe("a,b,c");
-  });
+    test('default value preserves commas', () => {
+        expect(resolveValue('$_env(APIJACK_MISSING, a,b,c)', ctx)).toBe('a,b,c');
+    });
 });

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -337,3 +337,90 @@ describe('$_env', () => {
         expect(resolveValue('$_env(APIJACK_MISSING, a,b,c)', ctx)).toBe('a,b,c');
     });
 });
+
+describe('$_find', () => {
+    function ctxWithItems(items: unknown): RoutineContext {
+        const ctx = makeCtx();
+
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: items,
+        });
+
+        return ctx;
+    }
+
+    test('finds element by string field', () => {
+        const ctx = ctxWithItems([
+            { name: 'alice', id: 1 },
+            { name: 'bob', id: 2 },
+        ]);
+
+        expect(resolveValue('$_find($items, name, bob)', ctx)).toEqual({ name: 'bob', id: 2 });
+    });
+
+    test('finds element by numeric field via string coercion', () => {
+        const ctx = ctxWithItems([
+            { name: 'alice', id: 1 },
+            { name: 'bob', id: 2 },
+        ]);
+
+        expect(resolveValue('$_find($items, id, 2)', ctx)).toEqual({ name: 'bob', id: 2 });
+    });
+
+    test('returns undefined when no element matches', () => {
+        const ctx = ctxWithItems([{ name: 'alice' }, { name: 'bob' }]);
+
+        expect(resolveValue('$_find($items, name, carol)', ctx)).toBeUndefined();
+    });
+
+    test('returns undefined when array ref is missing', () => {
+        const ctx = makeCtx();
+
+        expect(resolveValue('$_find($missing, name, bob)', ctx)).toBeUndefined();
+    });
+
+    test('returns undefined when ref is not an array', () => {
+        const ctx = makeCtx({ variables: { items: 'not-an-array' } });
+
+        expect(resolveValue('$_find($items, name, bob)', ctx)).toBeUndefined();
+    });
+
+    test('resolves $-ref as the value argument', () => {
+        const ctx = ctxWithItems([
+            { name: 'alice', id: 1 },
+            { name: 'bob', id: 2 },
+        ]);
+
+        ctx.variables.targetName = 'bob';
+
+        expect(resolveValue('$_find($items, name, $targetName)', ctx)).toEqual({ name: 'bob', id: 2 });
+    });
+});
+
+describe('$_contains', () => {
+    function ctxWithItems(items: unknown): RoutineContext {
+        const ctx = makeCtx();
+
+        ctx.stepOutputs.set('items', {
+            name: 'items',
+            success: true,
+            output: items,
+        });
+
+        return ctx;
+    }
+
+    test('returns "true" when element is present', () => {
+        const ctx = ctxWithItems([{ name: 'alice' }, { name: 'bob' }]);
+
+        expect(resolveValue('$_contains($items, name, alice)', ctx)).toBe('true');
+    });
+
+    test('returns "false" when element is absent', () => {
+        const ctx = ctxWithItems([{ name: 'alice' }, { name: 'bob' }]);
+
+        expect(resolveValue('$_contains($items, name, carol)', ctx)).toBe('false');
+    });
+});

--- a/tests/routine/resolver.test.ts
+++ b/tests/routine/resolver.test.ts
@@ -299,3 +299,31 @@ describe("$_random_distinct_from", () => {
     expect(result).toBe("only");
   });
 });
+
+describe("$_env", () => {
+  const ctx = makeCtx();
+
+  test("resolves env var value when set", () => {
+    process.env.APIJACK_TEST_KEY = "secret";
+    expect(resolveValue("$_env(APIJACK_TEST_KEY)", ctx)).toBe("secret");
+    delete process.env.APIJACK_TEST_KEY;
+  });
+
+  test("falls back to default when var unset", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING_VAR, fallback)", ctx)).toBe("fallback");
+  });
+
+  test("returns empty string when var unset and no default", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING_VAR)", ctx)).toBe("");
+  });
+
+  test("interpolates within larger string", () => {
+    process.env.APIJACK_TEST_KEY = "xyz";
+    expect(resolveValue("key=$_env(APIJACK_TEST_KEY)", ctx)).toBe("key=xyz");
+    delete process.env.APIJACK_TEST_KEY;
+  });
+
+  test("default value preserves commas", () => {
+    expect(resolveValue("$_env(APIJACK_MISSING, a,b,c)", ctx)).toBe("a,b,c");
+  });
+});

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -1,252 +1,259 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, existsSync, readFileSync, rmSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
-import { SessionManager } from "../src/session";
-import type { AuthStrategy, AuthSession, ResolvedAuth } from "../src/auth/types";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
+import { SessionManager } from '../src/session';
+import type { AuthStrategy, AuthSession, ResolvedAuth } from '../src/auth/types';
 
 function makeMockStrategy(overrides: Partial<AuthStrategy> = {}): AuthStrategy {
-  return {
-    authenticate: overrides.authenticate ?? (async (config) => ({
-      headers: { Authorization: "Bearer fresh-token" },
-      expiresAt: Date.now() + 30 * 60 * 1000,
-    })),
-    restore: overrides.restore ?? (async (cached, config) => cached),
-    ...overrides,
-  };
+    return {
+        authenticate: overrides.authenticate ?? (async config => ({
+            headers: { Authorization: 'Bearer fresh-token' },
+            expiresAt: Date.now() + 30 * 60 * 1000,
+        })),
+        restore: overrides.restore ?? (async (cached, config) => cached),
+        ...overrides,
+    };
 }
 
 const config: ResolvedAuth = {
-  baseUrl: "https://api.example.com",
-  username: "user",
-  password: "pass",
+    baseUrl: 'https://api.example.com',
+    username: 'user',
+    password: 'pass',
 };
 
-describe("SessionManager", () => {
-  let tmpDir: string;
-  let sessionPath: string;
-  let manager: SessionManager;
+describe('SessionManager', () => {
+    let tmpDir: string;
+    let sessionPath: string;
+    let manager: SessionManager;
 
-  beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "session-test-"));
-    sessionPath = join(tmpDir, "session.json");
-    manager = new SessionManager("test", sessionPath);
-  });
-
-  afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  test("resolve() calls strategy.authenticate() when no cached session", async () => {
-    let authenticateCalled = false;
-    const strategy = makeMockStrategy({
-      authenticate: async (cfg) => {
-        authenticateCalled = true;
-        return { headers: { Authorization: "Bearer new" } };
-      },
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'session-test-'));
+        sessionPath = join(tmpDir, 'session.json');
+        manager = new SessionManager('test', sessionPath);
     });
 
-    const session = await manager.resolve(strategy, config);
-
-    expect(authenticateCalled).toBe(true);
-    expect(session.headers.Authorization).toBe("Bearer new");
-  });
-
-  test("resolve() calls strategy.restore() when cache exists and not expired", async () => {
-    let restoreCalled = false;
-    let authenticateCalled = false;
-
-    // Pre-populate the cache with a non-expired session
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer cached" },
-      expiresAt: Date.now() + 60 * 1000, // 1 minute in the future
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
-
-    const strategy = makeMockStrategy({
-      authenticate: async () => {
-        authenticateCalled = true;
-        return { headers: { Authorization: "Bearer fresh" } };
-      },
-      restore: async (c, cfg) => {
-        restoreCalled = true;
-        return c;
-      },
+    afterEach(() => {
+        rmSync(tmpDir, { recursive: true, force: true });
     });
 
-    const session = await manager.resolve(strategy, config);
+    test('resolve() calls strategy.authenticate() when no cached session', async () => {
+        let authenticateCalled = false;
+        const strategy = makeMockStrategy({
+            authenticate: async (cfg) => {
+                authenticateCalled = true;
 
-    expect(restoreCalled).toBe(true);
-    expect(authenticateCalled).toBe(false);
-    expect(session.headers.Authorization).toBe("Bearer cached");
-  });
+                return { headers: { Authorization: 'Bearer new' } };
+            },
+        });
 
-  test("resolve() calls strategy.authenticate() when restore() returns null", async () => {
-    let authenticateCalled = false;
+        const session = await manager.resolve(strategy, config);
 
-    // Pre-populate with a valid (non-expired) cached session
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer stale" },
-      expiresAt: Date.now() + 60 * 1000,
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
-
-    const strategy = makeMockStrategy({
-      authenticate: async () => {
-        authenticateCalled = true;
-        return { headers: { Authorization: "Bearer fresh" } };
-      },
-      restore: async () => null,
+        expect(authenticateCalled).toBe(true);
+        expect(session.headers.Authorization).toBe('Bearer new');
     });
 
-    const session = await manager.resolve(strategy, config);
+    test('resolve() calls strategy.restore() when cache exists and not expired', async () => {
+        let restoreCalled = false;
+        let authenticateCalled = false;
 
-    expect(authenticateCalled).toBe(true);
-    expect(session.headers.Authorization).toBe("Bearer fresh");
-  });
+        // Pre-populate the cache with a non-expired session
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer cached' },
+            expiresAt: Date.now() + 60 * 1000, // 1 minute in the future
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
 
-  test("resolve() calls strategy.refresh() when session is expired and refresh is available", async () => {
-    let refreshCalled = false;
-    let authenticateCalled = false;
+        const strategy = makeMockStrategy({
+            authenticate: async () => {
+                authenticateCalled = true;
 
-    // Pre-populate with an expired session
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer expired" },
-      expiresAt: Date.now() - 1000, // 1 second in the past
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
+                return { headers: { Authorization: 'Bearer fresh' } };
+            },
+            restore: async (c, cfg) => {
+                restoreCalled = true;
 
-    const strategy = makeMockStrategy({
-      authenticate: async () => {
-        authenticateCalled = true;
-        return { headers: { Authorization: "Bearer fresh" } };
-      },
-      refresh: async (sess, cfg) => {
-        refreshCalled = true;
-        return { headers: { Authorization: "Bearer refreshed" }, expiresAt: Date.now() + 60000 };
-      },
+                return c;
+            },
+        });
+
+        const session = await manager.resolve(strategy, config);
+
+        expect(restoreCalled).toBe(true);
+        expect(authenticateCalled).toBe(false);
+        expect(session.headers.Authorization).toBe('Bearer cached');
     });
 
-    const session = await manager.resolve(strategy, config);
+    test('resolve() calls strategy.authenticate() when restore() returns null', async () => {
+        let authenticateCalled = false;
 
-    expect(refreshCalled).toBe(true);
-    expect(authenticateCalled).toBe(false);
-    expect(session.headers.Authorization).toBe("Bearer refreshed");
-  });
+        // Pre-populate with a valid (non-expired) cached session
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer stale' },
+            expiresAt: Date.now() + 60 * 1000,
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
 
-  test("resolve() calls strategy.authenticate() when expired and no refresh method", async () => {
-    let authenticateCalled = false;
+        const strategy = makeMockStrategy({
+            authenticate: async () => {
+                authenticateCalled = true;
 
-    // Pre-populate with an expired session
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer expired" },
-      expiresAt: Date.now() - 1000,
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
+                return { headers: { Authorization: 'Bearer fresh' } };
+            },
+            restore: async () => null,
+        });
 
-    const strategy = makeMockStrategy({
-      authenticate: async () => {
-        authenticateCalled = true;
-        return { headers: { Authorization: "Bearer fresh" } };
-      },
+        const session = await manager.resolve(strategy, config);
+
+        expect(authenticateCalled).toBe(true);
+        expect(session.headers.Authorization).toBe('Bearer fresh');
     });
-    // Remove refresh so it's undefined
-    delete (strategy as any).refresh;
 
-    const session = await manager.resolve(strategy, config);
+    test('resolve() calls strategy.refresh() when session is expired and refresh is available', async () => {
+        let refreshCalled = false;
+        let authenticateCalled = false;
 
-    expect(authenticateCalled).toBe(true);
-    expect(session.headers.Authorization).toBe("Bearer fresh");
-  });
+        // Pre-populate with an expired session
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer expired' },
+            expiresAt: Date.now() - 1000, // 1 second in the past
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
 
-  test("invalidate() clears cached session file", async () => {
+        const strategy = makeMockStrategy({
+            authenticate: async () => {
+                authenticateCalled = true;
+
+                return { headers: { Authorization: 'Bearer fresh' } };
+            },
+            refresh: async (sess, cfg) => {
+                refreshCalled = true;
+
+                return { headers: { Authorization: 'Bearer refreshed' }, expiresAt: Date.now() + 60000 };
+            },
+        });
+
+        const session = await manager.resolve(strategy, config);
+
+        expect(refreshCalled).toBe(true);
+        expect(authenticateCalled).toBe(false);
+        expect(session.headers.Authorization).toBe('Bearer refreshed');
+    });
+
+    test('resolve() calls strategy.authenticate() when expired and no refresh method', async () => {
+        let authenticateCalled = false;
+
+        // Pre-populate with an expired session
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer expired' },
+            expiresAt: Date.now() - 1000,
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
+
+        const strategy = makeMockStrategy({
+            authenticate: async () => {
+                authenticateCalled = true;
+
+                return { headers: { Authorization: 'Bearer fresh' } };
+            },
+        });
+        // Remove refresh so it's undefined
+        delete (strategy as any).refresh;
+
+        const session = await manager.resolve(strategy, config);
+
+        expect(authenticateCalled).toBe(true);
+        expect(session.headers.Authorization).toBe('Bearer fresh');
+    });
+
+    test('invalidate() clears cached session file', async () => {
     // Pre-populate cache
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer cached" },
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer cached' },
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
 
-    expect(existsSync(sessionPath)).toBe(true);
+        expect(existsSync(sessionPath)).toBe(true);
 
-    manager.invalidate();
+        manager.invalidate();
 
-    expect(existsSync(sessionPath)).toBe(false);
-  });
-
-  test("invalidate() does not throw when no session file exists", () => {
-    expect(() => manager.invalidate()).not.toThrow();
-  });
-
-  test("session is persisted to disk after resolve", async () => {
-    const strategy = makeMockStrategy({
-      authenticate: async () => ({
-        headers: { Authorization: "Bearer persisted" },
-        expiresAt: 9999999999999,
-        data: { role: "admin" },
-      }),
+        expect(existsSync(sessionPath)).toBe(false);
     });
 
-    await manager.resolve(strategy, config);
-
-    expect(existsSync(sessionPath)).toBe(true);
-    const saved = JSON.parse(readFileSync(sessionPath, "utf-8"));
-    expect(saved.headers.Authorization).toBe("Bearer persisted");
-    expect(saved.expiresAt).toBe(9999999999999);
-    expect(saved.data.role).toBe("admin");
-  });
-
-  test("default session path uses ~/.cliName/session.json", () => {
-    const { homedir } = require("os");
-    const defaultMgr = new SessionManager("myapp");
-    // Access the private sessionPath via any cast
-    const path = (defaultMgr as any).sessionPath;
-    expect(path).toBe(join(homedir(), ".myapp", "session.json"));
-  });
-
-  test("sessionPathOverride takes precedence over default", () => {
-    const customPath = join(tmpDir, "custom", "session.json");
-    const customMgr = new SessionManager("myapp", customPath);
-    const path = (customMgr as any).sessionPath;
-    expect(path).toBe(customPath);
-  });
-
-  test("resolve() handles cached session with no expiresAt as valid", async () => {
-    let restoreCalled = false;
-
-    // Cache a session without expiresAt (never expires)
-    const cached: AuthSession = {
-      headers: { Authorization: "Bearer eternal" },
-    };
-    const { writeFileSync, mkdirSync } = await import("fs");
-    const { dirname } = await import("path");
-    mkdirSync(dirname(sessionPath), { recursive: true });
-    writeFileSync(sessionPath, JSON.stringify(cached));
-
-    const strategy = makeMockStrategy({
-      restore: async (c) => {
-        restoreCalled = true;
-        return c;
-      },
+    test('invalidate() does not throw when no session file exists', () => {
+        expect(() => manager.invalidate()).not.toThrow();
     });
 
-    const session = await manager.resolve(strategy, config);
+    test('session is persisted to disk after resolve', async () => {
+        const strategy = makeMockStrategy({
+            authenticate: async () => ({
+                headers: { Authorization: 'Bearer persisted' },
+                expiresAt: 9999999999999,
+                data: { role: 'admin' },
+            }),
+        });
 
-    expect(restoreCalled).toBe(true);
-    expect(session.headers.Authorization).toBe("Bearer eternal");
-  });
+        await manager.resolve(strategy, config);
+
+        expect(existsSync(sessionPath)).toBe(true);
+        const saved = JSON.parse(readFileSync(sessionPath, 'utf-8'));
+        expect(saved.headers.Authorization).toBe('Bearer persisted');
+        expect(saved.expiresAt).toBe(9999999999999);
+        expect(saved.data.role).toBe('admin');
+    });
+
+    test('default session path uses ~/.cliName/session.json', () => {
+        const defaultMgr = new SessionManager('myapp');
+        // Access the private sessionPath via any cast
+        const path = (defaultMgr as any).sessionPath;
+        expect(path).toBe(join(homedir(), '.myapp', 'session.json'));
+    });
+
+    test('sessionPathOverride takes precedence over default', () => {
+        const customPath = join(tmpDir, 'custom', 'session.json');
+        const customMgr = new SessionManager('myapp', customPath);
+        const path = (customMgr as any).sessionPath;
+        expect(path).toBe(customPath);
+    });
+
+    test('resolve() handles cached session with no expiresAt as valid', async () => {
+        let restoreCalled = false;
+
+        // Cache a session without expiresAt (never expires)
+        const cached: AuthSession = {
+            headers: { Authorization: 'Bearer eternal' },
+        };
+        const { writeFileSync, mkdirSync } = await import('fs');
+        const { dirname } = await import('path');
+        mkdirSync(dirname(sessionPath), { recursive: true });
+        writeFileSync(sessionPath, JSON.stringify(cached));
+
+        const strategy = makeMockStrategy({
+            restore: async (c) => {
+                restoreCalled = true;
+
+                return c;
+            },
+        });
+
+        const session = await manager.resolve(strategy, config);
+
+        expect(restoreCalled).toBe(true);
+        expect(session.headers.Authorization).toBe('Bearer eternal');
+    });
 });


### PR DESCRIPTION
A focused release on routine expressiveness: custom resolver extensibility, idempotent lookups, and interactive auth flows.

## ✨ Features

- **Pluggable custom resolvers** (#30) — Drop a `.ts` file in `.apijack/resolvers/<name>.ts` and it's auto-registered as a routine-level function (`$_my_fn(...)`). Mirrors the existing `.apijack/commands/` and `.apijack/dispatchers/` extension patterns.
- **`resolve()` helper for custom resolvers** (#34) — `CustomResolver` now receives an optional `{ resolve }` helper so user-defined resolvers can expand `$ref` args against the routine context (e.g., `$_uppercase($input)` resolves `$input` first). Backwards-compatible with one-arg resolvers.
- **`$_find()` and `$_contains()` built-ins** (#29) — Look up elements in arrays without the forEach-with-dummy-command workaround. Enables idempotent routines: `condition: "$_find($items, name, $name) == undefined"`.
- **`$_env()` built-in** — Read env vars inside routine values with optional defaults: `--token: "$_env(API_TOKEN, dev-default)"`.
- **`onChallenge` hook on `SessionAuthStrategy`** — Project-level hook for handling mid-session auth challenges (MFA prompts, renewal flows, etc.) without tearing down the CLI.
- **Plugin install via the claude CLI** (#27) — `apijack plugin install` now shells out to the official Claude CLI instead of writing to `~/.claude/` directly, keeping the plugin index in sync.

## 🐛 Fixes

- **Path-param / body-field name collisions** (#25) — When a body field shares a name with a path parameter (`id`, for example), it now stays in the body instead of being hoisted.

## ⚠ Changed

- **`loadProjectAuth()` return shape** — Now returns `{ strategy, onChallenge }` instead of `AuthStrategy | null`. Only affects consumers importing `loadProjectAuth` from `@apijack/core` directly.

## 🧹 Internal

- Lint wired into CI with 0-error enforcement (#26).
- Tutorial e2e now exercises the custom-resolver path end-to-end (literal + `$ref`-resolving forms).
- `skills/write-routine/SKILL.md` docs updated with `$_find` / `$_contains` and a worked custom-resolver example.

## 📦 Routine YAML surface

| Feature | Example |
|---|---|
| Array lookup | `condition: "$_find($items, name, $name) == undefined"` |
| Array contains | `condition: "$_contains($items, id, $id) == true"` |
| Env var | `--token: "$_env(API_TOKEN, fallback)"` |
| Custom resolver | `--title: "$_uppercase($greeting)"` (with `.apijack/resolvers/uppercase.ts`) |

---

Shipped via `scripts/ship.sh`.
