### PR TITLE
feat(cli): opt-in auth resolution for custom commands and dispatchers (#37)

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -10,6 +10,7 @@ import { BearerTokenStrategy } from '../src/auth/bearer';
 import { ApiKeyStrategy } from '../src/auth/api-key';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir } from '../src/project';
 import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
+import { loadProjectSettings } from '../src/settings';
 import { checkForUpdate } from '../src/updater';
 import { getActiveEnvConfig } from '../src/config';
 import pkg from '../package.json';
@@ -131,7 +132,12 @@ let sessionAuth: SessionAuthConfig | undefined;
     }
 }
 
-// 8. Create CLI
+// 8. Load project settings (framework-level flags, separate from per-env config)
+const projectSettings = projectRoot
+    ? loadProjectSettings(join(projectRoot, '.apijack'))
+    : {};
+
+// 9. Create CLI
 const cli = createCli({
     name: CLI_NAME,
     description: 'Jack into any OpenAPI spec and rip a full-featured CLI',
@@ -142,20 +148,21 @@ const cli = createCli({
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,
     configPath: join(configDir, 'config.json'),
+    customCommandDefaults: projectSettings.customCommands?.defaults,
 });
 
-// 9. Register project-level extensions
+// 10. Register project-level extensions
 if (projectRoot) {
     const commands = await loadProjectCommands(join(projectRoot, '.apijack'));
 
     for (const cmd of commands) {
-        cli.command(cmd.name, cmd.registrar);
+        cli.command(cmd.name, cmd.registrar, { requiresAuth: cmd.requiresAuth });
     }
 
     const dispatchers = await loadProjectDispatchers(join(projectRoot, '.apijack'));
 
-    for (const [name, handler] of dispatchers) {
-        cli.dispatcher(name, handler);
+    for (const disp of dispatchers) {
+        cli.dispatcher(disp.name, disp.handler, { requiresAuth: disp.requiresAuth });
     }
 
     const resolvers = await loadProjectResolvers(join(projectRoot, '.apijack'));
@@ -165,5 +172,5 @@ if (projectRoot) {
     }
 }
 
-// 10. Run
+// 11. Run
 await cli.run();

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -27,9 +27,17 @@ import { resolveRequestHeaders } from './auth/resolve-headers';
 import { deepMergeSessionAuth } from './auth/config-merge';
 import { loadPreRequestHook } from './pre-request';
 
+export interface CommandOptions {
+    requiresAuth?: boolean;
+}
+
+export interface DispatcherOptions {
+    requiresAuth?: boolean;
+}
+
 export interface Cli {
-    command(name: string, registrar: CommandRegistrar): void;
-    dispatcher(name: string, handler: DispatcherHandler): void;
+    command(name: string, registrar: CommandRegistrar, options?: CommandOptions): void;
+    dispatcher(name: string, handler: DispatcherHandler, options?: DispatcherOptions): void;
     resolver(name: string, handler: CustomResolver): void;
     run(): Promise<void>;
 }
@@ -102,8 +110,8 @@ function showCustomHelp(
 }
 
 export function createCli(options: CliOptions): Cli {
-    const consumerCommands: { name: string; registrar: CommandRegistrar }[] = [];
-    const consumerDispatchers = new Map<string, DispatcherHandler>();
+    const consumerCommands: { name: string; registrar: CommandRegistrar; requiresAuth?: boolean }[] = [];
+    const consumerDispatchers = new Map<string, { handler: DispatcherHandler; requiresAuth?: boolean }>();
     const consumerResolvers = new Map<string, CustomResolver>();
     const cliName = options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
@@ -112,14 +120,17 @@ export function createCli(options: CliOptions): Cli {
         : join(homedir(), `.${cliName}`);
     const routinesDir = join(configDir, 'routines');
     const generatedDir = options.generatedDir ?? join(process.cwd(), 'src', 'generated');
+    const defaultRequiresAuth = options.customCommandDefaults?.requiresAuth ?? false;
+    const effectiveRequiresAuth = (explicit: boolean | undefined): boolean =>
+        explicit ?? defaultRequiresAuth;
 
     const cli: Cli = {
-        command(name: string, registrar: CommandRegistrar): void {
-            consumerCommands.push({ name, registrar });
+        command(name: string, registrar: CommandRegistrar, cmdOpts?: CommandOptions): void {
+            consumerCommands.push({ name, registrar, requiresAuth: cmdOpts?.requiresAuth });
         },
 
-        dispatcher(name: string, handler: DispatcherHandler): void {
-            consumerDispatchers.set(name, handler);
+        dispatcher(name: string, handler: DispatcherHandler, dispOpts?: DispatcherOptions): void {
+            consumerDispatchers.set(name, { handler, requiresAuth: dispOpts?.requiresAuth });
         },
 
         resolver(name: string, handler: CustomResolver): void {
@@ -264,7 +275,23 @@ export function createCli(options: CliOptions): Cli {
             const isDryRun = process.argv.includes('--dry-run') && process.argv[2] !== 'routine';
             const isCurl = oVal === 'curl';
             const isCurlWithCreds = oVal === 'curl-with-creds';
+            const isRoutineStep = oVal === 'routine-step';
             const isRequestPreview = isDryRun || isCurl || isCurlWithCreds;
+            // Skip auth resolution for preview/inspection modes. curl-with-creds still resolves.
+            const skipAuthResolution = isRoutineStep || isDryRun || isCurl || isHelpOrVersion;
+
+            // Shared session resolver — lazy, runs on first API request or explicit consumer call
+            const resolveSession = async (): Promise<void> => {
+                if (!resolved || !sessionMgr) {
+                    throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                }
+
+                if (ctx && ctx.session) return;
+
+                const session = await sessionMgr.resolve(strategy, resolved);
+
+                if (ctx) ctx.session = session;
+            };
 
             // 8. Create CliContext with lazy session
             let ctx: CliContext | null = null;
@@ -279,6 +306,18 @@ export function createCli(options: CliOptions): Cli {
                         sessionMgr!.invalidate();
                         ctx!.session = await sessionMgr!.resolve(strategy, resolved!);
                     },
+                    resolveSession,
+                    saveSession: async () => {
+                        if (!sessionMgr) {
+                            throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                        }
+
+                        if (ctx!.session) {
+                            sessionMgr.save(ctx!.session);
+                        } else {
+                            sessionMgr.invalidate();
+                        }
+                    },
                 };
             }
 
@@ -287,19 +326,6 @@ export function createCli(options: CliOptions): Cli {
                 const registerFn = commandsModule.registerGeneratedCommands as (
                     program: Command, client: unknown, onResult: (result: unknown) => void,
                 ) => void;
-
-                // Session resolver — lazy, runs once on first real API request
-                const resolveSession = async () => {
-                    if (!resolved || !sessionMgr) {
-                        throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
-                    }
-
-                    if (ctx && ctx.session) return;
-
-                    const session = await sessionMgr.resolve(strategy, resolved);
-
-                    if (ctx) ctx.session = session;
-                };
 
                 // Headers provider — reads from resolved session
                 const getHeaders = (method: string) =>
@@ -402,9 +428,34 @@ export function createCli(options: CliOptions): Cli {
                 registerFn(program, client, onResult);
             }
 
-            // 10. Register consumer commands
-            for (const { registrar } of consumerCommands) {
+            // 10. Register consumer commands and attach per-command requiresAuth preAction hooks.
+            // Track the actual Command instances each registrar adds (not just the logical name),
+            // so the hook still fires if the registrar names its subcommand differently.
+            const requiresAuthCommands = new Set<Command>();
+
+            for (const { registrar, requiresAuth } of consumerCommands) {
+                const before = new Set(program.commands);
+                // When auth is not configured, ctx is null. Consumers should only touch ctx
+                // inside action callbacks (which won't run until run() is further along).
                 registrar(program, ctx ?? (null as unknown as CliContext));
+
+                if (effectiveRequiresAuth(requiresAuth)) {
+                    for (const cmd of program.commands) {
+                        if (!before.has(cmd)) requiresAuthCommands.add(cmd);
+                    }
+                }
+            }
+
+            if (requiresAuthCommands.size > 0 && !skipAuthResolution) {
+                program.hook('preAction', async (_thisCommand, actionCommand) => {
+                    let cmd: Command = actionCommand;
+
+                    while (cmd.parent && cmd.parent !== program) cmd = cmd.parent;
+
+                    if (requiresAuthCommands.has(cmd)) {
+                        await resolveSession();
+                    }
+                });
             }
 
             // 11. Build dispatcher
@@ -431,11 +482,30 @@ export function createCli(options: CliOptions): Cli {
 
             const customResolvers = consumerResolvers.size > 0 ? consumerResolvers : undefined;
 
+            // Unwrap dispatcher entries and wrap requiresAuth handlers with ensureReady
+            let dispatcherHandlers: Map<string, DispatcherHandler> | undefined;
+
+            if (consumerDispatchers.size > 0) {
+                dispatcherHandlers = new Map();
+
+                for (const [name, entry] of consumerDispatchers) {
+                    if (effectiveRequiresAuth(entry.requiresAuth)) {
+                        dispatcherHandlers.set(name, async (args, positional, dctx) => {
+                            await resolveSession();
+
+                            return entry.handler(args, positional, dctx);
+                        });
+                    } else {
+                        dispatcherHandlers.set(name, entry.handler);
+                    }
+                }
+            }
+
             if (ctx) {
                 dispatch = buildDispatcher({
                     commandMap,
-                    client: ctx.client,
-                    consumerHandlers: consumerDispatchers.size > 0 ? consumerDispatchers : undefined,
+                    client: ctx.client as Record<string, unknown> | undefined,
+                    consumerHandlers: dispatcherHandlers,
                     customResolvers,
                     preDispatch: options.preDispatch,
                     ctx,
@@ -449,11 +519,7 @@ export function createCli(options: CliOptions): Cli {
             // 12. Register routine commands
             registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers);
 
-            // 11. Handle -o routine-step
-            const isRoutineStep
-                = process.argv.includes('-o')
-                    && process.argv[process.argv.indexOf('-o') + 1] === 'routine-step';
-
+            // 13. Handle -o routine-step
             if (isRoutineStep) {
                 program.hook('preAction', (_thisCommand, actionCommand) => {
                     const cmdParts: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,19 @@
 export { createCli } from './cli-builder';
-export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver, CustomResolverHelpers } from './types';
+export type { Cli, CommandOptions, DispatcherOptions } from './cli-builder';
+export type {
+    CliOptions,
+    CliContext,
+    AuthedCliContext,
+    CommandRegistrar,
+    DispatcherHandler,
+    CommandDispatcher,
+    CustomResolver,
+    CustomResolverHelpers,
+} from './types';
 export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
+export type { LoadedCommand, LoadedDispatcher } from './project-loader';
+export { loadProjectSettings } from './settings';
+export type { ProjectSettings } from './settings';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';
 export { BearerTokenStrategy } from './auth/bearer';

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -38,6 +38,7 @@ export async function loadProjectAuth(
 export interface LoadedCommand {
     name: string;
     registrar: CommandRegistrar;
+    requiresAuth?: boolean;
 }
 
 export async function loadProjectCommands(
@@ -55,9 +56,10 @@ export async function loadProjectCommands(
             const mod = await import(join(cmdDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const registrar = mod.default as CommandRegistrar;
+            const requiresAuth = typeof mod.requiresAuth === 'boolean' ? mod.requiresAuth : undefined;
 
             if (typeof registrar === 'function') {
-                commands.push({ name, registrar });
+                commands.push({ name, registrar, requiresAuth });
             }
         } catch {
             // Skip files that fail to import
@@ -67,14 +69,20 @@ export async function loadProjectCommands(
     return commands;
 }
 
+export interface LoadedDispatcher {
+    name: string;
+    handler: DispatcherHandler;
+    requiresAuth?: boolean;
+}
+
 export async function loadProjectDispatchers(
     apijackDir: string,
-): Promise<Map<string, DispatcherHandler>> {
+): Promise<LoadedDispatcher[]> {
     const dispDir = join(apijackDir, 'dispatchers');
 
-    if (!existsSync(dispDir)) return new Map();
+    if (!existsSync(dispDir)) return [];
 
-    const dispatchers = new Map<string, DispatcherHandler>();
+    const dispatchers: LoadedDispatcher[] = [];
     const files = readdirSync(dispDir).filter(f => f.endsWith('.ts'));
 
     for (const file of files) {
@@ -82,9 +90,10 @@ export async function loadProjectDispatchers(
             const mod = await import(join(dispDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const handler = mod.default as DispatcherHandler;
+            const requiresAuth = typeof mod.requiresAuth === 'boolean' ? mod.requiresAuth : undefined;
 
             if (typeof handler === 'function') {
-                dispatchers.set(name, handler);
+                dispatchers.push({ name, handler, requiresAuth });
             }
         } catch {
             // Skip files that fail to import

--- a/src/session.ts
+++ b/src/session.ts
@@ -52,6 +52,14 @@ export class SessionManager {
         }
     }
 
+    save(session: AuthSession): void {
+        mkdirSync(dirname(this.sessionPath), { recursive: true });
+        writeFileSync(
+            this.sessionPath,
+            JSON.stringify(session, null, 2) + '\n',
+        );
+    }
+
     private load(): AuthSession | null {
         try {
             if (!existsSync(this.sessionPath)) return null;
@@ -60,13 +68,5 @@ export class SessionManager {
         } catch {
             return null;
         }
-    }
-
-    private save(session: AuthSession): void {
-        mkdirSync(dirname(this.sessionPath), { recursive: true });
-        writeFileSync(
-            this.sessionPath,
-            JSON.stringify(session, null, 2) + '\n',
-        );
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface ProjectSettings {
+    customCommands?: {
+        defaults?: {
+            requiresAuth?: boolean;
+        };
+    };
+}
+
+export function loadProjectSettings(apijackDir: string): ProjectSettings {
+    const settingsPath = join(apijackDir, 'settings.json');
+
+    if (!existsSync(settingsPath)) return {};
+
+    try {
+        return JSON.parse(readFileSync(settingsPath, 'utf-8')) as ProjectSettings;
+    } catch {
+        return {};
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ export interface CliContext {
     auth: ResolvedAuth;
     strategy: AuthStrategy;
     refreshSession(): Promise<void>;
+    resolveSession(): Promise<void>;
+    saveSession(): Promise<void>;
+}
+
+export interface AuthedCliContext extends CliContext {
+    session: AuthSession;
 }
 
 export interface CliOptions {
@@ -24,15 +30,16 @@ export interface CliOptions {
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     allowedCidrs?: string[];
     configPath?: string;
+    customCommandDefaults?: { requiresAuth?: boolean };
 }
 
-export type CommandRegistrar = (program: Command, ctx: CliContext) => void;
+export type CommandRegistrar<R extends boolean = false> = R extends true
+    ? (program: Command, ctx: AuthedCliContext) => void
+    : (program: Command, ctx: CliContext) => void;
 
-export type DispatcherHandler = (
-    args: Record<string, unknown>,
-    positionalArgs: unknown[],
-    ctx: CliContext,
-) => Promise<unknown>;
+export type DispatcherHandler<R extends boolean = false> = R extends true
+    ? (args: Record<string, unknown>, positionalArgs: unknown[], ctx: AuthedCliContext) => Promise<unknown>
+    : (args: Record<string, unknown>, positionalArgs: unknown[], ctx: CliContext) => Promise<unknown>;
 
 export interface CustomResolverHelpers {
     /** Resolve `$refs` and built-in functions inside a string against the current routine context. */

--- a/tests/custom-command-auth.test.ts
+++ b/tests/custom-command-auth.test.ts
@@ -1,0 +1,420 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createCli } from '../src/cli-builder';
+import type { CliOptions, CliContext } from '../src/types';
+import { BasicAuthStrategy } from '../src/auth/basic';
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeOptions(overrides: Partial<CliOptions> = {}): CliOptions {
+    return {
+        name: 'testcli',
+        description: 'A test CLI',
+        version: '1.0.0',
+        specPath: '/v3/api-docs',
+        auth: new BasicAuthStrategy(),
+        outputModes: ['json'],
+        ...overrides,
+    };
+}
+
+async function captureOutput(fn: () => Promise<void>): Promise<void> {
+    const origLog = console.log;
+    const origErr = console.error;
+
+    console.log = () => {};
+    console.error = () => {};
+
+    try {
+        await fn();
+    } catch {
+        // process.exit is mocked to throw
+    } finally {
+        console.log = origLog;
+        console.error = origErr;
+    }
+}
+
+describe('custom command requiresAuth + ctx.saveSession / ctx.resolveSession', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+    let sessionPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-ctx-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+        sessionPath = join(testConfigDir, 'session.json');
+
+        writeFileSync(
+            configPath,
+            JSON.stringify({
+                active: 'default',
+                environments: {
+                    default: {
+                        url: 'http://localhost:8080',
+                        user: 'testuser',
+                        password: 'testpass',
+                    },
+                },
+            }),
+        );
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('ctx exposes resolveSession and saveSession methods', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let capturedCtx: CliContext | null = null;
+
+        cli.command('capture', (program, ctx) => {
+            program.command('capture').action(() => {
+                capturedCtx = ctx;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'capture'];
+
+        await captureOutput(() => cli.run());
+
+        expect(capturedCtx).not.toBeNull();
+        expect(typeof capturedCtx!.resolveSession).toBe('function');
+        expect(typeof capturedCtx!.saveSession).toBe('function');
+    });
+
+    test('requiresAuth: true resolves session before the action runs', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'needs-auth',
+            (program, ctx) => {
+                program.command('needs-auth').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'needs-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+        expect(sessionAtAction).toHaveProperty('headers');
+    });
+
+    test('requiresAuth: false leaves ctx.session null (existing behavior)', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command('no-auth', (program, ctx) => {
+            program.command('no-auth').action(() => {
+                sessionAtAction = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'no-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('customCommandDefaults.requiresAuth applies when per-command flag is unset', async () => {
+        const cli = createCli(
+            makeOptions({ configPath, customCommandDefaults: { requiresAuth: true } }),
+        );
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command('default-auth', (program, ctx) => {
+            program.command('default-auth').action(() => {
+                sessionAtAction = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'default-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+    });
+
+    test('per-command requiresAuth: false overrides settings default true', async () => {
+        const cli = createCli(
+            makeOptions({ configPath, customCommandDefaults: { requiresAuth: true } }),
+        );
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'explicit-off',
+            (program, ctx) => {
+                program.command('explicit-off').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: false },
+        );
+
+        process.argv = ['node', 'testcli', 'explicit-off'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('--dry-run skips requiresAuth preAction hook', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'preview-skip',
+            (program, ctx) => {
+                program.command('preview-skip').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'preview-skip', '--dry-run'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('-o routine-step skips requiresAuth preAction hook', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let actionRan = false;
+
+        cli.command(
+            'step-skip',
+            (program) => {
+                program.command('step-skip').action(() => {
+                    actionRan = true;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'step-skip', '-o', 'routine-step'];
+
+        await captureOutput(() => cli.run());
+
+        // routine-step exits before our action runs; we only care that it didn't crash on auth resolution
+        expect(actionRan).toBe(false);
+    });
+
+    test('ctx.saveSession() persists ctx.session to disk', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        cli.command(
+            'save',
+            (program, ctx) => {
+                program.command('save').action(async () => {
+                    ctx.session = { headers: { Authorization: 'Bearer new-token' } };
+                    await ctx.saveSession();
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'save'];
+
+        await captureOutput(() => cli.run());
+
+        expect(existsSync(sessionPath)).toBe(true);
+        const persisted = JSON.parse(readFileSync(sessionPath, 'utf-8'));
+        expect(persisted.headers.Authorization).toBe('Bearer new-token');
+    });
+
+    test('ctx.saveSession() with null ctx.session invalidates the session file', async () => {
+        writeFileSync(sessionPath, JSON.stringify({ headers: { Authorization: 'old' } }));
+
+        const cli = createCli(makeOptions({ configPath }));
+
+        cli.command('wipe', (program, ctx) => {
+            program.command('wipe').action(async () => {
+                ctx.session = null;
+                await ctx.saveSession();
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'wipe'];
+
+        await captureOutput(() => cli.run());
+
+        expect(existsSync(sessionPath)).toBe(false);
+    });
+
+    test('requiresAuth hook fires even when registrar adds a differently-named top-level subcommand', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'alias-name',
+            (program, ctx) => {
+                // Registrar intentionally uses a different name than the one passed to cli.command()
+                program.command('real-name').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'real-name'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+    });
+
+    test('ctx.resolveSession() populates ctx.session on demand', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionBefore: unknown = 'unset';
+        let sessionAfter: unknown = 'unset';
+
+        cli.command('manual', (program, ctx) => {
+            program.command('manual').action(async () => {
+                sessionBefore = ctx.session;
+                await ctx.resolveSession();
+                sessionAfter = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'manual'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionBefore).toBeNull();
+        expect(sessionAfter).not.toBeNull();
+        expect(sessionAfter).toHaveProperty('headers');
+    });
+});
+
+describe('dispatcher requiresAuth', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-disp-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+
+        writeFileSync(
+            configPath,
+            JSON.stringify({
+                active: 'default',
+                environments: {
+                    default: {
+                        url: 'http://localhost:8080',
+                        user: 'testuser',
+                        password: 'testpass',
+                    },
+                },
+            }),
+        );
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('requiresAuth dispatcher resolves session before the handler runs', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionInHandler: unknown = 'unset';
+
+        cli.dispatcher(
+            'do-thing',
+            async (_args, _pos, ctx) => {
+                sessionInHandler = ctx.session;
+
+                return { ok: true };
+            },
+            { requiresAuth: true },
+        );
+
+        // Drive the dispatcher through a routine file
+        const routinesDir = join(testConfigDir, 'routines');
+        mkdirSync(routinesDir, { recursive: true });
+        writeFileSync(
+            join(routinesDir, 'run-disp.yml'),
+            `name: run-disp
+steps:
+  - name: call
+    command: do-thing
+`,
+        );
+
+        process.argv = ['node', 'testcli', 'routine', 'run', 'run-disp'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionInHandler).not.toBeNull();
+        expect(sessionInHandler).toHaveProperty('headers');
+    });
+
+    test('non-requiresAuth dispatcher leaves ctx.session null', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionInHandler: unknown = 'unset';
+
+        cli.dispatcher('no-auth-disp', async (_args, _pos, ctx) => {
+            sessionInHandler = ctx.session;
+
+            return { ok: true };
+        });
+
+        const routinesDir = join(testConfigDir, 'routines');
+        mkdirSync(routinesDir, { recursive: true });
+        writeFileSync(
+            join(routinesDir, 'run-no-auth.yml'),
+            `name: run-no-auth
+steps:
+  - name: call
+    command: no-auth-disp
+`,
+        );
+
+        process.argv = ['node', 'testcli', 'routine', 'run', 'run-no-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionInHandler).toBeNull();
+    });
+});

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -105,10 +105,10 @@ describe('loadProjectDispatchers()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('returns empty map when no dispatchers/ dir exists', async () => {
+    test('returns empty array when no dispatchers/ dir exists', async () => {
         mkdirSync(testRoot, { recursive: true });
         const result = await loadProjectDispatchers(testRoot);
-        expect(result.size).toBe(0);
+        expect(result).toEqual([]);
     });
 
     test('loads dispatcher handlers from dispatchers/*.ts', async () => {
@@ -122,9 +122,73 @@ describe('loadProjectDispatchers()', () => {
         `);
 
         const result = await loadProjectDispatchers(testRoot);
-        expect(result.size).toBe(1);
-        expect(result.has('notify')).toBe(true);
-        expect(typeof result.get('notify')).toBe('function');
+        expect(result).toHaveLength(1);
+        expect(result[0]!.name).toBe('notify');
+        expect(typeof result[0]!.handler).toBe('function');
+        expect(result[0]!.requiresAuth).toBeUndefined();
+    });
+
+    test('reads requiresAuth export from dispatcher module', async () => {
+        const dispDir = join(testRoot, 'dispatchers');
+        mkdirSync(dispDir, { recursive: true });
+        writeFileSync(join(dispDir, 'notify-auth.ts'), `
+            export const name = 'notify-auth';
+            export const requiresAuth = true;
+            export default async function handle(args, positionalArgs, ctx) {
+                return { sent: true };
+            }
+        `);
+
+        const result = await loadProjectDispatchers(testRoot);
+        expect(result).toHaveLength(1);
+        expect(result[0]!.requiresAuth).toBe(true);
+    });
+});
+
+describe('loadProjectCommands() — requiresAuth', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('reads requiresAuth export from command module', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-auth.ts'), `
+            export const name = 'deploy-auth';
+            export const requiresAuth = true;
+            export default function register(program, ctx) {
+                program.command('deploy-auth').action(() => {});
+            }
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result).toHaveLength(1);
+        expect(result[0]!.requiresAuth).toBe(true);
+    });
+
+    test('leaves requiresAuth undefined when the export is missing', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-no-auth.ts'), `
+            export const name = 'deploy-no-auth';
+            export default function register(program, ctx) {}
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result[0]!.requiresAuth).toBeUndefined();
+    });
+
+    test('ignores non-boolean requiresAuth values', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-bad-auth.ts'), `
+            export const name = 'deploy-bad-auth';
+            export const requiresAuth = 'yes';
+            export default function register(program, ctx) {}
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result[0]!.requiresAuth).toBeUndefined();
     });
 });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { loadProjectSettings } from '../src/settings';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const testRoot = join(tmpdir(), 'apijack-settings-test-' + Date.now());
+
+describe('loadProjectSettings()', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('returns empty object when settings.json is missing', () => {
+        mkdirSync(testRoot, { recursive: true });
+        expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+
+    test('reads customCommands.defaults.requiresAuth', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(
+            join(testRoot, 'settings.json'),
+            JSON.stringify({ customCommands: { defaults: { requiresAuth: true } } }),
+        );
+
+        const settings = loadProjectSettings(testRoot);
+        expect(settings.customCommands?.defaults?.requiresAuth).toBe(true);
+    });
+
+    test('returns empty object on malformed JSON', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(join(testRoot, 'settings.json'), '{ not json');
+        expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+});


### PR DESCRIPTION
Closes #37

## Summary

- Adds `export const requiresAuth = true` for custom commands and dispatchers in `.apijack/commands/*.ts` and `.apijack/dispatchers/*.ts` — the framework resolves `ctx.session` via a `preAction` hook (commands) or handler wrap (dispatchers) before user code runs.
- Adds project-wide default via `<projectRoot>/.apijack/settings.json` under `customCommands.defaults.requiresAuth`. Module-level flag overrides it.
- Adds `ctx.resolveSession()` (public alias for the lazy resolver) and `ctx.saveSession()`. `saveSession()` with `ctx.session === null` calls `SessionManager.invalidate()`.
- Adds `AuthedCliContext` and generic `CommandRegistrar<R>` / `DispatcherHandler<R>` so `R extends true` narrows `ctx.session` to non-null.

## Design decisions (from triage)

- Settings file is project-scoped at `<projectRoot>/.apijack/settings.json`.
- Preview modes (`--dry-run`, `-o curl`, `-o routine-step`, `--help`) skip the preAction hook. `-o curl-with-creds` still resolves.
- `ctx.saveSession()` with null `ctx.session` invalidates the session file.

## Breaking change to note

`loadProjectDispatchers` return type changed from `Map<string, DispatcherHandler>` to `LoadedDispatcher[]` to carry `requiresAuth` metadata. Mirrors the existing `loadProjectCommands` shape. Only internal caller is `bin/apijack.ts`, updated here.

## Follow-up

Wiki entry for Project Mode needs updating. Wiki is gitignored in this repo; draft text is staged locally in `wiki/Project-Mode.md` for reference.

## Test plan

- [x] `bun test` — 731 pass / 0 fail (17 new tests covering the flag, settings resolution, preview-mode skip, `saveSession` persist/invalidate, name-mismatch subcommand).
- [x] `bun run lint` — 0 errors.
- [x] CI E2E green.