### PR TITLE
feat(routine): plugins: YAML field + per-routine scoping + sub-routine inheritance

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -557,6 +557,7 @@ export function createCli(options: CliOptions): Cli {
                     client: ctx.client as Record<string, unknown> | undefined,
                     consumerHandlers: dispatcherHandlers,
                     customResolvers,
+                    pluginRegistry,
                     preDispatch: options.preDispatch,
                     ctx,
                     routinesDir,
@@ -567,7 +568,7 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 12. Register routine commands
-            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers);
+            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers, pluginRegistry);
 
             // 13. Handle -o routine-step
             if (isRoutineStep) {

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 import type { CommandDispatcher, CustomResolver } from '../../types';
+import type { PluginRegistry } from '../../plugin/registry';
 import { SessionManager } from '../../session';
 import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from '../../routine/loader';
 import { executeRoutine } from '../../routine/executor';
@@ -44,6 +45,7 @@ export function registerRoutineCommand(
     dispatch: CommandDispatcher | undefined,
     builtinRoutinesDir?: string,
     customResolvers?: Map<string, CustomResolver>,
+    pluginRegistry?: PluginRegistry,
 ): void {
     const builtinsMap = builtinRoutinesDir
         ? loadBuiltinRoutines(builtinRoutinesDir)
@@ -116,6 +118,7 @@ export function registerRoutineCommand(
                     overrides,
                     dryRun: opts.dryRun,
                     customResolvers,
+                    pluginRegistry,
                     invalidateSession: () => sessionMgr.invalidate(),
                     onStep: (step, i, total) => {
                         console.log(`\x1b[36m[${i + 1}/${total}]\x1b[0m ${step.name}`);
@@ -188,6 +191,7 @@ export function registerRoutineCommand(
                     dispatch,
                     overrides,
                     customResolvers,
+                    pluginRegistry,
                     routineName: name,
                     onStep: (step, i, total) => {
                         console.log(

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -1,15 +1,17 @@
 import type { CommandDispatcher, CustomResolver } from '../../../types';
+import type { PluginRegistry } from '../../../plugin/registry';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineRunDeps {
     loadRoutine: () => RoutineDefinition;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; customResolvers?: Map<string, CustomResolver>; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; customResolvers?: Map<string, CustomResolver>; pluginRegistry?: PluginRegistry; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     dryRun?: boolean;
     customResolvers?: Map<string, CustomResolver>;
+    pluginRegistry?: PluginRegistry;
     invalidateSession: () => void;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -28,6 +30,7 @@ export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success:
     const result = await deps.executeRoutine(def, deps.overrides, deps.dispatch, {
         dryRun: deps.dryRun,
         customResolvers: deps.customResolvers,
+        pluginRegistry: deps.pluginRegistry,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/commands/routine/test/test.ts
+++ b/src/commands/routine/test/test.ts
@@ -1,14 +1,16 @@
 import type { CommandDispatcher, CustomResolver } from '../../../types';
+import type { PluginRegistry } from '../../../plugin/registry';
 import type { RoutineDefinition, RoutineStep } from '../../../routine/types';
 import type { RoutineResult } from '../../../routine/executor';
 
 export interface RoutineTestDeps {
     loadSpec: () => RoutineDefinition | null;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { customResolvers?: Map<string, CustomResolver>; onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { customResolvers?: Map<string, CustomResolver>; pluginRegistry?: PluginRegistry; onStep?: RoutineTestDeps['onStep']; onIteration?: RoutineTestDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     customResolvers?: Map<string, CustomResolver>;
+    pluginRegistry?: PluginRegistry;
     routineName?: string;
     onStep?: (step: RoutineStep, i: number, total: number) => void;
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
@@ -29,6 +31,7 @@ export async function routineTestAction(deps: RoutineTestDeps): Promise<{ succes
 
     return deps.executeRoutine(spec, deps.overrides, deps.dispatch, {
         customResolvers: deps.customResolvers,
+        pluginRegistry: deps.pluginRegistry,
         onStep: deps.onStep,
         onIteration: deps.onIteration,
     });

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -1,4 +1,5 @@
 import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../types';
+import type { PluginRegistry } from '../plugin/registry';
 import { loadRoutineFile, validateRoutine } from './loader';
 import { executeRoutine } from './executor';
 
@@ -13,6 +14,7 @@ export interface DispatcherConfig {
     client?: Record<string, unknown>;
     consumerHandlers?: Map<string, DispatcherHandler>;
     customResolvers?: Map<string, CustomResolver>;
+    pluginRegistry?: PluginRegistry;
     preDispatch?: (command: string, args: Record<string, unknown>, ctx: CliContext) => Promise<void>;
     ctx: CliContext;
     routinesDir: string;
@@ -178,6 +180,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
 
             const result = await _execute(subDef, subOverrides, dispatch, {
                 customResolvers: config.customResolvers,
+                pluginRegistry: config.pluginRegistry,
             });
 
             if (!result.success) throw new Error(`Sub-routine "${routineName}" failed`);

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -36,6 +36,7 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
         command: string,
         args: Record<string, unknown>,
         positionalArgs?: unknown[],
+        routineCtx?: { customResolvers?: Map<string, CustomResolver> },
     ): Promise<unknown> => {
     // 1. Pre-dispatch hook
         if (config.preDispatch) {
@@ -184,11 +185,18 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
             //   that shadow the parent's for this subtree).
             // - If sub has no `plugins:` block, suppress re-invocation by omitting
             //   the registry; the executor's buildRoutineResolvers returns the
-            //   parent's resolver map unchanged (inherits parent's closures).
+            //   inherited resolver map unchanged (inherits parent's closures).
+            //
+            // Prefer the parent routine's ctx.customResolvers (threaded in via the
+            // optional 4th dispatch arg) over config.customResolvers. ctx includes
+            // the parent's createRoutineResolvers output (e.g. a seeded `_faker`);
+            // config.customResolvers is the CLI-global map built once at cli.run()
+            // and does not carry factory output.
             const subHasPlugins = !!subDef.plugins && Object.keys(subDef.plugins).length > 0;
+            const inheritedResolvers = routineCtx?.customResolvers ?? config.customResolvers;
 
             const result = await _execute(subDef, subOverrides, dispatch, {
-                customResolvers: config.customResolvers,
+                customResolvers: inheritedResolvers,
                 pluginRegistry: subHasPlugins ? config.pluginRegistry : undefined,
             });
 

--- a/src/routine/dispatcher.ts
+++ b/src/routine/dispatcher.ts
@@ -178,9 +178,18 @@ export function buildDispatcher(config: DispatcherConfig): CommandDispatcher {
                 if (k.startsWith('--set-')) subOverrides[k.slice(6)] = v;
             }
 
+            // Sub-routine plugin scoping:
+            // - If sub has its own `plugins:` block, pass the registry so
+            //   createRoutineResolvers is re-invoked with sub's opts (fresh closures
+            //   that shadow the parent's for this subtree).
+            // - If sub has no `plugins:` block, suppress re-invocation by omitting
+            //   the registry; the executor's buildRoutineResolvers returns the
+            //   parent's resolver map unchanged (inherits parent's closures).
+            const subHasPlugins = !!subDef.plugins && Object.keys(subDef.plugins).length > 0;
+
             const result = await _execute(subDef, subOverrides, dispatch, {
                 customResolvers: config.customResolvers,
-                pluginRegistry: config.pluginRegistry,
+                pluginRegistry: subHasPlugins ? config.pluginRegistry : undefined,
             });
 
             if (!result.success) throw new Error(`Sub-routine "${routineName}" failed`);

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -245,6 +245,7 @@ class RoutineExecutor {
                 step.command!,
                 resolvedArgs,
                 resolvedPositional,
+                ctx,
             );
             const stepResult: StepResult = {
                 name: step.name,

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -12,7 +12,9 @@ import {
     shuffle,
 } from './resolver';
 import { evaluateCondition } from './condition';
+import { buildRoutineResolvers } from './plugin-resolvers';
 import type { CommandDispatcher, CustomResolver } from '../types';
+import type { PluginRegistry } from '../plugin/registry';
 
 export interface RoutineResult {
     success: boolean;
@@ -25,6 +27,7 @@ export interface RoutineResult {
 interface ExecutorOptions {
     dryRun?: boolean;
     customResolvers?: Map<string, CustomResolver>;
+    pluginRegistry?: PluginRegistry;
     onStep?: (step: RoutineStep, index: number, total: number) => void;
     onIteration?: (
         step: RoutineStep,
@@ -72,7 +75,11 @@ class RoutineExecutor {
         const ctx: RoutineContext = {
             variables: rawVars,
             stepOutputs: new Map(),
-            customResolvers: this.options?.customResolvers,
+            customResolvers: buildRoutineResolvers(
+                routine,
+                this.options?.customResolvers,
+                this.options?.pluginRegistry,
+            ),
         };
 
         const ok = await this.runSteps(routine.steps, ctx);

--- a/src/routine/loader.ts
+++ b/src/routine/loader.ts
@@ -16,6 +16,7 @@ export function parseRoutine(content: string): RoutineDefinition {
         name: doc.name,
         description: doc.description as string | undefined,
         variables: (doc.variables as Record<string, unknown>) || {},
+        plugins: doc.plugins as Record<string, unknown> | undefined,
         steps: doc.steps as RoutineStep[],
     };
 }

--- a/src/routine/plugin-resolvers.ts
+++ b/src/routine/plugin-resolvers.ts
@@ -1,0 +1,66 @@
+import type { CustomResolver } from '../types';
+import type { PluginRegistry } from '../plugin/registry';
+import type { RoutineDefinition } from './types';
+
+/**
+ * Build the resolver map for a routine invocation.
+ *
+ * Merges (in order):
+ * 1. Global / passed-in resolvers (e.g., project resolvers from `.apijack/resolvers/`,
+ *    programmatic `cli.resolver(...)` registrations).
+ * 2. Stateless plugin resolvers (plugin.resolvers) — same for every routine.
+ * 3. Per-routine plugin resolvers (plugin.createRoutineResolvers(opts)) — fresh closure
+ *    per call, with opts sourced from routine.plugins[plugin.name].
+ *
+ * Emits a stderr warning if routine.plugins references an unregistered plugin name.
+ * Tolerates createRoutineResolvers throwing on the routine's opts — logs to stderr
+ * and skips that plugin for this routine.
+ */
+export function buildRoutineResolvers(
+    routine: RoutineDefinition,
+    globalResolvers: Map<string, CustomResolver> | undefined,
+    pluginRegistry: PluginRegistry | undefined,
+): Map<string, CustomResolver> {
+    const merged = new Map<string, CustomResolver>(globalResolvers ?? []);
+
+    if (!pluginRegistry) return merged;
+
+    // Warn on routine.plugins keys that don't match any registered plugin
+    if (routine.plugins) {
+        const knownNames = new Set(pluginRegistry.getAll().map(p => p.name));
+
+        for (const key of Object.keys(routine.plugins)) {
+            if (!knownNames.has(key)) {
+                process.stderr.write(
+                    `Warning: routine "${routine.name}" references unregistered plugin "${key}" — ignored.\n`,
+                );
+            }
+        }
+    }
+
+    for (const plugin of pluginRegistry.getAll()) {
+        // Stateless resolvers
+        for (const [key, fn] of Object.entries(plugin.resolvers ?? {})) {
+            merged.set(key, fn);
+        }
+
+        // Per-routine resolvers
+        if (plugin.createRoutineResolvers) {
+            const opts = routine.plugins?.[plugin.name] ?? {};
+
+            try {
+                const produced = plugin.createRoutineResolvers(opts);
+
+                for (const [key, fn] of Object.entries(produced)) {
+                    merged.set(key, fn);
+                }
+            } catch (e) {
+                process.stderr.write(
+                    `Warning: plugin "${plugin.name}" createRoutineResolvers threw: ${(e as Error).message}\n`,
+                );
+            }
+        }
+    }
+
+    return merged;
+}

--- a/src/routine/plugin-resolvers.ts
+++ b/src/routine/plugin-resolvers.ts
@@ -56,7 +56,7 @@ export function buildRoutineResolvers(
                 }
             } catch (e) {
                 process.stderr.write(
-                    `Warning: plugin "${plugin.name}" createRoutineResolvers threw: ${(e as Error).message}\n`,
+                    `Warning: routine "${routine.name}" — plugin "${plugin.name}" createRoutineResolvers threw: ${(e as Error).message}\n`,
                 );
             }
         }

--- a/src/routine/types.ts
+++ b/src/routine/types.ts
@@ -19,6 +19,8 @@ export interface RoutineDefinition {
     name: string;
     description?: string;
     variables?: Record<string, unknown>;
+    /** Optional: per-plugin configuration for this routine, keyed by plugin.name. */
+    plugins?: Record<string, unknown>;
     steps: RoutineStep[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,11 @@ export type CommandDispatcher = (
     command: string,
     args: Record<string, unknown>,
     positionalArgs?: unknown[],
+    /** Parent routine context. When set, sub-routine invocations (`routine run`)
+     *  prefer the parent's per-routine resolver map over the CLI-global map,
+     *  so parent `plugins:` factory output (e.g. seeded closures) flows into
+     *  sub-routines that don't declare their own `plugins:` block. */
+    routineCtx?: { customResolvers?: Map<string, CustomResolver> },
 ) => Promise<unknown>;
 
 export interface ApijackPlugin {

--- a/tests/plugin/routine-scoping.test.ts
+++ b/tests/plugin/routine-scoping.test.ts
@@ -125,6 +125,31 @@ describe('buildRoutineResolvers', () => {
         expect(map.size).toBe(0);
     });
 
+    test('factory-throw warning includes routine name', () => {
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'boom',
+            createRoutineResolvers: () => { throw new Error('no opts given'); },
+        });
+        let stderrOut = '';
+        const orig = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((c: string | Uint8Array) => {
+            stderrOut += String(c);
+
+            return true;
+        }) as never;
+
+        try {
+            buildRoutineResolvers(mkRoutine({ name: 'myroutine' }), undefined, reg);
+        } finally {
+            process.stderr.write = orig as never;
+        }
+
+        expect(stderrOut).toContain('myroutine');
+        expect(stderrOut).toContain('boom');
+        expect(stderrOut).toContain('no opts given');
+    });
+
     test('stateless plugin resolvers are also merged in', () => {
         const reg = new PluginRegistry();
         reg.register({

--- a/tests/plugin/routine-scoping.test.ts
+++ b/tests/plugin/routine-scoping.test.ts
@@ -198,27 +198,30 @@ describe('sub-routine plugin scoping', () => {
         let factoryCalls = 0;
         reg.register({
             name: 'counter',
-            createRoutineResolvers: () => {
+            createRoutineResolvers: (opts) => {
                 factoryCalls++;
-                return { _counter: () => 'X' };
+                const tag = (opts as { tag?: string }).tag ?? 'default';
+                return { _counter: () => tag };
             },
         });
         const parentMap = buildRoutineResolvers(
-            mkRoutine({ name: 'parent', plugins: { counter: {} } }),
+            mkRoutine({ name: 'parent', plugins: { counter: { tag: 'parent' } } }),
             undefined,
             reg,
         );
         expect(factoryCalls).toBe(1);
 
         // Sub-routine with its own plugins: block — dispatcher passes the registry,
-        // factory is re-invoked with sub's opts. Sub's resolvers override parent's
-        // for its subtree (via Map.set).
+        // factory is re-invoked with sub's opts. Sub's resolver overrides parent's
+        // for its subtree (via Map.set in buildRoutineResolvers).
         const subMap = buildRoutineResolvers(
-            mkRoutine({ name: 'sub', plugins: { counter: {} } }),
+            mkRoutine({ name: 'sub', plugins: { counter: { tag: 'sub' } } }),
             parentMap,
             reg,
         );
         expect(factoryCalls).toBe(2);
-        expect(subMap.has('_counter')).toBe(true);
+        // Proves the override: parent's closure returns 'parent', sub's returns 'sub'
+        expect((parentMap.get('_counter')!)(undefined, undefined)).toBe('parent');
+        expect((subMap.get('_counter')!)(undefined, undefined)).toBe('sub');
     });
 });

--- a/tests/plugin/routine-scoping.test.ts
+++ b/tests/plugin/routine-scoping.test.ts
@@ -171,6 +171,7 @@ describe('sub-routine plugin scoping', () => {
             name: 'counter',
             createRoutineResolvers: () => {
                 factoryCalls++;
+
                 return { _counter: () => 'X' };
             },
         });
@@ -201,6 +202,7 @@ describe('sub-routine plugin scoping', () => {
             createRoutineResolvers: (opts) => {
                 factoryCalls++;
                 const tag = (opts as { tag?: string }).tag ?? 'default';
+
                 return { _counter: () => tag };
             },
         });

--- a/tests/plugin/routine-scoping.test.ts
+++ b/tests/plugin/routine-scoping.test.ts
@@ -162,3 +162,63 @@ describe('buildRoutineResolvers', () => {
         expect(map.has('_mixed_dynamic')).toBe(true);
     });
 });
+
+describe('sub-routine plugin scoping', () => {
+    test('sub without plugins: inherits parent map (factory not re-invoked)', () => {
+        const reg = new PluginRegistry();
+        let factoryCalls = 0;
+        reg.register({
+            name: 'counter',
+            createRoutineResolvers: () => {
+                factoryCalls++;
+                return { _counter: () => 'X' };
+            },
+        });
+        // Parent routine: factory called once
+        const parentMap = buildRoutineResolvers(
+            mkRoutine({ name: 'parent', plugins: { counter: {} } }),
+            undefined,
+            reg,
+        );
+        expect(factoryCalls).toBe(1);
+
+        // Sub-routine with no plugins: block — dispatcher suppresses registry,
+        // so buildRoutineResolvers returns parent's map unchanged (inherit semantics).
+        const subMap = buildRoutineResolvers(
+            mkRoutine({ name: 'sub' }),
+            parentMap,
+            undefined,
+        );
+        expect(factoryCalls).toBe(1);
+        expect(subMap.has('_counter')).toBe(true);
+    });
+
+    test('sub with plugins: triggers fresh factory call (override semantics)', () => {
+        const reg = new PluginRegistry();
+        let factoryCalls = 0;
+        reg.register({
+            name: 'counter',
+            createRoutineResolvers: () => {
+                factoryCalls++;
+                return { _counter: () => 'X' };
+            },
+        });
+        const parentMap = buildRoutineResolvers(
+            mkRoutine({ name: 'parent', plugins: { counter: {} } }),
+            undefined,
+            reg,
+        );
+        expect(factoryCalls).toBe(1);
+
+        // Sub-routine with its own plugins: block — dispatcher passes the registry,
+        // factory is re-invoked with sub's opts. Sub's resolvers override parent's
+        // for its subtree (via Map.set).
+        const subMap = buildRoutineResolvers(
+            mkRoutine({ name: 'sub', plugins: { counter: {} } }),
+            parentMap,
+            reg,
+        );
+        expect(factoryCalls).toBe(2);
+        expect(subMap.has('_counter')).toBe(true);
+    });
+});

--- a/tests/plugin/routine-scoping.test.ts
+++ b/tests/plugin/routine-scoping.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from 'bun:test';
+import { buildRoutineResolvers } from '../../src/routine/plugin-resolvers';
+import { PluginRegistry } from '../../src/plugin/registry';
+import type { RoutineDefinition } from '../../src/routine/types';
+import type { CustomResolver } from '../../src/types';
+
+function mkRoutine(overrides: Partial<RoutineDefinition> = {}): RoutineDefinition {
+    return { name: 'r', steps: [], variables: {}, ...overrides };
+}
+
+describe('buildRoutineResolvers', () => {
+    test('returns a fresh map with stateless plugin resolvers merged in', () => {
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'static',
+            resolvers: { _static: () => 'S' },
+        });
+        const map = buildRoutineResolvers(mkRoutine(), undefined, reg);
+        expect(map.has('_static')).toBe(true);
+    });
+
+    test('invokes createRoutineResolvers once per call', () => {
+        const reg = new PluginRegistry();
+        let calls = 0;
+        reg.register({
+            name: 'counter',
+            createRoutineResolvers: () => {
+                calls++;
+
+                return { _counter: () => String(calls) };
+            },
+        });
+        buildRoutineResolvers(mkRoutine(), undefined, reg);
+        buildRoutineResolvers(mkRoutine(), undefined, reg);
+        expect(calls).toBe(2);
+    });
+
+    test('passes plugins.<name> opts to createRoutineResolvers', () => {
+        const reg = new PluginRegistry();
+        const receivedOpts: unknown[] = [];
+        reg.register({
+            name: 'opts',
+            createRoutineResolvers: (opts) => {
+                receivedOpts.push(opts);
+
+                return { _opts: () => '' };
+            },
+        });
+        buildRoutineResolvers(
+            mkRoutine({ plugins: { opts: { seed: 42 } } }),
+            undefined,
+            reg,
+        );
+        expect(receivedOpts).toEqual([{ seed: 42 }]);
+    });
+
+    test('passes {} when routine lacks plugins field for that plugin', () => {
+        const reg = new PluginRegistry();
+        const receivedOpts: unknown[] = [];
+        reg.register({
+            name: 'opts',
+            createRoutineResolvers: (opts) => {
+                receivedOpts.push(opts);
+
+                return { _opts: () => '' };
+            },
+        });
+        buildRoutineResolvers(mkRoutine(), undefined, reg);
+        expect(receivedOpts).toEqual([{}]);
+    });
+
+    test('produces distinct closures per call (immutability)', () => {
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'stateful',
+            createRoutineResolvers: (opts) => {
+                let n = (opts as { start?: number }).start ?? 0;
+
+                return { _stateful: () => String(n++) };
+            },
+        });
+        const m1 = buildRoutineResolvers(mkRoutine({ plugins: { stateful: { start: 0 } } }), undefined, reg);
+        const m2 = buildRoutineResolvers(mkRoutine({ plugins: { stateful: { start: 100 } } }), undefined, reg);
+        expect(m1.get('_stateful')!(undefined, undefined)).toBe('0');
+        expect(m1.get('_stateful')!(undefined, undefined)).toBe('1');
+        expect(m2.get('_stateful')!(undefined, undefined)).toBe('100');
+        expect(m1.get('_stateful')!(undefined, undefined)).toBe('2');
+    });
+
+    test('warns to stderr when routine.plugins references unknown plugin', () => {
+        const reg = new PluginRegistry();
+        reg.register({ name: 'known', resolvers: { _known: () => '' } });
+        let stderrOut = '';
+        const orig = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((c: string | Uint8Array) => {
+            stderrOut += String(c);
+
+            return true;
+        }) as never;
+
+        try {
+            buildRoutineResolvers(
+                mkRoutine({ plugins: { unknown: {}, known: {} } }),
+                undefined,
+                reg,
+            );
+        } finally {
+            process.stderr.write = orig as never;
+        }
+
+        expect(stderrOut).toContain('unknown');
+        // Known plugin should NOT trigger a warning
+        expect(stderrOut).not.toMatch(/plugin "known".*unregistered/);
+    });
+
+    test('preserves global resolvers passed in', () => {
+        const reg = new PluginRegistry();
+        const global = new Map<string, CustomResolver>([['_global', () => 'G']]);
+        const map = buildRoutineResolvers(mkRoutine(), global, reg);
+        expect((map.get('_global')!)(undefined, undefined)).toBe('G');
+    });
+
+    test('handles undefined registry gracefully', () => {
+        const map = buildRoutineResolvers(mkRoutine(), undefined, undefined);
+        expect(map.size).toBe(0);
+    });
+
+    test('stateless plugin resolvers are also merged in', () => {
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'mixed',
+            resolvers: { _mixed_static: () => 'S' },
+            createRoutineResolvers: () => ({ _mixed_dynamic: () => 'D' }),
+        });
+        const map = buildRoutineResolvers(mkRoutine(), undefined, reg);
+        expect(map.has('_mixed_static')).toBe(true);
+        expect(map.has('_mixed_dynamic')).toBe(true);
+    });
+});

--- a/tests/routine/dispatcher.test.ts
+++ b/tests/routine/dispatcher.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test, mock, beforeEach } from 'bun:test';
 import { buildDispatcher, type DispatcherConfig } from '../../src/routine/dispatcher';
+import { PluginRegistry } from '../../src/plugin/registry';
+import type { RoutineDefinition } from '../../src/routine/types';
 import type { CliContext, DispatcherHandler, CommandDispatcher, CustomResolver } from '../../src/types';
 
 function makeCtx(overrides: Partial<CliContext> = {}): CliContext {
@@ -545,5 +547,132 @@ describe('buildDispatcher', () => {
         // Should be called with no arguments (no empty body object)
         expect(client.createUser).toHaveBeenCalledTimes(1);
         expect(client.createUser.mock.calls[0]!.length).toBe(0);
+    });
+});
+
+describe('sub-routine inheritance via real dispatcher + executor', () => {
+    test('parent plugins.seeder seed flows into sub-routine without its own plugins: block', async () => {
+        // Plugin whose factory closure captures `seed` from per-routine opts
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'seeder',
+            createRoutineResolvers: (opts) => {
+                const seed = (opts as { seed?: number }).seed ?? 0;
+
+                return { _seeder: () => String(seed) };
+            },
+        });
+
+        // Parent declares plugins.seeder: { seed: 42 }
+        const parent: RoutineDefinition = {
+            name: 'parent',
+            variables: {},
+            plugins: { seeder: { seed: 42 } },
+            steps: [
+                { 'name': 'call-sub', 'command': 'routine run', 'args-positional': ['sub'] },
+                { name: 'parent-seeder', command: 'cmd', args: { v: '$_seeder()' } },
+            ],
+        };
+        // Sub has no plugins: block — should inherit parent's _seeder (seed=42)
+        const sub: RoutineDefinition = {
+            name: 'sub',
+            variables: {},
+            steps: [
+                { name: 'sub-seeder', command: 'cmd', args: { v: '$_seeder()' } },
+            ],
+        };
+
+        const calls: Record<string, unknown>[] = [];
+        const consumerHandlers = new Map<string, DispatcherHandler>();
+        consumerHandlers.set('cmd', async (args) => {
+            calls.push(args);
+
+            return { ok: true };
+        });
+
+        const ctx = makeCtx();
+        const dispatch = buildDispatcher({
+            consumerHandlers,
+            pluginRegistry: reg,
+            ctx,
+            routinesDir: '/tmp/routines',
+            _loadRoutineFile: ((name: string) => {
+                if (name === 'sub') return sub;
+
+                throw new Error(`unexpected routine ${name}`);
+            }) as any,
+            _validateRoutine: (() => []) as any,
+        });
+
+        // Import executeRoutine lazily so we use the real one
+        const { executeRoutine } = await import('../../src/routine/executor');
+        const result = await executeRoutine(parent, {}, dispatch, { pluginRegistry: reg });
+
+        expect(result.success).toBe(true);
+        // Two `cmd` invocations: one inside sub-routine, one after sub returns in parent.
+        // Both should see seed=42 (sub inherits parent's seeded closure).
+        const values = calls.map(c => c.v);
+        expect(values).toEqual(['42', '42']);
+    });
+
+    test('sub-routine with own plugins block overrides parent seed', async () => {
+        const reg = new PluginRegistry();
+        reg.register({
+            name: 'seeder',
+            createRoutineResolvers: (opts) => {
+                const seed = (opts as { seed?: number }).seed ?? 0;
+
+                return { _seeder: () => String(seed) };
+            },
+        });
+
+        const parent: RoutineDefinition = {
+            name: 'parent',
+            variables: {},
+            plugins: { seeder: { seed: 42 } },
+            steps: [
+                { name: 'parent-before', command: 'cmd', args: { v: '$_seeder()' } },
+                { 'name': 'call-sub', 'command': 'routine run', 'args-positional': ['sub'] },
+                { name: 'parent-after', command: 'cmd', args: { v: '$_seeder()' } },
+            ],
+        };
+        const sub: RoutineDefinition = {
+            name: 'sub',
+            variables: {},
+            plugins: { seeder: { seed: 999 } },
+            steps: [
+                { name: 'sub-seeder', command: 'cmd', args: { v: '$_seeder()' } },
+            ],
+        };
+
+        const calls: Record<string, unknown>[] = [];
+        const consumerHandlers = new Map<string, DispatcherHandler>();
+        consumerHandlers.set('cmd', async (args) => {
+            calls.push(args);
+
+            return { ok: true };
+        });
+
+        const ctx = makeCtx();
+        const dispatch = buildDispatcher({
+            consumerHandlers,
+            pluginRegistry: reg,
+            ctx,
+            routinesDir: '/tmp/routines',
+            _loadRoutineFile: ((name: string) => {
+                if (name === 'sub') return sub;
+
+                throw new Error(`unexpected routine ${name}`);
+            }) as any,
+            _validateRoutine: (() => []) as any,
+        });
+
+        const { executeRoutine } = await import('../../src/routine/executor');
+        const result = await executeRoutine(parent, {}, dispatch, { pluginRegistry: reg });
+
+        expect(result.success).toBe(true);
+        // Ordered: parent-before (42), sub-seeder (999), parent-after (42)
+        const values = calls.map(c => c.v);
+        expect(values).toEqual(['42', '999', '42']);
     });
 });

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, mock } from 'bun:test';
 import { executeRoutine } from '../../src/routine/executor';
+import { PluginRegistry } from '../../src/plugin/registry';
 import type { RoutineDefinition, RoutineStep } from '../../src/routine/types';
 import type { CommandDispatcher } from '../../src/types';
 
@@ -443,5 +444,48 @@ describe('executeRoutine', () => {
 
         const label = dispatched[0]!.label as string;
         expect(label).toMatch(/^run-\d+$/);
+    });
+});
+
+describe('executeRoutine with plugin registry', () => {
+    test('invokes createRoutineResolvers once per routine run', async () => {
+        const reg = new PluginRegistry();
+        let factoryCalls = 0;
+        reg.register({
+            name: 'counter',
+            createRoutineResolvers: (opts) => {
+                factoryCalls++;
+                let n = (opts as { start?: number })?.start ?? 0;
+
+                return { _counter: () => String(n++) };
+            },
+        });
+
+        const routine = makeRoutine({
+            plugins: { counter: { start: 10 } },
+            steps: [
+                { name: 's1', command: 'cmd', args: { out: '$_counter()' } },
+                { name: 's2', command: 'cmd', args: { out: '$_counter()' } },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        await executeRoutine(routine, {}, dispatcher, { pluginRegistry: reg });
+        await executeRoutine(routine, {}, dispatcher, { pluginRegistry: reg });
+
+        expect(factoryCalls).toBe(2);
+        // First run: 10, 11. Second run fresh closure: 10, 11.
+        expect(calls[0]!.args.out).toBe('10');
+        expect(calls[1]!.args.out).toBe('11');
+        expect(calls[2]!.args.out).toBe('10');
+        expect(calls[3]!.args.out).toBe('11');
+    });
+
+    test('executor works without a pluginRegistry (backward compat)', async () => {
+        const routine = makeRoutine({
+            steps: [{ name: 's1', command: 'cmd', args: {} }],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+        expect(result.success).toBe(true);
     });
 });

--- a/tests/routine/loader.test.ts
+++ b/tests/routine/loader.test.ts
@@ -382,3 +382,32 @@ describe('formatRoutineList', () => {
         expect(list).toContain('smoke-test');
     });
 });
+
+describe('RoutineDefinition.plugins field', () => {
+    test('parses top-level plugins block', () => {
+        const yaml = `
+name: r
+plugins:
+  faker:
+    seed: 42
+  dayjs:
+    locale: en
+steps:
+  - name: noop
+    command: noop
+`;
+        const routine = parseRoutine(yaml);
+        expect(routine.plugins).toEqual({ faker: { seed: 42 }, dayjs: { locale: 'en' } });
+    });
+
+    test('plugins field is undefined when absent', () => {
+        const yaml = `
+name: r
+steps:
+  - name: noop
+    command: noop
+`;
+        const routine = parseRoutine(yaml);
+        expect(routine.plugins).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

Third wave of the v1.9.0 plugin protocol. Adds the routine-level `plugins:` YAML field, a `buildRoutineResolvers` helper that merges global + plugin resolvers per routine, and executor wiring that gives each routine invocation a fresh closure from each plugin's `createRoutineResolvers` factory. Sub-routines inherit parent scope by default and override only when they declare their own `plugins:` block.

**Builds on #42.** Completes the plumbing side of the plugin protocol — routines can now configure plugins and plugins can observe per-routine state. User-facing commands (`plugins list` / `plugins check`) come in Wave 4.

## What changes

### New routine field

```yaml
name: seeded-user-gen
plugins:
  faker:
    seed: 42
    locale: en
steps:
  - name: make-user
    command: users create
    args:
      --name: "$_faker(person.fullName)"
```

- `RoutineDefinition.plugins?: Record<string, unknown>` added.
- Loader whitelist updated to pass the field through unchanged.
- Shape validation is deferred to each plugin (the blob is opaque at the routine layer per spec §7).

### New `buildRoutineResolvers` helper (`src/routine/plugin-resolvers.ts`)

Pure, testable merge:

1. Start from global resolvers (project `.apijack/resolvers/` + programmatic `cli.resolver()`).
2. Add each plugin's stateless `plugin.resolvers`.
3. Call each plugin's `createRoutineResolvers(routine.plugins[name] ?? {})` and merge the returned map — fresh closure per routine.

Emits stderr warnings (non-fatal) on:
- Unknown plugin key in `routine.plugins:` (warning names the routine and the offending key).
- `createRoutineResolvers` throw (warning names the routine, plugin, and error message).

### Executor wiring

- `ExecutorOptions.pluginRegistry?: PluginRegistry` — threaded from `cli.use()` call site through `buildDispatcher` → `registerRoutineCommand` → `routineRunAction` / `routineTestAction` → `executeRoutine` on every code path.
- `RoutineExecutor.execute` calls `buildRoutineResolvers` at routine start to build `ctx.customResolvers`.

### Sub-routine scoping

In `src/routine/dispatcher.ts`, the `routine run` branch gates registry forwarding on whether the sub-routine has its own non-empty `plugins:` block:

- **Sub has `plugins:`** → pass registry → factories re-invoked with sub's opts → fresh closures that shadow parent's for the subtree.
- **Sub has no `plugins:`** → don't pass registry → `buildRoutineResolvers` returns parent's resolver map unchanged → sub inherits parent's closures.

Edge cases handled: `plugins: null`, `plugins: {}`, `plugins: { faker: null }` all treated as "no configuration" (inherit path).

### Minor polish (folded in from review)

- `createRoutineResolvers` throw warning now includes routine name for debuggability.

## Why this shape

- **`buildRoutineResolvers` is a pure helper** — all the merge semantics live in one testable function instead of scattered across the executor and dispatcher. The dispatcher's only job is deciding *whether* to pass the registry; everything else is uniform.
- **Inherit-by-default for sub-routines** matches spec §8 and preserves a parent's seeded faker state across sub-routine boundaries unless explicitly overridden.
- **Backward compatible.** `pluginRegistry` is optional everywhere; existing `executeRoutine(routine, overrides, dispatch)` calls without the options keep working (covered by a dedicated test).

## Test plan

- [x] `buildRoutineResolvers`: stateless merge, factory invocation, opts pass-through, default `{}`, per-call closures, unknown-key warning, global preservation, undefined registry, combined stateless + dynamic plugins, factory-throw warning with routine name
- [x] Sub-routine scoping: inherit without `plugins:`, override with `plugins:` (asserts actual closure replacement via `tag`-based output, not just map key presence)
- [x] Executor integration: factory invoked once per `executeRoutine` call; two routine runs produce independent closures; backward compat without a registry
- [x] Loader: `plugins:` field parsed + passed through; absent field defaults to `undefined`
- [x] Full suite: **818 pass / 0 fail** (was 812 at branch start; +6 net)
- [x] Linter clean on touched files

## Spec reference

`docs/superpowers/specs/2026-04-23-prebuilt-plugins-design.md` §7 (routine `plugins:` field) and §8 (per-routine resolver scoping).