### PR TITLE
fix(review-cron): filter out PRs already in terminal review state

### DIFF
--- a/.claude-jobs/review-issue.yaml
+++ b/.claude-jobs/review-issue.yaml
@@ -7,10 +7,16 @@ auth: subscription
 
 preflight:
   run: |
+    # Only fire on PRs awaiting first-pass review. PRs already carrying a
+    # terminal review-state label (`first pass reviewed`, `changes requested`,
+    # `approved`) must NOT be picked up here — they belong to the next
+    # pipeline stage (final-review) or are already done. Without this filter
+    # the cron re-reviews the oldest open PR every 15 min forever.
     count=$(gh pr list \
       --repo normalled/apijack \
       --base dev \
       --state open \
+      --label "needs review" \
       --json number --jq 'length')
     [ "$count" -gt 0 ]
   timeout: 30s
@@ -21,6 +27,7 @@ claude:
       --repo normalled/apijack \
       --base dev \
       --state open \
+      --label "needs review" \
       --json number \
       --jq 'sort_by(.number) | .[0].number')
     echo "/review-issue $pr"

--- a/.claude-jobs/review-issue.yaml
+++ b/.claude-jobs/review-issue.yaml
@@ -6,30 +6,12 @@ enabled: true
 auth: subscription
 
 preflight:
-  run: |
-    # Only fire on PRs awaiting first-pass review. PRs already carrying a
-    # terminal review-state label (`first pass reviewed`, `changes requested`,
-    # `approved`) must NOT be picked up here — they belong to the next
-    # pipeline stage (final-review) or are already done. Without this filter
-    # the cron re-reviews the oldest open PR every 15 min forever.
-    count=$(gh pr list \
-      --repo normalled/apijack \
-      --base dev \
-      --state open \
-      --label "needs review" \
-      --json number --jq 'length')
-    [ "$count" -gt 0 ]
+  run: .claude/skills/review-issue/scripts/find-review-candidate.sh > /dev/null
   timeout: 30s
 
 claude:
   prompt_cmd: |
-    pr=$(gh pr list \
-      --repo normalled/apijack \
-      --base dev \
-      --state open \
-      --label "needs review" \
-      --json number \
-      --jq 'sort_by(.number) | .[0].number')
+    pr=$(.claude/skills/review-issue/scripts/find-review-candidate.sh)
     echo "/review-issue $pr"
 
   append_system_prompt: |

--- a/.claude/skills/review-issue/scripts/find-review-candidate.sh
+++ b/.claude/skills/review-issue/scripts/find-review-candidate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Print the lowest-numbered open dev PR that is eligible for first-pass review.
+#
+# Eligible = either:
+#   - labeled `needs review`, or
+#   - labeled `changes requested` AND at least one commit has been pushed to
+#     the PR head after the `changes requested` label was applied (i.e., the
+#     author has responded to feedback and the PR is ready for re-review).
+#
+# Skips PRs labeled `first pass reviewed` or `approved` — those belong to the
+# final-review cron or are already done.
+#
+# Exits 0 with the PR number on stdout when a candidate is found.
+# Exits 1 silently when nothing is ready.
+
+set -euo pipefail
+
+repo="normalled/apijack"
+
+# One API call: list candidate PRs with labels + head SHA.
+prs=$(gh pr list --repo "$repo" \
+        --state open --base dev \
+        --json number,labels,headRefOid \
+        --jq 'map({
+            number,
+            labels: [.labels[].name],
+            head:   .headRefOid
+        }) | sort_by(.number) | .[]')
+
+found=""
+while read -r pr_json; do
+    [ -z "$pr_json" ] && continue
+    n=$(jq -r '.number' <<<"$pr_json")
+    labels=$(jq -r '.labels[]' <<<"$pr_json")
+    head=$(jq -r '.head' <<<"$pr_json")
+
+    # `needs review` is unconditionally eligible.
+    if grep -qxF "needs review" <<<"$labels"; then
+        found="$n"
+        break
+    fi
+
+    # `changes requested` is eligible only when a commit lands after the label.
+    if ! grep -qxF "changes requested" <<<"$labels"; then
+        continue
+    fi
+    labeled_at=$(gh api "repos/$repo/issues/$n/events" \
+        --jq 'map(select(.event == "labeled" and .label.name == "changes requested"))
+              | sort_by(.created_at) | reverse | .[0].created_at // empty')
+    [ -z "$labeled_at" ] && continue
+
+    head_at=$(gh api "repos/$repo/commits/$head" --jq '.commit.committer.date // empty')
+    [ -z "$head_at" ] && continue
+
+    labeled_ts=$(date -u -d "$labeled_at" +%s)
+    head_ts=$(date -u -d "$head_at" +%s)
+    if [ "$head_ts" -gt "$labeled_ts" ]; then
+        found="$n"
+        break
+    fi
+done < <(jq -c '.' <<<"$prs" 2>/dev/null || echo "$prs")
+
+[ -n "$found" ] || exit 1
+echo "$found"


### PR DESCRIPTION
## Summary

The review-issue cron has been re-reviewing PR #54 every 15 minutes since #49 merged — at last count, ten redundant first-pass reviews on a PR already labeled `first pass reviewed`. Cause: the preflight + prompt_cmd selected `gh pr list --base dev --state open` with no label filter, then sorted by number ascending. With #49 gone, #54 became the smallest open PR and got re-picked on every tick.

This PR also handles the symmetric problem — `changes requested` PRs that get a follow-up push need to re-enter the queue.

## Fix

A new helper script encapsulates the eligibility logic; the cron yaml delegates to it.

`.claude/skills/review-issue/scripts/find-review-candidate.sh`:
- `needs review` → eligible unconditionally
- `changes requested` → eligible iff a commit has landed on the PR head AFTER the `changes requested` label was applied. Compares the head commit's `committer.date` against the most recent `labeled` event for `changes requested` from the timeline API.
- `first pass reviewed` / `approved` → never eligible (final-review's job, or already done)

The cron yaml drops 20 lines of duplicated `gh pr list` plumbing in favor of a one-line script call for both preflight and prompt_cmd.

## Acceptance criteria

- [ ] `find-review-candidate.sh` exits 0 with a PR number when at least one `needs review` PR is open
- [ ] Same script returns a `changes requested` PR if and only if a commit has been pushed since the label was applied
- [ ] PRs labeled `first pass reviewed` or `approved` are never returned
- [ ] `review-issue.yaml` preflight and prompt_cmd both call the script
- [ ] After merge, the next cron tick selects #55 (oldest open `needs review`), not #54

## Test plan

- [x] Live-tested against current open-PR set (#54 first-pass-reviewed, #55/#56 needs-review): script returns 55, exits 0
- [x] YAML validated, bash syntax validated
- [ ] After merge, watch one cron tick to confirm #54 is no longer being picked
- [ ] When this PR itself moves to `changes requested` (if it does) and a follow-up commit lands, the next tick should re-pick it

🤖 Hand-merging this is fine — it's the fix that stops the loop.