### PR TITLE
v1.8.0: opt-in auth resolution for custom commands and dispatchers

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: implement-issue
+description: Use when a GitHub issue has been triaged and is ready for implementation on the apijack repo — creates the issue branch, implements, tests, self-reviews, and opens a PR to dev
+---
+
+# Implement Issue
+
+Phase 2 of the apijack issue workflow. Turn a triaged issue into a reviewed PR against `dev`.
+
+## When to Use
+
+- After `triage-issue` has clarified the issue and handed off
+- User explicitly asks to implement a specific, already-clear issue
+
+Do not invoke this skill before triage is complete. If the issue has not been triaged, invoke `triage-issue` first.
+
+## Steps
+
+### 1. Create the issue branch
+
+Slugify the issue title: lowercase, hyphenated, drop filler words, aim for 3–5 words.
+
+```bash
+git fetch origin
+git checkout dev && git pull origin dev
+git checkout -b issues/<number>-<short-slug>
+```
+
+Example: `issues/37-opt-in-auth` for issue #37 "Make auth opt-in".
+
+### 2. Plan or implement
+
+If the issue is clear and small (single obvious change): implement directly.
+
+If **any** of the following are true, invoke the brainstorming skill first to plan:
+- Multiple files affected and the structure isn't obvious
+- Public API or generated code output changes
+- Multiple viable approaches with real tradeoffs
+
+```
+Skill(skill="superpowers:brainstorming")
+```
+
+### 3. Implement
+
+- Follow existing patterns in the codebase
+- Keep changes focused on the issue — no drive-by refactors
+- Add or update tests alongside code changes
+- If MCP server code changed (`src/mcp-server*.ts`), run `bun run build:plugin`
+
+### 4. Self-review
+
+Use a subagent for an independent second pair of eyes:
+
+```
+Skill(skill="superpowers:requesting-code-review")
+```
+
+Address any issues it raises before moving on.
+
+### 5. Verify
+
+All must pass before PR:
+
+```bash
+bun test              # unit tests — all green
+bun run lint          # 0 errors
+```
+
+E2E tests run in CI after push (`.github/workflows/e2e.yml`). If you touched codegen, tutorial, or auth flows, expect E2E to exercise them.
+
+### 6. Commit and push
+
+Use a conventional commit message (`feat:`, `fix:`, `chore:`, `docs:`) that references the issue:
+
+```bash
+git add <files>
+git commit -m "fix: <description> (#<issue-number>)"
+git push -u origin issues/<number>-<slug>
+```
+
+Do not include Co-Authored-By lines.
+
+### 7. Open PR to dev
+
+```bash
+gh pr create --base dev --title "<type>: <description> (#<issue-number>)" --body "$(cat <<'EOF'
+Closes #<issue-number>
+
+## Summary
+<1-3 bullets>
+
+## Test plan
+- [ ] bun test passes
+- [ ] bun run lint passes
+- [ ] E2E CI green
+EOF
+)"
+```
+
+### 8. Wait for CI
+
+```bash
+gh pr checks <pr-number> --watch
+```
+
+If CI fails, fix on the branch, push, and re-watch. Do not merge.
+
+## STOP
+
+Once the PR is open and CI is green, **work is done**. Do not merge. Do not invoke any other skill. Report the PR URL to the user and stop.
+
+## Red Flags
+
+- "I'll skip the subagent review, the change is small" → STOP, run it anyway
+- "Tests fail but it's unrelated" → STOP, investigate
+- "I'll merge and fix later" → STOP, you do not merge in this skill
+- "I'll PR to main" → STOP, PRs target `dev`

--- a/.claude/skills/next-deployer/SKILL.md
+++ b/.claude/skills/next-deployer/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: next-deployer
+description: Use after merging an issue PR to dev on apijack — fast-forwards the rolling next branch from dev, waits for the publish-next workflow, and comments the @next install command on the issue
+---
+
+# Next Deployer
+
+Phase 4 (terminal) of the apijack issue workflow. Roll `next` forward to `dev` and announce the pre-release on the issue.
+
+## Background
+
+`next` is the "nightly" / edge rolling branch. Pushing to `next` triggers the `publish-next` job in `.github/workflows/publish.yml`, which computes and publishes a `X.Y.Z-next.N` version to npm under the `@next` dist-tag.
+
+## When to Use
+
+- Invoked by `review-issue` immediately after merging an issue PR to `dev`
+- User explicitly asks to deploy the current `dev` state to `next`
+
+## Steps
+
+### 1. Sync dev locally
+
+```bash
+git fetch origin
+git checkout dev && git pull origin dev
+```
+
+### 2. Check if next is behind dev
+
+```bash
+git fetch origin next
+BEHIND=$(git rev-list --count origin/next..origin/dev)
+echo "next is behind dev by $BEHIND commits"
+```
+
+If `BEHIND` is `0`: `next` is already up to date — skip to step 4.
+
+### 3. Fast-forward next from dev and push
+
+```bash
+git checkout next 2>/dev/null || git checkout -b next origin/next
+git merge --ff-only origin/dev
+git push origin next
+```
+
+If fast-forward fails (next has diverged), STOP and ask the user how to proceed — do not force-push.
+
+Return to `dev`:
+
+```bash
+git checkout dev
+```
+
+### 4. Wait for publish-next workflow
+
+```bash
+# Find the run triggered by this push
+RUN_ID=$(gh run list --workflow publish.yml --branch next --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --exit-status
+```
+
+If the run fails:
+
+```bash
+gh run view "$RUN_ID" --log-failed
+```
+
+STOP, report the failure to the user, and do not comment on the issue.
+
+### 5. Get the published version
+
+```bash
+NEXT_VERSION=$(npm view @apijack/core@next version)
+echo "Published: $NEXT_VERSION"
+```
+
+Expect a value like `1.8.0-next.1`.
+
+### 6. Comment on the issue and label it
+
+```bash
+gh issue comment <issue-number> --repo normalled/apijack --body "$(cat <<EOF
+Fix deployed to \`next\`. Install the exact version:
+
+\`\`\`bash
+bun install -g @apijack/core@$NEXT_VERSION
+\`\`\`
+EOF
+)"
+```
+
+Add the `deployed to next` label so the issue's lifecycle stage is visible at a glance:
+
+```bash
+gh issue edit <issue-number> --repo normalled/apijack --add-label "deployed to next"
+```
+
+Substitute `<issue-number>` with the argument passed in from `review-issue`, or parse it from the merge commit body (`Closes #NN`).
+
+### 7. STOP
+
+Report to the user:
+- `next` was advanced (or was already current)
+- Published version
+- Issue comment URL
+- Issue labeled `deployed to next`
+
+Do not chain into further skills. The workflow is complete.
+
+## Red Flags
+
+- `next` has diverged from `dev` (non-fast-forward) → STOP, ask user; never force-push
+- Publish workflow failed → STOP, do not comment on issue
+- Cannot determine issue number → STOP, ask user

