### PR TITLE
feat(plugins): .apijack/plugins.ts auto-registration extension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,24 @@ cli.use(faker({ seed: 42 }));  // with default opts
 await cli.run();
 ```
 
+### Auto-registration via `.apijack/plugins.ts`
+
+Projects that consume the shared `apijack` binary (no custom `bin/<cli>.ts`) can register plugins by exporting an array from `.apijack/plugins.ts`:
+
+```ts
+// .apijack/plugins.ts
+import faker from '@apijack/plugin-faker';
+import type { ApijackPlugin } from '@apijack/core';
+
+const plugins: ApijackPlugin[] = [
+    faker({ seed: 42 }),
+];
+
+export default plugins;
+```
+
+The binary calls `cli.use(plugin)` for each entry before registering project commands, dispatchers, and resolvers — so a project resolver can wrap a plugin-provided function.
+
 ### Per-routine plugin configuration
 
 ```yaml
@@ -184,6 +202,7 @@ The `.apijack/` directory at a project root is auto-loaded when the CLI runs ins
 | `.apijack/dispatchers/<name>.ts` | Handle non-API commands invoked from routines (`default: (args, posArgs, ctx) => Promise<unknown>`) |
 | `.apijack/resolvers/<name>.ts` | Custom `$_*(...)` routine functions |
 | `.apijack/auth.ts` | Project-level `AuthStrategy` and optional `onChallenge` |
+| `.apijack/plugins.ts` | Project-level plugin registrations (`default: ApijackPlugin[]` — each entry passed to `cli.use(...)`) |
 | `.apijack/routines/*.yaml` | Routines available via `routine run <name>` |
 | `.apijack/settings.json` | Framework defaults (see below) |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,13 +106,13 @@ Usable anywhere a routine value is resolved (args, conditions, variables):
 
 ## Plugin System
 
