### PR TITLE
ci: skip tests + e2e on PRs that don't touch testable surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+    # Skip on PRs that don't touch testable surface area. Pushes to main / dev
+    # always run (above) so the branch heads stay verified.
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'package.json'
+      - 'bun.lockb'
+      - 'tsconfig*.json'
+      - '.github/workflows/ci.yml'
 
 jobs:
   lint:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,15 @@ on:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+    # E2E only needs to fire on PRs that touch codegen, fixtures, build / lock,
+    # or this workflow itself. Pushes to main / dev still always run (above).
+    paths:
+      - 'src/**'
+      - 'tests/fixtures/**'
+      - 'package.json'
+      - 'bun.lockb'
+      - 'tsconfig*.json'
+      - '.github/workflows/e2e.yml'
 
 jobs:
   codegen-petstore:


### PR DESCRIPTION
## Summary

Skip `Tests` and `E2E` workflow runs on PRs that don't touch testable surface area. Pushes to `main` / `dev` still always run, so the branch heads stay verified.

## What changes

`paths` filter on the `pull_request` trigger in both workflows:

- **`ci.yml`** runs on PRs that touch `src/**`, `tests/**`, `package.json`, `bun.lockb`, `tsconfig*.json`, or the workflow itself.
- **`e2e.yml`** runs on PRs that touch `src/**`, `tests/fixtures/**`, build/lock/tsconfig, or the workflow itself. The e2e suite is fixture-driven, so doc/skill PRs can't break codegen.

PRs that only modify docs (`*.md`), skill files (`.claude/**`), cron yamls (`.claude-jobs/**`), or release scripts no longer fire either workflow.

## Caveat — required status checks

GitHub treats path-filtered PR runs as *skipped*: no checks reported. If `Tests` or `E2E` is configured as a required status check on a branch protection rule, PRs that skip will sit waiting indefinitely.

Two ways to handle this if it bites:
- mark the checks as not strictly required, or
- add a separate "always-pass on path-skip" job with the same name as the required check (the dummy-job pattern)

Not addressing branch protection here since the user didn't request it; flagging so the next person to hit it knows what to look at.

## Acceptance criteria

- [ ] `ci.yml` has a `pull_request.paths` filter listing `src/**`, `tests/**`, `package.json`, `bun.lockb`, `tsconfig*.json`, `.github/workflows/ci.yml`
- [ ] `e2e.yml` has a `pull_request.paths` filter listing `src/**`, `tests/fixtures/**`, `package.json`, `bun.lockb`, `tsconfig*.json`, `.github/workflows/e2e.yml`
- [ ] `push` triggers on both workflows are unchanged (always run on main / dev)

## Test plan

- [x] YAML validated
- [ ] Open this PR — should NOT trigger either Tests or E2E (only workflow files changed)
- [ ] Open a follow-up PR that touches `src/` — should trigger both
