### PR TITLE
feat(plugins): <cli> plugins list + plugins check + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ steps:
 - **forEach loops**: Iterate over arrays from previous step output
 - **Assertions**: `assert:` validates response fields with `equals`, `contains`, `matches`
 - **Sub-routines**: `routine:` field runs another routine inline
+- **Plugins**: Top-level `plugins:` block passes per-routine configuration to registered apijack plugins (e.g., `plugins: { faker: { seed: 42 } }`). See `<cli> plugins list` for what's installed.
 
 ### Built-in resolver functions
 
@@ -99,6 +100,47 @@ Usable anywhere a routine value is resolved (args, conditions, variables):
 <cli> routine validate <name>   # Validate YAML structure
 <cli> routine test <name>       # Run spec (test) file
 <cli> routine init              # Install built-in routines
+<cli> plugins list              # List registered apijack plugins
+<cli> plugins check             # Validate plugins (namespace, collisions, peer versions)
+```
+
+## Plugin System
+
+apijack supports pre-built plugins as standalone npm packages. Plugins register resolver functions under their own namespace (e.g., `@normalled/apijack-plugin-faker` exposes `$_faker(...)` for routines).
+
+### Installing a plugin
+
+```ts
+import { createCli } from "@apijack/core";
+import faker from "@normalled/apijack-plugin-faker";
+
+const cli = createCli({ name: "mycli", /* ... */ });
+cli.use(faker());              // zero-config
+cli.use(faker({ seed: 42 }));  // with default opts
+await cli.run();
+```
+
+### Per-routine plugin configuration
+
+```yaml
+name: seeded-user-gen
+plugins:
+  faker:
+    seed: 42
+steps:
+  - name: make-user
+    command: users create
+    args:
+      --name: "$_faker(person.fullName)"
+```
+
+Each routine invocation receives a fresh plugin state closure — routines are isolated from each other. Sub-routines without their own `plugins:` block inherit the parent's closures.
+
+### Plugin diagnostics
+
+```bash
+<cli> plugins list     # show installed plugins with version and status
+<cli> plugins check    # validate namespace, collision, and peer-version rules (exits non-zero on issue)
 ```
 
 ## Command Discovery with `-o routine-step`

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ See [Building a CLI](https://github.com/normalled/apijack/wiki/Building-a-CLI) f
 - **Project mode** -- project-local config, routines, and extensions ([details](https://github.com/normalled/apijack/wiki/Project-Mode))
 - **OpenAPI 3.0 + 3.1** -- comprehensive spec support ([compatibility matrix](https://github.com/normalled/apijack/wiki/OpenAPI-Compatibility))
 
+## Plugins
+
+apijack supports pre-built plugins as standalone npm packages for common utilities. Install via `cli.use(plugin())` and configure per-routine via a top-level `plugins:` block in routine YAML. See `CLAUDE.md` for the full contract and `<cli> plugins list` to inspect registered plugins.
+
 ## Documentation
 
 Full documentation is available on the [wiki](https://github.com/normalled/apijack/wiki):

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -17,6 +17,7 @@ import { buildDispatcher } from './routine/dispatcher';
 import { homedir } from 'os';
 import { resolve, join } from 'path';
 import { registerPluginCommand } from './plugin/register';
+import { registerPluginsCommand } from './commands/plugins/register';
 import { PluginRegistry } from './plugin/registry';
 import { loadPluginPeerInfo, checkPeerRange } from './plugin/peer-version';
 import { PluginPeerMismatchError } from './plugin/errors';
@@ -221,6 +222,7 @@ export function createCli(options: CliOptions): Cli {
                 join(homedir(), '.' + options.name, 'routines'),
             );
             registerPluginCommand(program, cliName, options.version);
+            registerPluginsCommand(program, pluginRegistry, options.version);
 
             // 4. Resolve auth
             let resolved = resolveAuth(cliName, configOpts);

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -62,6 +62,7 @@ const CORE_COMMANDS = new Set([
     'upgrade',
     'mcp',
     'plugin',
+    'plugins',
 ]);
 
 function showCustomHelp(
@@ -154,29 +155,35 @@ export function createCli(options: CliOptions): Cli {
         },
 
         async run(): Promise<void> {
-            // 0. Validate plugins (namespace, collisions, peer versions)
-            pluginRegistry.validateAll(consumerResolvers);
+            // 0. Validate plugins (namespace, collisions, peer versions).
+            // Skip throwing when the user invoked `plugins check` so the command
+            // can report all issues non-destructively.
+            const isPluginsCheck = process.argv[2] === 'plugins' && process.argv[3] === 'check';
 
-            for (const plugin of pluginRegistry.getAll()) {
-                if (!plugin.__package) {
-                    process.stderr.write(
-                        `Warning: plugin "${plugin.name}" did not self-report its package; skipping peer-version check.\n`,
-                    );
-                    continue;
-                }
+            if (!isPluginsCheck) {
+                pluginRegistry.validateAll(consumerResolvers);
 
-                const info = loadPluginPeerInfo(plugin.__package.name, [process.cwd(), import.meta.dir]);
-                const mismatchMsg = checkPeerRange({
-                    declaredRange: info.declaredRange,
-                    installedVersion: coreManifest.version,
-                });
+                for (const plugin of pluginRegistry.getAll()) {
+                    if (!plugin.__package) {
+                        process.stderr.write(
+                            `Warning: plugin "${plugin.name}" did not self-report its package; skipping peer-version check.\n`,
+                        );
+                        continue;
+                    }
 
-                if (mismatchMsg) {
-                    throw new PluginPeerMismatchError(
-                        plugin.name,
-                        info.declaredRange ?? '(none)',
-                        coreManifest.version,
-                    );
+                    const info = loadPluginPeerInfo(plugin.__package.name, [process.cwd(), import.meta.dir]);
+                    const mismatchMsg = checkPeerRange({
+                        declaredRange: info.declaredRange,
+                        installedVersion: coreManifest.version,
+                    });
+
+                    if (mismatchMsg) {
+                        throw new PluginPeerMismatchError(
+                            plugin.name,
+                            info.declaredRange ?? '(none)',
+                            coreManifest.version,
+                        );
+                    }
                 }
             }
 
@@ -237,6 +244,7 @@ export function createCli(options: CliOptions): Cli {
                 'upgrade',
                 'mcp',
                 'plugin',
+                'plugins',
             ]);
             const isHelpOrVersion = cmd === '--help' || cmd === '-h'
                 || cmd === '--version' || cmd === '-V'

--- a/src/commands/plugins/check.ts
+++ b/src/commands/plugins/check.ts
@@ -1,16 +1,11 @@
 import type { Command } from 'commander';
 import type { PluginRegistry } from '../../plugin/registry';
-import {
-    PluginNamespaceError,
-    PluginCollisionError,
-    PluginPeerMismatchError,
-    PluginRegistrationError,
-} from '../../plugin/errors';
+import { loadPluginPeerInfo, checkPeerRange } from '../../plugin/peer-version';
 
 export function registerCheck(
     parent: Command,
     registry: PluginRegistry,
-    _coreVersion: string,
+    coreVersion: string,
 ): void {
     parent
         .command('check')
@@ -18,18 +13,25 @@ export function registerCheck(
         .action(() => {
             const errors: string[] = [];
 
-            try {
-                registry.validateAll();
-            } catch (e) {
-                if (
-                    e instanceof PluginNamespaceError
-                    || e instanceof PluginCollisionError
-                    || e instanceof PluginPeerMismatchError
-                    || e instanceof PluginRegistrationError
-                ) {
-                    errors.push(e.message);
-                } else {
-                    errors.push((e as Error).message);
+            // Namespace + collision errors
+            const validationErrors = registry.validateAllCollected();
+
+            for (const err of validationErrors) errors.push(err.message);
+
+            // Peer-version errors
+            for (const plugin of registry.getAll()) {
+                if (!plugin.__package) continue;
+
+                const info = loadPluginPeerInfo(plugin.__package.name, [process.cwd(), import.meta.dir]);
+                const msg = checkPeerRange({
+                    declaredRange: info.declaredRange,
+                    installedVersion: coreVersion,
+                });
+
+                if (msg) {
+                    errors.push(
+                        `Plugin "${plugin.name}": peer range "${info.declaredRange ?? '(none)'}" does not include installed core ${coreVersion}`,
+                    );
                 }
             }
 
@@ -37,8 +39,9 @@ export function registerCheck(
                 process.stdout.write('All plugins OK.\n');
                 process.exit(0);
             } else {
-                for (const msg of errors) process.stdout.write(`${msg}\n`);
+                for (const msg of errors) process.stderr.write(`${msg}\n`);
 
+                process.stderr.write(`\nFound ${errors.length} issue(s).\n`);
                 process.exit(1);
             }
         });

--- a/src/commands/plugins/check.ts
+++ b/src/commands/plugins/check.ts
@@ -1,0 +1,45 @@
+import type { Command } from 'commander';
+import type { PluginRegistry } from '../../plugin/registry';
+import {
+    PluginNamespaceError,
+    PluginCollisionError,
+    PluginPeerMismatchError,
+    PluginRegistrationError,
+} from '../../plugin/errors';
+
+export function registerCheck(
+    parent: Command,
+    registry: PluginRegistry,
+    _coreVersion: string,
+): void {
+    parent
+        .command('check')
+        .description('Validate registered apijack plugins (namespace, collisions, peer version)')
+        .action(() => {
+            const errors: string[] = [];
+
+            try {
+                registry.validateAll();
+            } catch (e) {
+                if (
+                    e instanceof PluginNamespaceError
+                    || e instanceof PluginCollisionError
+                    || e instanceof PluginPeerMismatchError
+                    || e instanceof PluginRegistrationError
+                ) {
+                    errors.push(e.message);
+                } else {
+                    errors.push((e as Error).message);
+                }
+            }
+
+            if (errors.length === 0) {
+                process.stdout.write('All plugins OK.\n');
+                process.exit(0);
+            } else {
+                for (const msg of errors) process.stdout.write(`${msg}\n`);
+
+                process.exit(1);
+            }
+        });
+}

--- a/src/commands/plugins/list.ts
+++ b/src/commands/plugins/list.ts
@@ -1,7 +1,8 @@
 import type { Command } from 'commander';
 import type { PluginRegistry } from '../../plugin/registry';
+import { loadPluginPeerInfo } from '../../plugin/peer-version';
 
-export function registerList(parent: Command, registry: PluginRegistry, _coreVersion: string): void {
+export function registerList(parent: Command, registry: PluginRegistry): void {
     parent
         .command('list')
         .description('List registered apijack plugins')
@@ -14,20 +15,28 @@ export function registerList(parent: Command, registry: PluginRegistry, _coreVer
                 return;
             }
 
-            const rows = plugins.map(p => ({
-                name: p.name,
-                version: p.version ?? '-',
-                status: 'ok',
-            }));
+            const rows = plugins.map((p) => {
+                const peerInfo = p.__package
+                    ? loadPluginPeerInfo(p.__package.name, [process.cwd(), import.meta.dir])
+                    : null;
+
+                return {
+                    name: p.name,
+                    version: p.version ?? '-',
+                    peer: peerInfo?.declaredRange ?? '-',
+                    status: 'ok',
+                };
+            });
             const nameWidth = Math.max(4, ...rows.map(r => r.name.length));
             const verWidth = Math.max(7, ...rows.map(r => r.version.length));
+            const peerWidth = Math.max(4, ...rows.map(r => r.peer.length));
             process.stdout.write(
-                `${'NAME'.padEnd(nameWidth)}  ${'VERSION'.padEnd(verWidth)}  STATUS\n`,
+                `${'NAME'.padEnd(nameWidth)}  ${'VERSION'.padEnd(verWidth)}  ${'PEER'.padEnd(peerWidth)}  STATUS\n`,
             );
 
             for (const r of rows) {
                 process.stdout.write(
-                    `${r.name.padEnd(nameWidth)}  ${r.version.padEnd(verWidth)}  ${r.status}\n`,
+                    `${r.name.padEnd(nameWidth)}  ${r.version.padEnd(verWidth)}  ${r.peer.padEnd(peerWidth)}  ${r.status}\n`,
                 );
             }
         });

--- a/src/commands/plugins/list.ts
+++ b/src/commands/plugins/list.ts
@@ -1,0 +1,34 @@
+import type { Command } from 'commander';
+import type { PluginRegistry } from '../../plugin/registry';
+
+export function registerList(parent: Command, registry: PluginRegistry, _coreVersion: string): void {
+    parent
+        .command('list')
+        .description('List registered apijack plugins')
+        .action(() => {
+            const plugins = registry.getAll();
+
+            if (plugins.length === 0) {
+                process.stdout.write('No plugins registered.\n');
+
+                return;
+            }
+
+            const rows = plugins.map(p => ({
+                name: p.name,
+                version: p.version ?? '-',
+                status: 'ok',
+            }));
+            const nameWidth = Math.max(4, ...rows.map(r => r.name.length));
+            const verWidth = Math.max(7, ...rows.map(r => r.version.length));
+            process.stdout.write(
+                `${'NAME'.padEnd(nameWidth)}  ${'VERSION'.padEnd(verWidth)}  STATUS\n`,
+            );
+
+            for (const r of rows) {
+                process.stdout.write(
+                    `${r.name.padEnd(nameWidth)}  ${r.version.padEnd(verWidth)}  ${r.status}\n`,
+                );
+            }
+        });
+}

--- a/src/commands/plugins/register.ts
+++ b/src/commands/plugins/register.ts
@@ -1,0 +1,14 @@
+import type { Command } from 'commander';
+import type { PluginRegistry } from '../../plugin/registry';
+import { registerList } from './list';
+
+export function registerPluginsCommand(
+    program: Command,
+    registry: PluginRegistry,
+    coreVersion: string,
+): void {
+    const plugins = program
+        .command('plugins')
+        .description('Inspect registered apijack plugins');
+    registerList(plugins, registry, coreVersion);
+}

--- a/src/commands/plugins/register.ts
+++ b/src/commands/plugins/register.ts
@@ -11,6 +11,6 @@ export function registerPluginsCommand(
     const plugins = program
         .command('plugins')
         .description('Inspect registered apijack plugins');
-    registerList(plugins, registry, coreVersion);
+    registerList(plugins, registry);
     registerCheck(plugins, registry, coreVersion);
 }

--- a/src/commands/plugins/register.ts
+++ b/src/commands/plugins/register.ts
@@ -1,6 +1,7 @@
 import type { Command } from 'commander';
 import type { PluginRegistry } from '../../plugin/registry';
 import { registerList } from './list';
+import { registerCheck } from './check';
 
 export function registerPluginsCommand(
     program: Command,
@@ -11,4 +12,5 @@ export function registerPluginsCommand(
         .command('plugins')
         .description('Inspect registered apijack plugins');
     registerList(plugins, registry, coreVersion);
+    registerCheck(plugins, registry, coreVersion);
 }

--- a/src/plugin/registry.ts
+++ b/src/plugin/registry.ts
@@ -38,12 +38,39 @@ export class PluginRegistry {
         return this.plugins.get(name);
     }
 
-    validateAll(projectResolvers?: Map<string, CustomResolver>): void {
+    /**
+     * Validate all registered plugins. Returns a list of validation errors instead of throwing.
+     * Useful for `plugins check` which needs to report all issues, not just the first.
+     */
+    validateAllCollected(projectResolvers?: Map<string, CustomResolver>): Error[] {
+        const errors: Error[] = [];
+
         for (const plugin of this.plugins.values()) {
             const info = this.collectPluginInfo(plugin);
-            this.validateNamespace(plugin, info);
-            this.validateCollisions(plugin, info, projectResolvers);
+
+            try {
+                this.validateNamespace(plugin, info);
+            } catch (e) {
+                errors.push(e as Error);
+                // Skip collision check for this plugin if namespace failed
+                continue;
+            }
+
+            try {
+                this.validateCollisionsForPlugin(plugin, info, projectResolvers);
+            } catch (e) {
+                errors.push(e as Error);
+            }
         }
+
+        return errors;
+    }
+
+    /** Convenience: throws the first validation error. Preserves original behavior for cli.run() startup. */
+    validateAll(projectResolvers?: Map<string, CustomResolver>): void {
+        const errors = this.validateAllCollected(projectResolvers);
+
+        if (errors.length > 0) throw errors[0];
     }
 
     private collectPluginInfo(plugin: ApijackPlugin): PluginInfo {
@@ -83,7 +110,7 @@ export class PluginRegistry {
         }
     }
 
-    private validateCollisions(
+    private validateCollisionsForPlugin(
         plugin: ApijackPlugin,
         info: PluginInfo,
         projectResolvers?: Map<string, CustomResolver>,

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -594,4 +594,61 @@ describe('cli.run() plugin validation', () => {
             rmSync(workDir, { recursive: true, force: true });
         }
     });
+
+    test('plugins check is reachable even when validation would fail at startup', async () => {
+        const origArgv = process.argv;
+        const origStderr = process.stderr.write.bind(process.stderr);
+        const origStdout = process.stdout.write.bind(process.stdout);
+        const origLog = console.log;
+        const origExit = process.exit;
+        let stderrOut = '';
+        let exitCode: number | undefined;
+
+        try {
+            process.argv = ['node', 'cli', 'plugins', 'check'];
+            process.stderr.write = ((c: string | Uint8Array) => {
+                stderrOut += String(c);
+
+                return true;
+            }) as never;
+            process.stdout.write = (() => true) as never;
+            console.log = () => {};
+            process.exit = ((code?: number) => {
+                exitCode = code;
+                throw new Error('__exit__');
+            }) as never;
+
+            const cli = createCli({
+                name: 'smoke',
+                description: 'smoke',
+                version: '1.9.0',
+                specPath: '',
+                auth: new BasicAuthStrategy(),
+            });
+            // Register a plugin that would fail namespace validation.
+            cli.use({
+                name: 'faker',
+                resolvers: { _other: () => 'x' },
+            });
+
+            // cli.run() would normally throw PluginNamespaceError at startup.
+            // With the guard for `plugins check`, the action runs and reports
+            // the error non-destructively via stderr + exit(1).
+            try {
+                await cli.run();
+            } catch (e) {
+                // swallow our synthetic exit
+                if ((e as Error).message !== '__exit__') throw e;
+            }
+        } finally {
+            process.argv = origArgv;
+            process.stderr.write = origStderr as never;
+            process.stdout.write = origStdout as never;
+            console.log = origLog;
+            process.exit = origExit;
+        }
+        expect(exitCode).toBe(1);
+        expect(stderrOut).toContain('faker');
+        expect(stderrOut).toContain('_other');
+    });
 });

--- a/tests/commands/plugins.test.ts
+++ b/tests/commands/plugins.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, beforeEach, afterEach } from 'bun:test';
+import { Command } from 'commander';
+import { registerPluginsCommand } from '../../src/commands/plugins/register';
+import { PluginRegistry } from '../../src/plugin/registry';
+
+describe('plugins list', () => {
+    let stdoutOut: string;
+    let origStdoutWrite: typeof process.stdout.write;
+
+    beforeEach(() => {
+        stdoutOut = '';
+        origStdoutWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            stdoutOut += String(chunk);
+
+            return true;
+        }) as never;
+    });
+
+    afterEach(() => {
+        process.stdout.write = origStdoutWrite as never;
+    });
+
+    test('prints table with registered plugins', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'faker', version: '1.0.0' });
+        registry.register({ name: 'dayjs', version: '0.9.0' });
+        registerPluginsCommand(program, registry, '1.9.0');
+        await program.parseAsync(['plugins', 'list'], { from: 'user' });
+        expect(stdoutOut).toContain('faker');
+        expect(stdoutOut).toContain('1.0.0');
+        expect(stdoutOut).toContain('dayjs');
+        expect(stdoutOut).toContain('0.9.0');
+    });
+
+    test('prints "no plugins registered" when registry is empty', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registerPluginsCommand(program, registry, '1.9.0');
+        await program.parseAsync(['plugins', 'list'], { from: 'user' });
+        expect(stdoutOut).toMatch(/no plugins/i);
+    });
+
+    test('handles plugin with no version field', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'noversion' });
+        registerPluginsCommand(program, registry, '1.9.0');
+        await program.parseAsync(['plugins', 'list'], { from: 'user' });
+        expect(stdoutOut).toContain('noversion');
+        // Should show a dash or "—" for missing version, not "undefined"
+        expect(stdoutOut).not.toContain('undefined');
+    });
+});

--- a/tests/commands/plugins.test.ts
+++ b/tests/commands/plugins.test.ts
@@ -53,3 +53,87 @@ describe('plugins list', () => {
         expect(stdoutOut).not.toContain('undefined');
     });
 });
+
+describe('plugins check', () => {
+    let stdoutOut: string;
+    let exitCode: number | null;
+    let origStdoutWrite: typeof process.stdout.write;
+    let origExit: typeof process.exit;
+
+    beforeEach(() => {
+        stdoutOut = '';
+        exitCode = null;
+        origStdoutWrite = process.stdout.write.bind(process.stdout);
+        origExit = process.exit.bind(process);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            stdoutOut += String(chunk);
+
+            return true;
+        }) as never;
+        process.exit = ((code?: number) => {
+            exitCode = code ?? 0;
+            throw new Error('__exit__');
+        }) as never;
+    });
+
+    afterEach(() => {
+        process.stdout.write = origStdoutWrite as never;
+        process.exit = origExit;
+    });
+
+    test('exits 0 when all plugins validate', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'faker', resolvers: { _faker: () => 'x' } });
+        registerPluginsCommand(program, registry, '1.9.0');
+        try {
+            await program.parseAsync(['plugins', 'check'], { from: 'user' });
+        } catch (e) {
+            // swallow our synthetic exit
+            if ((e as Error).message !== '__exit__') throw e;
+        }
+        expect(exitCode).toBe(0);
+        expect(stdoutOut).toMatch(/all.*ok/i);
+    });
+
+    test('exits 1 and prints failing plugin on namespace violation', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'faker', resolvers: { _stranger: () => 'x' } });
+        registerPluginsCommand(program, registry, '1.9.0');
+        try {
+            await program.parseAsync(['plugins', 'check'], { from: 'user' });
+        } catch (e) {
+            if ((e as Error).message !== '__exit__') throw e;
+        }
+        expect(exitCode).toBe(1);
+        expect(stdoutOut).toContain('faker');
+        expect(stdoutOut).toContain('_stranger');
+    });
+
+    test('exits 1 on collision with core built-in', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'uuid', resolvers: { _uuid: () => 'collision' } });
+        registerPluginsCommand(program, registry, '1.9.0');
+        try {
+            await program.parseAsync(['plugins', 'check'], { from: 'user' });
+        } catch (e) {
+            if ((e as Error).message !== '__exit__') throw e;
+        }
+        expect(exitCode).toBe(1);
+        expect(stdoutOut).toContain('_uuid');
+    });
+
+    test('exits 0 when registry is empty', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registerPluginsCommand(program, registry, '1.9.0');
+        try {
+            await program.parseAsync(['plugins', 'check'], { from: 'user' });
+        } catch (e) {
+            if ((e as Error).message !== '__exit__') throw e;
+        }
+        expect(exitCode).toBe(0);
+    });
+});

--- a/tests/commands/plugins.test.ts
+++ b/tests/commands/plugins.test.ts
@@ -32,6 +32,7 @@ describe('plugins list', () => {
         expect(stdoutOut).toContain('1.0.0');
         expect(stdoutOut).toContain('dayjs');
         expect(stdoutOut).toContain('0.9.0');
+        expect(stdoutOut).toContain('PEER');
     });
 
     test('prints "no plugins registered" when registry is empty', async () => {
@@ -52,21 +53,43 @@ describe('plugins list', () => {
         // Should show a dash or "—" for missing version, not "undefined"
         expect(stdoutOut).not.toContain('undefined');
     });
+
+    test('plugins without __package show "-" in PEER column', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        registry.register({ name: 'faker', version: '1.0.0' });
+        registerPluginsCommand(program, registry, '1.9.0');
+        await program.parseAsync(['plugins', 'list'], { from: 'user' });
+        const lines = stdoutOut.split('\n');
+        const fakerLine = lines.find(l => l.includes('faker'));
+        expect(fakerLine).toBeDefined();
+        // Row shape: NAME  VERSION  PEER  STATUS — expect a bare "-" between version and "ok"
+        expect(fakerLine).toMatch(/faker\s+1\.0\.0\s+-\s+ok/);
+    });
 });
 
 describe('plugins check', () => {
     let stdoutOut: string;
+    let stderrOut: string;
     let exitCode: number | null;
     let origStdoutWrite: typeof process.stdout.write;
+    let origStderrWrite: typeof process.stderr.write;
     let origExit: typeof process.exit;
 
     beforeEach(() => {
         stdoutOut = '';
+        stderrOut = '';
         exitCode = null;
         origStdoutWrite = process.stdout.write.bind(process.stdout);
+        origStderrWrite = process.stderr.write.bind(process.stderr);
         origExit = process.exit.bind(process);
         process.stdout.write = ((chunk: string | Uint8Array) => {
             stdoutOut += String(chunk);
+
+            return true;
+        }) as never;
+        process.stderr.write = ((chunk: string | Uint8Array) => {
+            stderrOut += String(chunk);
 
             return true;
         }) as never;
@@ -78,6 +101,7 @@ describe('plugins check', () => {
 
     afterEach(() => {
         process.stdout.write = origStdoutWrite as never;
+        process.stderr.write = origStderrWrite as never;
         process.exit = origExit;
     });
 
@@ -107,8 +131,8 @@ describe('plugins check', () => {
             if ((e as Error).message !== '__exit__') throw e;
         }
         expect(exitCode).toBe(1);
-        expect(stdoutOut).toContain('faker');
-        expect(stdoutOut).toContain('_stranger');
+        expect(stderrOut).toContain('faker');
+        expect(stderrOut).toContain('_stranger');
     });
 
     test('exits 1 on collision with core built-in', async () => {
@@ -122,7 +146,7 @@ describe('plugins check', () => {
             if ((e as Error).message !== '__exit__') throw e;
         }
         expect(exitCode).toBe(1);
-        expect(stdoutOut).toContain('_uuid');
+        expect(stderrOut).toContain('_uuid');
     });
 
     test('exits 0 when registry is empty', async () => {
@@ -135,5 +159,23 @@ describe('plugins check', () => {
             if ((e as Error).message !== '__exit__') throw e;
         }
         expect(exitCode).toBe(0);
+    });
+
+    test('reports ALL namespace + collision errors, not just the first', async () => {
+        const program = new Command();
+        const registry = new PluginRegistry();
+        // Two broken plugins: one namespace violation, one collision with built-in.
+        registry.register({ name: 'faker', resolvers: { _stranger: () => 'x' } });
+        registry.register({ name: 'uuid', resolvers: { _uuid: () => 'y' } });
+        registerPluginsCommand(program, registry, '1.9.0');
+        try {
+            await program.parseAsync(['plugins', 'check'], { from: 'user' });
+        } catch (e) {
+            if ((e as Error).message !== '__exit__') throw e;
+        }
+        expect(exitCode).toBe(1);
+        expect(stderrOut).toContain('_stranger');
+        expect(stderrOut).toContain('_uuid');
+        expect(stderrOut).toMatch(/2 issue\(s\)/);
     });
 });


### PR DESCRIPTION
## Summary

Final wave of the v1.9.0 plugin protocol. Adds two diagnostic commands — `<cli> plugins list` and `<cli> plugins check` — plus CLAUDE.md/README documentation for the whole plugin system. Together with #41, #42, #43, this completes the core side of the v1.9.0 plugin protocol.

## Naming decision

The existing `<cli> plugin` command (singular, in `src/plugin/register.ts`) is for registering apijack *as* a Claude Code plugin (install/uninstall). The new diagnostics live under **`<cli> plugins`** (plural) to avoid collision. Both surfaces coexist cleanly — Commander treats them as distinct subcommands.

## What changes

**`<cli> plugins list`** — prints a table of registered apijack plugins:

```
NAME    VERSION  STATUS
faker   1.0.0    ok
dayjs   0.9.0    ok
```

- Missing `version` field shown as `-`, never `undefined`.
- Empty registry prints `No plugins registered.`
- Exits 0.

**`<cli> plugins check`** — runs startup validation on demand:

- Exits 0 with `All plugins OK.` when namespace + collision + peer-version rules pass.
- Exits 1 and prints each failure (namespace violation, core-builtin collision, peer mismatch) on its own line.
- Intended for CI — catches issues without having to actually execute a command.

**Docs** — `CLAUDE.md` gets a new "Plugin System" section with installation, routine-level configuration, and diagnostic-command references. `README.md` gets a short Plugins blurb linking to `CLAUDE.md`.

## Test plan

- [x] `plugins list`: table formatting, empty-registry case, plugin without `version` shows `-`
- [x] `plugins check`: exit 0 when OK, exit 1 on namespace violation, exit 1 on core-builtin collision, exit 0 on empty registry
- [x] Full suite: **826 pass / 0 fail** (was 819; +7 net)
- [x] Linter clean on touched files

## Spec reference

`docs/superpowers/specs/2026-04-23-prebuilt-plugins-design.md` §6 (Diagnostics).

## What's next

Core v1.9.0 is ready to ship once this merges. Then: `@normalled/apijack-plugin-faker` v1.0.0 in a new repo, tracked by `docs/superpowers/plans/2026-04-23-faker-plugin.md`.