-apijack supports pre-built plugins as standalone npm packages. Plugins register resolver functions under their own namespace (e.g., `@normalled/apijack-plugin-faker` exposes `$_faker(...)` for routines).
+apijack supports pre-built plugins as standalone npm packages. Plugins register resolver functions under their own namespace (e.g., `@apijack/plugin-faker` exposes `$_faker(...)` for routines).
 
 ### Installing a plugin
 
 ```ts
 import { createCli } from "@apijack/core";
-import faker from "@normalled/apijack-plugin-faker";
+import faker from "@apijack/plugin-faker";
 
 const cli = createCli({ name: "mycli", /* ... */ });
 cli.use(faker());              // zero-config

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -9,7 +9,7 @@ import { BasicAuthStrategy } from '../src/auth/basic';
 import { BearerTokenStrategy } from '../src/auth/bearer';
 import { ApiKeyStrategy } from '../src/auth/api-key';
 import { findProjectConfig, loadProjectConfig, resolveConfigDir } from '../src/project';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectPlugins, loadProjectResolvers } from '../src/project-loader';
 import { loadProjectSettings } from '../src/settings';
 import { checkForUpdate } from '../src/updater';
 import { getActiveEnvConfig } from '../src/config';
@@ -153,6 +153,14 @@ const cli = createCli({
 
 // 10. Register project-level extensions
 if (projectRoot) {
+    // Plugins register first so project resolvers/commands/dispatchers can
+    // depend on plugin-provided resolver functions or registered state.
+    const plugins = await loadProjectPlugins(join(projectRoot, '.apijack'));
+
+    for (const plugin of plugins) {
+        cli.use(plugin);
+    }
+
     const commands = await loadProjectCommands(join(projectRoot, '.apijack'));
 
     for (const cmd of commands) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export {
     PluginPeerMismatchError,
     PluginRegistrationError,
 } from './plugin/errors';
-export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from './project-loader';
+export { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectPlugins, loadProjectResolvers } from './project-loader';
 export type { LoadedCommand, LoadedDispatcher } from './project-loader';
 export { loadProjectSettings } from './settings';
 export type { ProjectSettings } from './settings';

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import type { AuthStrategy, SessionAuthConfig } from './auth/types';
 import { BUILTIN_RESOLVER_NAMES } from './routine/resolver';
-import type { CommandRegistrar, DispatcherHandler, CustomResolver } from './types';
+import type { CommandRegistrar, DispatcherHandler, CustomResolver, ApijackPlugin } from './types';
 
 export interface ProjectAuth {
     strategy: AuthStrategy | null;
@@ -135,4 +135,25 @@ export async function loadProjectResolvers(
     }
 
     return resolvers;
+}
+
+export async function loadProjectPlugins(
+    apijackDir: string,
+): Promise<ApijackPlugin[]> {
+    const pluginsPath = join(apijackDir, 'plugins.ts');
+
+    if (!existsSync(pluginsPath)) return [];
+
+    try {
+        const mod = await import(pluginsPath);
+        const plugins = mod.default;
+
+        if (!Array.isArray(plugins)) return [];
+
+        return plugins.filter(
+            (p): p is ApijackPlugin => p != null && typeof p === 'object',
+        );
+    } catch {
+        return [];
+    }
 }

--- a/src/project-loader.ts
+++ b/src/project-loader.ts
@@ -151,7 +151,7 @@ export async function loadProjectPlugins(
         if (!Array.isArray(plugins)) return [];
 
         return plugins.filter(
-            (p): p is ApijackPlugin => p != null && typeof p === 'object',
+            (p): p is ApijackPlugin => p != null && typeof p === 'object' && !Array.isArray(p),
         );
     } catch {
         return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,6 @@ export interface ApijackPlugin {
      *  `routine.plugins[plugin.name] ?? {}`. Must tolerate `{}` (empty opts). */
     createRoutineResolvers?: (opts: unknown) => Record<string, CustomResolver>;
     /** Internal: set by the plugin's default export so core can locate its package.json.
-     *  Typically set as `__package: { name: "@normalled/apijack-plugin-faker" }`. */
+     *  Typically set as `__package: { name: "@apijack/plugin-faker" }`. */
     __package?: { name: string; version?: string };
 }

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, afterEach } from 'bun:test';
-import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectResolvers } from '../src/project-loader';
+import { loadProjectAuth, loadProjectCommands, loadProjectDispatchers, loadProjectPlugins, loadProjectResolvers } from '../src/project-loader';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -263,5 +263,110 @@ describe('loadProjectResolvers()', () => {
 
         const result = await loadProjectResolvers(testRoot);
         expect(result.size).toBe(0);
+    });
+});
+
+describe('loadProjectPlugins()', () => {
+    const makeRoot = (suffix: string) =>
+        join(tmpdir(), `apijack-loader-plugins-${suffix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+    test('returns empty array when no plugins.ts exists', async () => {
+        const root = makeRoot('none');
+        mkdirSync(root, { recursive: true });
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toEqual([]);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test('loads plugin instances from plugins.ts default export', async () => {
+        const root = makeRoot('default');
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'plugins.ts'), `
+            export default [
+                { name: 'alpha', version: '1.0.0' },
+                { name: 'beta' },
+            ];
+        `);
+
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toHaveLength(2);
+            expect(result[0]!.name).toBe('alpha');
+            expect(result[0]!.version).toBe('1.0.0');
+            expect(result[1]!.name).toBe('beta');
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test('returns empty array when default export is not an array', async () => {
+        const root = makeRoot('not-array');
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'plugins.ts'), `
+            export default { name: 'not-an-array' };
+        `);
+
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toEqual([]);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test('returns empty array when plugins.ts has no default export', async () => {
+        const root = makeRoot('no-default');
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'plugins.ts'), `
+            export const plugins = [{ name: 'named-export-only' }];
+        `);
+
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toEqual([]);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test('filters out null and non-object entries', async () => {
+        const root = makeRoot('filter');
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'plugins.ts'), `
+            export default [
+                { name: 'good' },
+                null,
+                undefined,
+                'string-entry',
+                42,
+                { name: 'also-good' },
+            ];
+        `);
+
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toHaveLength(2);
+            expect(result.map(p => p.name)).toEqual(['good', 'also-good']);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    test('returns empty array when plugins.ts throws on import', async () => {
+        const root = makeRoot('throws');
+        mkdirSync(root, { recursive: true });
+        writeFileSync(join(root, 'plugins.ts'), `
+            throw new Error('boom');
+        `);
+
+        try {
+            const result = await loadProjectPlugins(root);
+            expect(result).toEqual([]);
+        } finally {
+            rmSync(root, { recursive: true, force: true });
+        }
     });
 });

--- a/tests/project-loader.test.ts
+++ b/tests/project-loader.test.ts
@@ -332,7 +332,7 @@ describe('loadProjectPlugins()', () => {
         }
     });
 