--- a/.claude/skills/review-issue/SKILL.md
+++ b/.claude/skills/review-issue/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: review-issue
+description: Use when reviewing an open apijack PR that targets the dev branch — verifies acceptance criteria, leaves PR comments on any findings, or merges and hands off to next-deployer
+---
+
+# Review Issue PR
+
+Phase 3 of the apijack issue workflow. Review a PR targeting `dev` against the linked issue's acceptance criteria.
+
+## When to Use
+
+- User asks to review an open PR on the apijack repo
+- Only for PRs whose **base is `dev`** — refuse to proceed if base is `main` or any other branch
+
+## Steps
+
+### 1. Load the PR and linked issue
+
+```bash
+gh pr view <pr-number> --comments
+gh pr diff <pr-number>
+gh pr checks <pr-number>
+```
+
+Find the linked issue (`Closes #NN` in the body) and load it:
+
+```bash
+gh issue view <issue-number> --comments
+```
+
+**Abort if the base branch is not `dev`** — tell the user and stop.
+
+### 1.5. Apply "review in progress" label
+
+Ensure the three workflow labels exist (idempotent — safe to run every time):
+
+```bash
+gh label create "review in progress" --color "FBCA04" --description "Review is actively underway" 2>/dev/null || true
+gh label create "first pass reviewed"  --color "0E8A16" --description "Review passed with no blocking issues" 2>/dev/null || true
+gh label create "changes requested"    --color "D93F0B" --description "Review found blocking issues" 2>/dev/null || true
+```
+
+Apply the in-progress label and remove any stale outcome labels from a previous review cycle (including the intake `needs review` label added by the auto-label workflow):
+
+```bash
+gh pr edit <pr-number> --add-label "review in progress"
+gh pr edit <pr-number> --remove-label "needs review"        2>/dev/null || true
+gh pr edit <pr-number> --remove-label "first pass reviewed" 2>/dev/null || true
+gh pr edit <pr-number> --remove-label "changes requested"   2>/dev/null || true
+```
+
+### 2. Establish acceptance criteria
+
+- **Explicit** — issue lists them → use those
+- **Narrow scope** — issue is a simple, well-defined fix → improvise minimal criteria (the bug no longer reproduces, relevant tests added)
+- **Involved scope** — issue is multi-faceted and criteria are unclear → STOP and ask the user how to proceed
+
+### 3. Review
+
+Check each of:
+
+- **Correctness**: does the diff actually solve the issue?
+- **Acceptance criteria**: each criterion met?
+- **Tests**: new behavior is tested; existing tests still pass (CI green)
+- **Scope**: no unrelated changes smuggled in
+- **Style/consistency**: matches the surrounding codebase
+- **Backwards compatibility**: public API and generated output unchanged unless the issue explicitly asks
+
+For a structured review, invoke the code-review skill on the diff:
+
+```
+Skill(skill="superpowers:requesting-code-review")
+```
+
+### 4. Decide
+
+**If ANY blocking issue is found OR any acceptance criterion is unmet:**
+
+Build the review body using GitHub-flavored markdown. Blocking items appear at the top; non-blocking observations and nits are hidden in collapsible `<details>` blocks. Omit any section that has no items.
+
+```
+<1-2 sentence summary of what is blocking the merge>
+
+**Blocking:**
+- <blocking item 1>
+- <blocking item 2>
+
+<details>
+<summary>Non-blocking observations</summary>
+
+- <observation 1>
+- <observation 2>
+
+</details>
+
+<details>
+<summary>Nitpicks</summary>
+
+- <nitpick 1>
+
+</details>
+
+Reviewed by claude 🤖
+```
+
+Post the review and request changes:
+
+```bash
+gh pr review <pr-number> --request-changes --body "<body from template above>"
+# plus inline comments via the GitHub UI or gh api if needed
+```
+
+Update labels — remove in-progress, add outcome label, ensure the opposite outcome label is absent:
+
+```bash
+gh pr edit <pr-number> --remove-label "review in progress"
+gh pr edit <pr-number> --remove-label "first pass reviewed" 2>/dev/null || true
+gh pr edit <pr-number> --add-label "changes requested"
+```
+
+Then **STOP**. Report findings to the user and end.
+
+**If AND ONLY IF all criteria are met and no blocking issues are found (only non-blocking observations / nits, or nothing at all):**
+
+Build the review body — skip the **Blocking:** section entirely. Only include non-empty `<details>` blocks for observations/nits:
+
+```
+<1-2 sentence summary confirming the PR looks good>
+
+<details>
+<summary>Non-blocking observations</summary>
+
+- <observation 1>
+
+</details>
+
+<details>
+<summary>Nitpicks</summary>
+
+- <nitpick 1>
+
+</details>
+
+Reviewed by claude 🤖
+```
+
+Post a non-blocking comment (does not block merging):
+
+```bash
+gh pr review <pr-number> --comment --body "<body from template above>"
+```
+
+Update labels — remove in-progress, add outcome label, ensure the opposite outcome label is absent:
+
+```bash
+gh pr edit <pr-number> --remove-label "review in progress"
+gh pr edit <pr-number> --remove-label "changes requested"   2>/dev/null || true
+gh pr edit <pr-number> --add-label "first pass reviewed"
+```
+
+Merge the PR:
+
+```bash
+gh pr merge <pr-number> --merge --delete-branch
+```
+
+Then invoke the next skill:
+
+```
+Skill(skill="next-deployer", args="<issue-number>")
+```
+
+## Red Flags — Do Not Merge
+
+- "CI is red but I know it's flaky" → STOP
+- "The PR targets main" → STOP, do not review here
+- "Acceptance criteria are missing but I'll guess" → STOP, ask the user
+- "There are nits but I'll merge anyway" → leave comments, do not merge
+- "I'll squash-merge" → use plain `--merge` to preserve history on `dev`
+
+## Output
+
+Either: PR comments + "changes requested" review and STOP, or: merged to `dev` and handed off to `next-deployer`.

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: ship-release
+description: Use when shipping a release from dev to main on apijack — drafts a curated release-style PR title/description (like v1.7.0), then runs scripts/ship.sh to version-bump, push, merge, and publish
+---
+
+# Ship Release
+
+The PR that merges `dev` into `main` *is* the release notes on GitHub. `scripts/ship.sh` auto-creates a bland "dev → main (N commits)" PR if none exists — so this skill creates the curated PR first, then lets ship.sh pick it up.
+
+## When to Use
+
+- User says "ship", "cut a release", "release to main", or similar
+- There are commits on `dev` that are not yet on `main`
+- **Not** for mid-development PRs targeting `dev` (use `dev-workflow` for those)
+
+## Preflight
+
+```bash
+git branch --show-current          # must be dev
+git status --porcelain             # must be empty
+git fetch origin
+git log origin/main..HEAD --oneline
+```
+
+Abort and tell the user if:
+- Not on `dev`, or working tree is dirty
+- No commits ahead of main (nothing to ship)
+- An open PR already exists from `dev` → `main` with a curated body (check `gh pr list --head dev --base main`). If so, skip to step 5.
+
+## Step 1: Compute the next version
+
+Mirror the logic in `scripts/ship.sh`:
+
+```bash
+RANGE=origin/main..HEAD
+git log $RANGE --pretty=format:"%s%n%b" > /tmp/ship-commits.txt
+```
+
+- Contains `BREAKING CHANGE` → **major**
+- Contains a line starting with `feat` → **minor**
+- Otherwise → **patch**
+
+Read `package.json` version and bump accordingly. Call this `NEW_VERSION`.
+
+## Step 2: Categorize commits
+
+Group commits from `git log origin/main..HEAD --pretty=format:"%s"` into buckets. **Skip merge commits and the `chore(release):` bump** (ship.sh adds its own).
+
+| Bucket | Matches | PR section |
+|---|---|---|
+| Features | `feat(...)`, `feat: ...` | `## ✨ Features` |
+| Fixes | `fix(...)`, `fix: ...` | `## 🐛 Fixes` |
+| Breaking / Behavior | commits with `BREAKING CHANGE` body, or reviewer-flagged behavior changes | `## ⚠ Changed` |
+| Internal | `chore:`, `docs:`, `test:`, `refactor:`, `ci:` | `## 🧹 Internal` |
+
+For each commit, look up the PR number (often `(#NN)` in the subject, or `gh pr list --state merged --search "<commit-subject>"`) so entries read like `**Feature name** (#30) — one-sentence impact.`
+
+**Write for humans, not for git.** A bullet should answer "what does this do for the user?" not restate the commit subject.
+
+## Step 3: Draft the PR title and body
+
+**Title format:** `v<NEW_VERSION>: <comma-separated highlights>`
+
+- 2–4 highlights max, taken from the Features bucket
+- Example: `v1.7.0: custom resolvers, $_find / $_contains, $_env, auth challenges`
+
+### Concision rules — this body IS the GitHub release note
+
+The PR body is pasted verbatim into the GitHub release. Keep it skimmable.
+
+- **Link, don't duplicate.** Every bullet ends in `(#NN)`. The linked PR has the design, rationale, migration notes, before/after examples, and internal trade-offs. Do not restate them here.
+- **One bullet per feature**, not one per export / setting / helper. If three related additions all ship together, combine them into one bullet. Every `(#37)` appearing 3 times in a row is a smell — merge.
+- **Internal section is one line** — "Claude Code skills for the dev loop" beats listing every skill name. If there's nothing user-facing, drop the section entirely.
+- **No surface-level tables** unless the release adds a genuinely new YAML/API surface worth an at-a-glance reference (PR #36 earned its table with 4 new routine built-ins). Single-feature releases don't need one.
+- **Target length:** thesis + Features + (optional) Fixes + (optional) one-line Internal. If the body is longer than ~20 lines for a single-feature release, cut.
+- **Rule of thumb:** if a reader could get the same information by clicking the `(#NN)` link, delete it.
+
+**Body structure** (omit sections that have no entries):
+
+```markdown
+<1–2 sentence thesis describing the release's focus.>
+
+## ✨ Features
+
+- **<feature name>** (#NN) — <one-sentence user-facing impact>.
+- ...
+
+## 🐛 Fixes
+
+- **<fix summary>** (#NN) — <what was broken, what now works>.
+
+## ⚠ Changed
+
+- **<what changed>** (#NN) — <who's affected, what they need to do>.
+
+## 🧹 Internal
+
+- <one line max, or omit the section>.
+
+---
+
+Shipped via `scripts/ship.sh`.
+```
+
+The trailing `Shipped via scripts/ship.sh.` line matches ship.sh's auto-generated footer — keep it.
+
+Reference releases:
+- **PR #36 (v1.7.0)** — multi-feature release; earns its table and longer sections.
+- **PR #40 (v1.8.0)** — single-feature release; tight body, one combined bullet per concept, no table.
+
+Match the density to the release, not to a template.
+
+## Step 4: Present to the user, then create the PR
+
+Show the drafted title and body in the chat. Ask for approval or edits before creating the PR — this is the release notes, so it's worth a human read.
+
+Once approved:
+
+```bash
+git push -u origin dev
+gh pr create --base main --head dev --title "<title>" --body "<body>"
+```
+
+Use a heredoc for the body to preserve markdown formatting.
+
+## Step 5: Run ship.sh
+
+```bash
+./scripts/ship.sh
+```
+
+ship.sh will:
+1. Bump the version (adds a `chore(release): vX.Y.Z` commit on dev and pushes) — the existing PR picks up the new commit automatically
+2. Find the existing PR (won't overwrite the curated title/body)
+3. Wait for CI
+4. Merge via `gh pr merge --merge --admin`
+5. Watch the publish workflow
+6. Sync main and rebase dev
+
+If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off.
+
+## Red Flags
+
+- **ship.sh created a `dev → main (N commits)` PR before you drafted one** → ship.sh ran first. Either update the PR title/body via `gh pr edit <num> --title ... --body ...` before the merge completes, or let it merge and edit the GitHub release afterward.
+- **Title is longer than ~80 chars** → trim highlights to the 2–3 most notable.
+- **Body reads like `git log` output** → rewrite bullets from the user's perspective.
+- **You included the `chore(release):` commit as a bullet** → remove it; it's noise.

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: triage-issue
+description: Use when the user references a GitHub issue (URL, number, or says "this issue") on the apijack repo and wants to begin work — investigates the issue, resolves ambiguity, then hands off to implementation
+---
+
+# Triage Issue
+
+Phase 1 of the apijack issue workflow. Investigate and disambiguate a GitHub issue before any code is written.
+
+## When to Use
+
+- User provides a GitHub issue URL or number for the apijack repo
+- User says "let's work on issue X" or "triage this issue"
+- Entry point for the issue-handling workflow (triage → implement → review → next-deployer)
+
+## Steps
+
+### 1. Fetch the issue
+
+```bash
+gh issue view <number> --repo normalled/apijack --comments --json number,title,body,labels,comments
+```
+
+Read the title, body, labels, and all comments.
+
+**Label gate:** the issue MUST have the `needs triage` label to proceed. If it doesn't:
+
+- The issue may already be triaged — STOP and confirm with the user before continuing.
+- If the user confirms re-triage is intended, proceed.
+
+To list issues that are ready to triage:
+
+```bash
+gh issue list --repo normalled/apijack --label "needs triage" --state open
+```
+
+### 2. Investigate
+
+- Read any files the issue names or implies
+- Check recent commits touching the same area: `git log --oneline -- <path>`
+- Look at related PRs or linked issues if mentioned
+- Confirm the issue still reproduces (if it's a bug) — run the command, read the code path
+
+### 3. Assess clarity
+
+Decide: is there enough detail to proceed to implementation without guessing?
+
+**STOP and ask the user if ANY of these apply:**
+- The issue is ambiguous (multiple valid interpretations of the ask)
+- The issue mentions a **workaround** — surface it and ask whether to fix the root cause, document the workaround, or do both
+- Scope is unclear (small fix vs. broader refactor)
+- Acceptance criteria are missing AND the change is non-trivial
+- The fix could affect backwards compatibility or public API
+
+When asking, be specific: "The issue mentions X workaround — should I [A] fix the underlying cause, [B] make the workaround the documented solution, or [C] both?"
+
+### 4. Summarize and hand off
+
+Once the issue is clear, output a short summary:
+
+- **Issue**: #NN — title
+- **Root cause / desired behavior**: one or two sentences
+- **Proposed approach**: one or two sentences
+- **Acceptance criteria**: bullet list (explicit from the issue, or improvised if narrow scope)
+
+Remove the `needs triage` label now that triage is complete:
+
+```bash
+gh issue edit <number> --repo normalled/apijack --remove-label "needs triage"
+```
+
+Then invoke the next skill via the `Skill` tool:
+
+```
+Skill(skill="implement-issue", args="<issue number>")
+```
+
+## Red Flags — Do Not Proceed
+
+- "I'll figure out the ambiguity during implementation" → STOP, ask now
+- "The workaround is fine, I'll just add a note" → STOP, confirm with user
+- "The scope seems bigger than the issue says" → STOP, confirm with user
+
+## Output
+
+Your handoff to `implement-issue` must include the issue number and the summary above. Do not start implementing in this phase.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 bun.lockb
 .env
 *.local.*
+.local
 .apijack/
 
 # Superpowers docs (plans & specs)

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -10,6 +10,7 @@ import { BearerTokenStrategy } from '../src/auth/bearer';
 import { ApiKeyStrategy } from '../src/auth/api-key';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir } from '../src/project';
 import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
+import { loadProjectSettings } from '../src/settings';
 import { checkForUpdate } from '../src/updater';
 import { getActiveEnvConfig } from '../src/config';
 import pkg from '../package.json';
@@ -131,7 +132,12 @@ let sessionAuth: SessionAuthConfig | undefined;
     }
 }
 