-    test('filters out null and non-object entries', async () => {
+    test('filters out null, primitives, and array entries', async () => {
         const root = makeRoot('filter');
         mkdirSync(root, { recursive: true });
         writeFileSync(join(root, 'plugins.ts'), `
@@ -342,6 +342,7 @@ describe('loadProjectPlugins()', () => {
                 undefined,
                 'string-entry',
                 42,
+                [{ name: 'nested-array' }],
                 { name: 'also-good' },
             ];
         `);


### PR DESCRIPTION
## Summary

Adds a `.apijack/plugins.ts` extension that the shared `apijack` binary auto-loads and registers via `cli.use(plugin)`. Eliminates the need for consumer projects (e.g., rrc-cli) to fork the entire `bin/apijack.ts` bootstrap just to register a single plugin.

A consumer project can now drop a 4-line `.apijack/plugins.ts` exporting an `ApijackPlugin[]` and the binary handles the rest — alongside the existing `.apijack/auth.ts`, `commands/`, `dispatchers/`, and `resolvers/` extensions.

## What changes

### New loader (`src/project-loader.ts`)

`loadProjectPlugins(apijackDir)` mirrors the existing `loadProjectAuth` shape:

```ts
export async function loadProjectPlugins(apijackDir: string): Promise<ApijackPlugin[]> {
    const pluginsPath = join(apijackDir, 'plugins.ts');
    if (!existsSync(pluginsPath)) return [];
    try {
        const mod = await import(pluginsPath);
        const plugins = mod.default;
        if (!Array.isArray(plugins)) return [];
        return plugins.filter((p): p is ApijackPlugin => p != null && typeof p === 'object');
    } catch {
        return [];
    }
}
```

Failure modes match sibling loaders: missing file, malformed export, and import errors all return `[]` (silent skip, consistent with the rest of `project-loader.ts`).

### Wiring in `bin/apijack.ts`

Plugins register **first** in the project-extensions block, before commands/dispatchers/resolvers — so a project resolver can wrap a plugin-provided resolver function:

```ts
if (projectRoot) {
    const plugins = await loadProjectPlugins(join(projectRoot, '.apijack'));
    for (const plugin of plugins) {
        cli.use(plugin);
    }
    // ...then commands, dispatchers, resolvers
}
```

### Public API

`loadProjectPlugins` is exported from `src/index.ts` alongside the other `loadProjectX` siblings, so consumers writing a custom `bin/<cli>.ts` can use it directly.

### Docs (`CLAUDE.md`)

- New row in the Project Extensions table for `.apijack/plugins.ts`.
- New `### Auto-registration via .apijack/plugins.ts` subsection under `## Plugin System` with a copy-pasteable example.
- Stale `@normalled/apijack-plugin-faker` package-name references corrected to the npm name `@apijack/plugin-faker` in three places (CLAUDE.md ×2, src/types.ts ×1).

## End-user shape

```ts
// .apijack/plugins.ts
import faker from '@apijack/plugin-faker';
import type { ApijackPlugin } from '@apijack/core';

const plugins: ApijackPlugin[] = [
    faker({ seed: 42 }),
];

export default plugins;
```

## Acceptance criteria

- [ ] A project with a `.apijack/plugins.ts` exporting `ApijackPlugin[]` registers each entry via `cli.use(...)` when the binary boots.
- [ ] Plugins register **before** project commands/dispatchers/resolvers, so a project resolver can reference a plugin-provided function.
- [ ] Missing `.apijack/plugins.ts` → no error, no behavior change (loader returns `[]`).
- [ ] Malformed export (non-array default, no default, throw on import) → silent skip, no crash.
- [ ] Non-object entries in the array (null, undefined, primitives) are filtered out before `cli.use()`.
- [ ] `loadProjectPlugins` is exported from `@apijack/core` (`src/index.ts`).
- [ ] CLAUDE.md documents the new extension in both the Project Extensions table and the Plugin System section.

## Test plan

- [x] `bun test` — 835 pass / 0 fail (was 829)
- [x] `bun run lint` — 0 errors (107 pre-existing warnings)
- [x] Six new unit tests in `tests/project-loader.test.ts` covering: missing file, valid array, non-array default, no default export, mixed null/non-object entries, import-throw error
- [x] End-to-end smoke test: temp project with `.apijack.json` marker + `.apijack/plugins.ts` exporting `[{ name: 'smoketest', version: '0.0.1', resolvers: { _smoketest: () => 'ok' } }]` → `bun run bin/apijack.ts plugins list` shows the `smoketest` row

## Commits

- `2cf35c3` docs(plugins): document `.apijack/plugins.ts` extension
- `03f435e` feat(plugins): add `loadProjectPlugins` for `.apijack/plugins.ts`
- `eeb152a` feat(plugins): auto-register `.apijack/plugins.ts` in `bin/apijack`
- `c23a008` feat(plugins): export `loadProjectPlugins` from public API
- `c985aa7` docs(plugins): use npm package name `@apijack/plugin-faker` in examples