-// 8. Create CLI
+// 8. Load project settings (framework-level flags, separate from per-env config)
+const projectSettings = projectRoot
+    ? loadProjectSettings(join(projectRoot, '.apijack'))
+    : {};
+
+// 9. Create CLI
 const cli = createCli({
     name: CLI_NAME,
     description: 'Jack into any OpenAPI spec and rip a full-featured CLI',
@@ -142,20 +148,21 @@ const cli = createCli({
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,
     configPath: join(configDir, 'config.json'),
+    customCommandDefaults: projectSettings.customCommands?.defaults,
 });
 
-// 9. Register project-level extensions
+// 10. Register project-level extensions
 if (projectRoot) {
     const commands = await loadProjectCommands(join(projectRoot, '.apijack'));
 
     for (const cmd of commands) {
-        cli.command(cmd.name, cmd.registrar);
+        cli.command(cmd.name, cmd.registrar, { requiresAuth: cmd.requiresAuth });
     }
 
     const dispatchers = await loadProjectDispatchers(join(projectRoot, '.apijack'));
 
-    for (const [name, handler] of dispatchers) {
-        cli.dispatcher(name, handler);
+    for (const disp of dispatchers) {
+        cli.dispatcher(disp.name, disp.handler, { requiresAuth: disp.requiresAuth });
     }
 
     const resolvers = await loadProjectResolvers(join(projectRoot, '.apijack'));
@@ -165,5 +172,5 @@ if (projectRoot) {
     }
 }
 
-// 10. Run
+// 11. Run
 await cli.run();

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.7.0",
+  "version": "1.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -27,9 +27,17 @@ import { resolveRequestHeaders } from './auth/resolve-headers';
 import { deepMergeSessionAuth } from './auth/config-merge';
 import { loadPreRequestHook } from './pre-request';
 
+export interface CommandOptions {
+    requiresAuth?: boolean;
+}
+
+export interface DispatcherOptions {
+    requiresAuth?: boolean;
+}
+
 export interface Cli {
-    command(name: string, registrar: CommandRegistrar): void;
-    dispatcher(name: string, handler: DispatcherHandler): void;
+    command(name: string, registrar: CommandRegistrar, options?: CommandOptions): void;
+    dispatcher(name: string, handler: DispatcherHandler, options?: DispatcherOptions): void;
     resolver(name: string, handler: CustomResolver): void;
     run(): Promise<void>;
 }
@@ -102,8 +110,8 @@ function showCustomHelp(
 }
 
 export function createCli(options: CliOptions): Cli {
-    const consumerCommands: { name: string; registrar: CommandRegistrar }[] = [];
-    const consumerDispatchers = new Map<string, DispatcherHandler>();
+    const consumerCommands: { name: string; registrar: CommandRegistrar; requiresAuth?: boolean }[] = [];
+    const consumerDispatchers = new Map<string, { handler: DispatcherHandler; requiresAuth?: boolean }>();
     const consumerResolvers = new Map<string, CustomResolver>();
     const cliName = options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
@@ -112,14 +120,17 @@ export function createCli(options: CliOptions): Cli {
         : join(homedir(), `.${cliName}`);
     const routinesDir = join(configDir, 'routines');
     const generatedDir = options.generatedDir ?? join(process.cwd(), 'src', 'generated');
+    const defaultRequiresAuth = options.customCommandDefaults?.requiresAuth ?? false;
+    const effectiveRequiresAuth = (explicit: boolean | undefined): boolean =>
+        explicit ?? defaultRequiresAuth;
 
     const cli: Cli = {
-        command(name: string, registrar: CommandRegistrar): void {
-            consumerCommands.push({ name, registrar });
+        command(name: string, registrar: CommandRegistrar, cmdOpts?: CommandOptions): void {
+            consumerCommands.push({ name, registrar, requiresAuth: cmdOpts?.requiresAuth });
         },
 
-        dispatcher(name: string, handler: DispatcherHandler): void {
-            consumerDispatchers.set(name, handler);
+        dispatcher(name: string, handler: DispatcherHandler, dispOpts?: DispatcherOptions): void {
+            consumerDispatchers.set(name, { handler, requiresAuth: dispOpts?.requiresAuth });
         },
 
         resolver(name: string, handler: CustomResolver): void {
@@ -264,7 +275,23 @@ export function createCli(options: CliOptions): Cli {
             const isDryRun = process.argv.includes('--dry-run') && process.argv[2] !== 'routine';
             const isCurl = oVal === 'curl';
             const isCurlWithCreds = oVal === 'curl-with-creds';
+            const isRoutineStep = oVal === 'routine-step';
             const isRequestPreview = isDryRun || isCurl || isCurlWithCreds;
+            // Skip auth resolution for preview/inspection modes. curl-with-creds still resolves.
+            const skipAuthResolution = isRoutineStep || isDryRun || isCurl || isHelpOrVersion;
+
+            // Shared session resolver — lazy, runs on first API request or explicit consumer call
+            const resolveSession = async (): Promise<void> => {
+                if (!resolved || !sessionMgr) {
+                    throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                }
+
+                if (ctx && ctx.session) return;
+
+                const session = await sessionMgr.resolve(strategy, resolved);
+
+                if (ctx) ctx.session = session;
+            };
 
             // 8. Create CliContext with lazy session
             let ctx: CliContext | null = null;
@@ -279,6 +306,18 @@ export function createCli(options: CliOptions): Cli {
                         sessionMgr!.invalidate();
                         ctx!.session = await sessionMgr!.resolve(strategy, resolved!);
                     },
+                    resolveSession,
+                    saveSession: async () => {
+                        if (!sessionMgr) {
+                            throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                        }
+
+                        if (ctx!.session) {
+                            sessionMgr.save(ctx!.session);
+                        } else {
+                            sessionMgr.invalidate();
+                        }
+                    },
                 };
             }
 
@@ -287,19 +326,6 @@ export function createCli(options: CliOptions): Cli {
                 const registerFn = commandsModule.registerGeneratedCommands as (
                     program: Command, client: unknown, onResult: (result: unknown) => void,
                 ) => void;
-
-                // Session resolver — lazy, runs once on first real API request
-                const resolveSession = async () => {
-                    if (!resolved || !sessionMgr) {
-                        throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
-                    }
-
-                    if (ctx && ctx.session) return;
-
-                    const session = await sessionMgr.resolve(strategy, resolved);
-
-                    if (ctx) ctx.session = session;
-                };
 
                 // Headers provider — reads from resolved session
                 const getHeaders = (method: string) =>
@@ -402,9 +428,34 @@ export function createCli(options: CliOptions): Cli {
                 registerFn(program, client, onResult);
             }
 
-            // 10. Register consumer commands
-            for (const { registrar } of consumerCommands) {
+            // 10. Register consumer commands and attach per-command requiresAuth preAction hooks.
+            // Track the actual Command instances each registrar adds (not just the logical name),
+            // so the hook still fires if the registrar names its subcommand differently.
+            const requiresAuthCommands = new Set<Command>();
+
+            for (const { registrar, requiresAuth } of consumerCommands) {
+                const before = new Set(program.commands);
+                // When auth is not configured, ctx is null. Consumers should only touch ctx
+                // inside action callbacks (which won't run until run() is further along).
                 registrar(program, ctx ?? (null as unknown as CliContext));
+
+                if (effectiveRequiresAuth(requiresAuth)) {
+                    for (const cmd of program.commands) {
+                        if (!before.has(cmd)) requiresAuthCommands.add(cmd);
+                    }
+                }
+            }
+
+            if (requiresAuthCommands.size > 0 && !skipAuthResolution) {
+                program.hook('preAction', async (_thisCommand, actionCommand) => {
+                    let cmd: Command = actionCommand;
+
+                    while (cmd.parent && cmd.parent !== program) cmd = cmd.parent;
+
+                    if (requiresAuthCommands.has(cmd)) {
+                        await resolveSession();
+                    }
+                });
             }
 
             // 11. Build dispatcher
@@ -431,11 +482,30 @@ export function createCli(options: CliOptions): Cli {
 
             const customResolvers = consumerResolvers.size > 0 ? consumerResolvers : undefined;
 
+            // Unwrap dispatcher entries and wrap requiresAuth handlers with ensureReady
+            let dispatcherHandlers: Map<string, DispatcherHandler> | undefined;
+
+            if (consumerDispatchers.size > 0) {
+                dispatcherHandlers = new Map();
+
+                for (const [name, entry] of consumerDispatchers) {
+                    if (effectiveRequiresAuth(entry.requiresAuth)) {
+                        dispatcherHandlers.set(name, async (args, positional, dctx) => {
+                            await resolveSession();
+
+                            return entry.handler(args, positional, dctx);
+                        });
+                    } else {
+                        dispatcherHandlers.set(name, entry.handler);
+                    }
+                }
+            }
+
             if (ctx) {
                 dispatch = buildDispatcher({
                     commandMap,
-                    client: ctx.client,
-                    consumerHandlers: consumerDispatchers.size > 0 ? consumerDispatchers : undefined,
+                    client: ctx.client as Record<string, unknown> | undefined,
+                    consumerHandlers: dispatcherHandlers,
                     customResolvers,
                     preDispatch: options.preDispatch,
                     ctx,
@@ -449,11 +519,7 @@ export function createCli(options: CliOptions): Cli {
             // 12. Register routine commands
             registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers);
 
-            // 11. Handle -o routine-step
-            const isRoutineStep
-                = process.argv.includes('-o')
-                    && process.argv[process.argv.indexOf('-o') + 1] === 'routine-step';
-
+            // 13. Handle -o routine-step
             if (isRoutineStep) {
                 program.hook('preAction', (_thisCommand, actionCommand) => {
                     const cmdParts: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,19 @@
 export { createCli } from './cli-builder';
-export type { Cli } from './cli-builder';
-export type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, CommandDispatcher, CustomResolver, CustomResolverHelpers } from './types';
+export type { Cli, CommandOptions, DispatcherOptions } from './cli-builder';
+export type {
+    CliOptions,
+    CliContext,
+    AuthedCliContext,
+    CommandRegistrar,
+    DispatcherHandler,
+    CommandDispatcher,
+    CustomResolver,
+    CustomResolverHelpers,
+} from './types';
 export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
+export type { LoadedCommand, LoadedDispatcher } from './project-loader';
+export { loadProjectSettings } from './settings';
+export type { ProjectSettings } from './settings';
 export type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from './auth/types';
 export { BasicAuthStrategy } from './auth/basic';
 export { BearerTokenStrategy } from './auth/bearer';

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -38,6 +38,7 @@ export async function loadProjectAuth(
 export interface LoadedCommand {
     name: string;
     registrar: CommandRegistrar;
+    requiresAuth?: boolean;
 }
 
 export async function loadProjectCommands(
@@ -55,9 +56,10 @@ export async function loadProjectCommands(
             const mod = await import(join(cmdDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const registrar = mod.default as CommandRegistrar;
+            const requiresAuth = typeof mod.requiresAuth === 'boolean' ? mod.requiresAuth : undefined;
 
             if (typeof registrar === 'function') {
-                commands.push({ name, registrar });
+                commands.push({ name, registrar, requiresAuth });
             }
         } catch {
             // Skip files that fail to import
@@ -67,14 +69,20 @@ export async function loadProjectCommands(
     return commands;
 }
 
+export interface LoadedDispatcher {
+    name: string;
+    handler: DispatcherHandler;
+    requiresAuth?: boolean;
+}
+
 export async function loadProjectDispatchers(
     apijackDir: string,
-): Promise<Map<string, DispatcherHandler>> {
+): Promise<LoadedDispatcher[]> {
     const dispDir = join(apijackDir, 'dispatchers');
 
-    if (!existsSync(dispDir)) return new Map();
+    if (!existsSync(dispDir)) return [];
 
-    const dispatchers = new Map<string, DispatcherHandler>();
+    const dispatchers: LoadedDispatcher[] = [];
     const files = readdirSync(dispDir).filter(f => f.endsWith('.ts'));
 
     for (const file of files) {
@@ -82,9 +90,10 @@ export async function loadProjectDispatchers(
             const mod = await import(join(dispDir, file));
             const name = mod.name ?? basename(file, '.ts');
             const handler = mod.default as DispatcherHandler;
+            const requiresAuth = typeof mod.requiresAuth === 'boolean' ? mod.requiresAuth : undefined;
 
             if (typeof handler === 'function') {
-                dispatchers.set(name, handler);
+                dispatchers.push({ name, handler, requiresAuth });
             }
         } catch {
             // Skip files that fail to import

--- a/src/session.ts
+++ b/src/session.ts
@@ -52,6 +52,14 @@ export class SessionManager {
         }
     }
 
+    save(session: AuthSession): void {
+        mkdirSync(dirname(this.sessionPath), { recursive: true });
+        writeFileSync(
+            this.sessionPath,
+            JSON.stringify(session, null, 2) + '\n',
+        );
+    }
+
     private load(): AuthSession | null {
         try {
             if (!existsSync(this.sessionPath)) return null;
@@ -60,13 +68,5 @@ export class SessionManager {
         } catch {
             return null;
         }
-    }
-
-    private save(session: AuthSession): void {
-        mkdirSync(dirname(this.sessionPath), { recursive: true });
-        writeFileSync(
-            this.sessionPath,
-            JSON.stringify(session, null, 2) + '\n',
-        );
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface ProjectSettings {
+    customCommands?: {
+        defaults?: {
+            requiresAuth?: boolean;
+        };
+    };
+}
+
+export function loadProjectSettings(apijackDir: string): ProjectSettings {
+    const settingsPath = join(apijackDir, 'settings.json');
+
+    if (!existsSync(settingsPath)) return {};
+
+    try {
+        return JSON.parse(readFileSync(settingsPath, 'utf-8')) as ProjectSettings;
+    } catch {
+        return {};
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,12 @@ export interface CliContext {
     auth: ResolvedAuth;
     strategy: AuthStrategy;
     refreshSession(): Promise<void>;
+    resolveSession(): Promise<void>;
+    saveSession(): Promise<void>;
+}
+
+export interface AuthedCliContext extends CliContext {
+    session: AuthSession;
 }
 
 export interface CliOptions {
@@ -24,15 +30,16 @@ export interface CliOptions {
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     allowedCidrs?: string[];
     configPath?: string;
+    customCommandDefaults?: { requiresAuth?: boolean };
 }
 
-export type CommandRegistrar = (program: Command, ctx: CliContext) => void;
+export type CommandRegistrar<R extends boolean = false> = R extends true
+    ? (program: Command, ctx: AuthedCliContext) => void
+    : (program: Command, ctx: CliContext) => void;
 
-export type DispatcherHandler = (
-    args: Record<string, unknown>,
-    positionalArgs: unknown[],
-    ctx: CliContext,
-) => Promise<unknown>;
+export type DispatcherHandler<R extends boolean = false> = R extends true
+    ? (args: Record<string, unknown>, positionalArgs: unknown[], ctx: AuthedCliContext) => Promise<unknown>
+    : (args: Record<string, unknown>, positionalArgs: unknown[], ctx: CliContext) => Promise<unknown>;
 
 export interface CustomResolverHelpers {
     /** Resolve `$refs` and built-in functions inside a string against the current routine context. */

--- a/tests/custom-command-auth.test.ts
+++ b/tests/custom-command-auth.test.ts
@@ -1,0 +1,420 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createCli } from '../src/cli-builder';
+import type { CliOptions, CliContext } from '../src/types';
+import { BasicAuthStrategy } from '../src/auth/basic';
+import { mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+function makeOptions(overrides: Partial<CliOptions> = {}): CliOptions {
+    return {
+        name: 'testcli',
+        description: 'A test CLI',
+        version: '1.0.0',
+        specPath: '/v3/api-docs',
+        auth: new BasicAuthStrategy(),
+        outputModes: ['json'],
+        ...overrides,
+    };
+}
+
+async function captureOutput(fn: () => Promise<void>): Promise<void> {
+    const origLog = console.log;
+    const origErr = console.error;
+
+    console.log = () => {};
+    console.error = () => {};
+
+    try {
+        await fn();
+    } catch {
+        // process.exit is mocked to throw
+    } finally {
+        console.log = origLog;
+        console.error = origErr;
+    }
+}
+
+describe('custom command requiresAuth + ctx.saveSession / ctx.resolveSession', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+    let sessionPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-ctx-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+        sessionPath = join(testConfigDir, 'session.json');
+
+        writeFileSync(
+            configPath,
+            JSON.stringify({
+                active: 'default',
+                environments: {
+                    default: {
+                        url: 'http://localhost:8080',
+                        user: 'testuser',
+                        password: 'testpass',
+                    },
+                },
+            }),
+        );
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('ctx exposes resolveSession and saveSession methods', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let capturedCtx: CliContext | null = null;
+
+        cli.command('capture', (program, ctx) => {
+            program.command('capture').action(() => {
+                capturedCtx = ctx;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'capture'];
+
+        await captureOutput(() => cli.run());
+
+        expect(capturedCtx).not.toBeNull();
+        expect(typeof capturedCtx!.resolveSession).toBe('function');
+        expect(typeof capturedCtx!.saveSession).toBe('function');
+    });
+
+    test('requiresAuth: true resolves session before the action runs', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'needs-auth',
+            (program, ctx) => {
+                program.command('needs-auth').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'needs-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+        expect(sessionAtAction).toHaveProperty('headers');
+    });
+
+    test('requiresAuth: false leaves ctx.session null (existing behavior)', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command('no-auth', (program, ctx) => {
+            program.command('no-auth').action(() => {
+                sessionAtAction = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'no-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('customCommandDefaults.requiresAuth applies when per-command flag is unset', async () => {
+        const cli = createCli(
+            makeOptions({ configPath, customCommandDefaults: { requiresAuth: true } }),
+        );
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command('default-auth', (program, ctx) => {
+            program.command('default-auth').action(() => {
+                sessionAtAction = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'default-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+    });
+
+    test('per-command requiresAuth: false overrides settings default true', async () => {
+        const cli = createCli(
+            makeOptions({ configPath, customCommandDefaults: { requiresAuth: true } }),
+        );
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'explicit-off',
+            (program, ctx) => {
+                program.command('explicit-off').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: false },
+        );
+
+        process.argv = ['node', 'testcli', 'explicit-off'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('--dry-run skips requiresAuth preAction hook', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'preview-skip',
+            (program, ctx) => {
+                program.command('preview-skip').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'preview-skip', '--dry-run'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).toBeNull();
+    });
+
+    test('-o routine-step skips requiresAuth preAction hook', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let actionRan = false;
+
+        cli.command(
+            'step-skip',
+            (program) => {
+                program.command('step-skip').action(() => {
+                    actionRan = true;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'step-skip', '-o', 'routine-step'];
+
+        await captureOutput(() => cli.run());
+
+        // routine-step exits before our action runs; we only care that it didn't crash on auth resolution
+        expect(actionRan).toBe(false);
+    });
+
+    test('ctx.saveSession() persists ctx.session to disk', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        cli.command(
+            'save',
+            (program, ctx) => {
+                program.command('save').action(async () => {
+                    ctx.session = { headers: { Authorization: 'Bearer new-token' } };
+                    await ctx.saveSession();
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'save'];
+
+        await captureOutput(() => cli.run());
+
+        expect(existsSync(sessionPath)).toBe(true);
+        const persisted = JSON.parse(readFileSync(sessionPath, 'utf-8'));
+        expect(persisted.headers.Authorization).toBe('Bearer new-token');
+    });
+
+    test('ctx.saveSession() with null ctx.session invalidates the session file', async () => {
+        writeFileSync(sessionPath, JSON.stringify({ headers: { Authorization: 'old' } }));
+
+        const cli = createCli(makeOptions({ configPath }));
+
+        cli.command('wipe', (program, ctx) => {
+            program.command('wipe').action(async () => {
+                ctx.session = null;
+                await ctx.saveSession();
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'wipe'];
+
+        await captureOutput(() => cli.run());
+
+        expect(existsSync(sessionPath)).toBe(false);
+    });
+
+    test('requiresAuth hook fires even when registrar adds a differently-named top-level subcommand', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionAtAction: unknown = 'unset';
+
+        cli.command(
+            'alias-name',
+            (program, ctx) => {
+                // Registrar intentionally uses a different name than the one passed to cli.command()
+                program.command('real-name').action(() => {
+                    sessionAtAction = ctx.session;
+                });
+            },
+            { requiresAuth: true },
+        );
+
+        process.argv = ['node', 'testcli', 'real-name'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionAtAction).not.toBeNull();
+    });
+
+    test('ctx.resolveSession() populates ctx.session on demand', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionBefore: unknown = 'unset';
+        let sessionAfter: unknown = 'unset';
+
+        cli.command('manual', (program, ctx) => {
+            program.command('manual').action(async () => {
+                sessionBefore = ctx.session;
+                await ctx.resolveSession();
+                sessionAfter = ctx.session;
+            });
+        });
+
+        process.argv = ['node', 'testcli', 'manual'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionBefore).toBeNull();
+        expect(sessionAfter).not.toBeNull();
+        expect(sessionAfter).toHaveProperty('headers');
+    });
+});
+
+describe('dispatcher requiresAuth', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-disp-test-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+
+        writeFileSync(
+            configPath,
+            JSON.stringify({
+                active: 'default',
+                environments: {
+                    default: {
+                        url: 'http://localhost:8080',
+                        user: 'testuser',
+                        password: 'testpass',
+                    },
+                },
+            }),
+        );
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('requiresAuth dispatcher resolves session before the handler runs', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionInHandler: unknown = 'unset';
+
+        cli.dispatcher(
+            'do-thing',
+            async (_args, _pos, ctx) => {
+                sessionInHandler = ctx.session;
+
+                return { ok: true };
+            },
+            { requiresAuth: true },
+        );
+
+        // Drive the dispatcher through a routine file
+        const routinesDir = join(testConfigDir, 'routines');
+        mkdirSync(routinesDir, { recursive: true });
+        writeFileSync(
+            join(routinesDir, 'run-disp.yml'),
+            `name: run-disp
+steps:
+  - name: call
+    command: do-thing
+`,
+        );
+
+        process.argv = ['node', 'testcli', 'routine', 'run', 'run-disp'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionInHandler).not.toBeNull();
+        expect(sessionInHandler).toHaveProperty('headers');
+    });
+
+    test('non-requiresAuth dispatcher leaves ctx.session null', async () => {
+        const cli = createCli(makeOptions({ configPath }));
+
+        let sessionInHandler: unknown = 'unset';
+
+        cli.dispatcher('no-auth-disp', async (_args, _pos, ctx) => {
+            sessionInHandler = ctx.session;
+
+            return { ok: true };
+        });
+
+        const routinesDir = join(testConfigDir, 'routines');
+        mkdirSync(routinesDir, { recursive: true });
+        writeFileSync(
+            join(routinesDir, 'run-no-auth.yml'),
+            `name: run-no-auth
+steps:
+  - name: call
+    command: no-auth-disp
+`,
+        );
+
+        process.argv = ['node', 'testcli', 'routine', 'run', 'run-no-auth'];
+
+        await captureOutput(() => cli.run());
+
+        expect(sessionInHandler).toBeNull();
+    });
+});

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -105,10 +105,10 @@ describe('loadProjectDispatchers()', () => {
         rmSync(testRoot, { recursive: true, force: true });
     });
 
-    test('returns empty map when no dispatchers/ dir exists', async () => {
+    test('returns empty array when no dispatchers/ dir exists', async () => {
         mkdirSync(testRoot, { recursive: true });
         const result = await loadProjectDispatchers(testRoot);
-        expect(result.size).toBe(0);
+        expect(result).toEqual([]);
     });
 
     test('loads dispatcher handlers from dispatchers/*.ts', async () => {
@@ -122,9 +122,73 @@ describe('loadProjectDispatchers()', () => {
         `);
 
         const result = await loadProjectDispatchers(testRoot);
-        expect(result.size).toBe(1);
-        expect(result.has('notify')).toBe(true);
-        expect(typeof result.get('notify')).toBe('function');
+        expect(result).toHaveLength(1);
+        expect(result[0]!.name).toBe('notify');
+        expect(typeof result[0]!.handler).toBe('function');
+        expect(result[0]!.requiresAuth).toBeUndefined();
+    });
+
+    test('reads requiresAuth export from dispatcher module', async () => {
+        const dispDir = join(testRoot, 'dispatchers');
+        mkdirSync(dispDir, { recursive: true });
+        writeFileSync(join(dispDir, 'notify-auth.ts'), `
+            export const name = 'notify-auth';
+            export const requiresAuth = true;
+            export default async function handle(args, positionalArgs, ctx) {
+                return { sent: true };
+            }
+        `);
+
+        const result = await loadProjectDispatchers(testRoot);
+        expect(result).toHaveLength(1);
+        expect(result[0]!.requiresAuth).toBe(true);
+    });
+});
+
+describe('loadProjectCommands() — requiresAuth', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('reads requiresAuth export from command module', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-auth.ts'), `
+            export const name = 'deploy-auth';
+            export const requiresAuth = true;
+            export default function register(program, ctx) {
+                program.command('deploy-auth').action(() => {});
+            }
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result).toHaveLength(1);
+        expect(result[0]!.requiresAuth).toBe(true);
+    });
+
+    test('leaves requiresAuth undefined when the export is missing', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-no-auth.ts'), `
+            export const name = 'deploy-no-auth';
+            export default function register(program, ctx) {}
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result[0]!.requiresAuth).toBeUndefined();
+    });
+
+    test('ignores non-boolean requiresAuth values', async () => {
+        const cmdDir = join(testRoot, 'commands');
+        mkdirSync(cmdDir, { recursive: true });
+        writeFileSync(join(cmdDir, 'deploy-bad-auth.ts'), `
+            export const name = 'deploy-bad-auth';
+            export const requiresAuth = 'yes';
+            export default function register(program, ctx) {}
+        `);
+
+        const result = await loadProjectCommands(testRoot);
+        expect(result[0]!.requiresAuth).toBeUndefined();
     });
 });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { loadProjectSettings } from '../src/settings';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const testRoot = join(tmpdir(), 'apijack-settings-test-' + Date.now());
+
+describe('loadProjectSettings()', () => {
+    afterEach(() => {
+        rmSync(testRoot, { recursive: true, force: true });
+    });
+
+    test('returns empty object when settings.json is missing', () => {
+        mkdirSync(testRoot, { recursive: true });
+        expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+
+    test('reads customCommands.defaults.requiresAuth', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(
+            join(testRoot, 'settings.json'),
+            JSON.stringify({ customCommands: { defaults: { requiresAuth: true } } }),
+        );
+
+        const settings = loadProjectSettings(testRoot);
+        expect(settings.customCommands?.defaults?.requiresAuth).toBe(true);
+    });
+
+    test('returns empty object on malformed JSON', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(join(testRoot, 'settings.json'), '{ not json');
+        expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+});


### PR DESCRIPTION
Adds an opt-in auth resolution path for consumer-registered custom commands and dispatchers, plus public helpers for session persistence.

## ✨ Features

- **Opt-in auth for custom commands and dispatchers** (#37) — Export `requiresAuth = true` from a `.apijack/commands/*.ts` or `.apijack/dispatchers/*.ts` module (or set `customCommands.defaults.requiresAuth: true` in `.apijack/settings.json`) and core resolves the session before your handler runs. Type as `CommandRegistrar<true>` / `DispatcherHandler<true>` for a non-null `ctx.session`.
- **`ctx.resolveSession()` and `ctx.saveSession()`** (#37) — Public helpers on `CliContext` for one-off resolution and persisting session mutations, so consumers no longer need internal imports.

## 🧹 Internal

- Claude Code skills for the dev loop and release drafting.

---

Shipped via `scripts/ship.sh`.
