### PR TITLE
fix: generate command honors project AuthStrategy (#61)

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -220,7 +220,6 @@ export function createCli(options: CliOptions): Cli {
                 knownSites: options.knownSites,
                 allowedCidrs: options.allowedCidrs,
             });
-            registerGenerateCommand(program, cliName, options.specPath, generatedDir, configOpts);
             registerUpgradeCommand(program, options.version);
             registerMcpCommand(
                 program,
@@ -303,6 +302,17 @@ export function createCli(options: CliOptions): Cli {
                     : options.auth;
                 sessionMgr = new SessionManager(cliName, join(configDir, 'session.json'));
             }
+
+            // 5b. Register generate (depends on strategy + sessionMgr from step 5)
+            registerGenerateCommand(
+                program,
+                cliName,
+                options.specPath,
+                generatedDir,
+                configOpts,
+                strategy,
+                sessionMgr,
+            );
 
             // 6. Import generated commands (ALWAYS — no auth needed)
             let commandsModule: Record<string, unknown> | null = null;

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { fetchSpec } from './index';
+import type { AuthStrategy, AuthSession } from '../auth/types';
+import type { SessionManager } from '../session';
+
+const stubResponse = (status: number, body: unknown = {}) =>
+    new Response(JSON.stringify(body), { status });
+
+describe('fetchSpec', () => {
+    const originalFetch = globalThis.fetch;
+    let fetchMock: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+        fetchMock = mock(() => Promise.resolve(stubResponse(200, { paths: {} })));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('uses Basic auth when no strategy is provided', async () => {
+        await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://localhost:8080/v3/api-docs');
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Authorization).toBe(
+            'Basic ' + btoa('admin:secret'),
+        );
+        expect(headers.Accept).toBe('application/json');
+    });
+
+    test('uses session headers from strategy when provided', async () => {
+        const session: AuthSession = {
+            headers: { Cookie: 'JSESSIONID=abc; X-XSRF=xyz' },
+        };
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve(session)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+            strategy,
+            sessionManager,
+        });
+
+        expect(sessionManager.resolve).toHaveBeenCalledWith(strategy, {
+            baseUrl: 'http://localhost:8080',
+            username: 'admin',
+            password: 'secret',
+        });
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Cookie).toBe('JSESSIONID=abc; X-XSRF=xyz');
+        expect(headers.Authorization).toBeUndefined();
+    });
+
+    test('on 401, invalidates session and retries once', async () => {
+        const session: AuthSession = { headers: { Cookie: 'fresh' } };
+        const resolve = mock(() => Promise.resolve(session));
+        const invalidate = mock(() => {});
+        const sessionManager = { resolve, invalidate } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        let callCount = 0;
+        fetchMock = mock(() => {
+            callCount++;
+
+            return Promise.resolve(
+                callCount === 1
+                    ? stubResponse(401, {})
+                    : stubResponse(200, { paths: {} }),
+            );
+        });
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const spec = await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+            strategy,
+            sessionManager,
+        });
+
+        expect(invalidate).toHaveBeenCalledTimes(1);
+        expect(resolve).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(spec).toEqual({ paths: {} });
+    });
+
+    test('throws when retry after 401 still fails', async () => {
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve({ headers: {} } as AuthSession)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        fetchMock = mock(() => Promise.resolve(stubResponse(401, {})));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(
+            fetchSpec({
+                baseUrl: 'http://localhost:8080',
+                specPath: '/v3/api-docs',
+                auth: { username: 'admin', password: 'secret' },
+                strategy,
+                sessionManager,
+            }),
+        ).rejects.toThrow(/401/);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(sessionManager.invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not retry on 401 when no strategy is provided', async () => {
+        fetchMock = mock(() => Promise.resolve(stubResponse(401, {})));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(
+            fetchSpec({
+                baseUrl: 'http://localhost:8080',
+                specPath: '/v3/api-docs',
+                auth: { username: 'admin', password: 'secret' },
+            }),
+        ).rejects.toThrow(/401/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4,6 +4,8 @@ import { generateClient } from './client';
 import { generateCommands } from './commands';
 import { generateCommandMap } from './command-map';
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
+import type { AuthStrategy } from '../auth/types';
+import type { SessionManager } from '../session';
 
 export interface GenerateOptions {
     spec: {
@@ -11,6 +13,14 @@ export interface GenerateOptions {
         components?: { schemas?: Record<string, OpenApiSchema> };
     };
     outDir: string;
+}
+
+export interface FetchSpecOptions {
+    baseUrl: string;
+    specPath: string;
+    auth?: { username: string; password: string };
+    strategy?: AuthStrategy;
+    sessionManager?: SessionManager;
 }
 
 export interface FetchAndGenerateOptions {
@@ -37,18 +47,33 @@ export async function generate(opts: GenerateOptions): Promise<void> {
     await Bun.write(`${opts.outDir}/command-map.ts`, commandMapContent);
 }
 
-export async function fetchAndGenerate(
-    opts: FetchAndGenerateOptions,
-): Promise<void> {
-    const headers: Record<string, string> = { Accept: 'application/json' };
+export async function fetchSpec(opts: FetchSpecOptions): Promise<unknown> {
+    const buildHeaders = async (): Promise<Record<string, string>> => {
+        const headers: Record<string, string> = { Accept: 'application/json' };
 
-    if (opts.auth) {
-        headers.Authorization
-            = 'Basic ' + btoa(`${opts.auth.username}:${opts.auth.password}`);
-    }
+        if (opts.strategy && opts.sessionManager && opts.auth) {
+            const session = await opts.sessionManager.resolve(opts.strategy, {
+                baseUrl: opts.baseUrl,
+                username: opts.auth.username,
+                password: opts.auth.password,
+            });
+            Object.assign(headers, session.headers);
+        } else if (opts.auth) {
+            headers.Authorization
+                = 'Basic ' + btoa(`${opts.auth.username}:${opts.auth.password}`);
+        }
+
+        return headers;
+    };
 
     const url = `${opts.baseUrl}${opts.specPath}`;
-    const res = await fetch(url, { headers });
+    let res = await fetch(url, { headers: await buildHeaders() });
+
+    // Cached session may be stale — invalidate + retry once on 401
+    if (res.status === 401 && opts.strategy && opts.sessionManager) {
+        opts.sessionManager.invalidate();
+        res = await fetch(url, { headers: await buildHeaders() });
+    }
 
     if (!res.ok) {
         throw new Error(
@@ -56,6 +81,15 @@ export async function fetchAndGenerate(
         );
     }
 
-    const spec = await res.json();
-    await generate({ spec, outDir: opts.outDir });
+    return res.json();
+}
+
+export async function fetchAndGenerate(
+    opts: FetchAndGenerateOptions,
+): Promise<void> {
+    const spec = await fetchSpec(opts);
+    await generate({
+        spec: spec as GenerateOptions['spec'],
+        outDir: opts.outDir,
+    });
 }

--- a/src/commands/generate/generate.test.ts
+++ b/src/commands/generate/generate.test.ts
@@ -1,22 +1,56 @@
 import { describe, test, expect, mock } from 'bun:test';
 import { generateAction } from './generate';
+import type { AuthStrategy, AuthSession } from '../../auth/types';
+import type { SessionManager } from '../../session';
 
 describe('generateAction', () => {
-    test('calls fetchAndGenerate with correct params', async () => {
-        const fetchAndGen = mock(() => Promise.resolve());
+    test('calls fetchSpec and generate with correct params', async () => {
+        const fetchSpec = mock(() => Promise.resolve({ paths: {} } as unknown));
+        const generate = mock(() => Promise.resolve());
+
         await generateAction({
             env: { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
             specPath: '/v3/api-docs',
             outDir: '/tmp/generated',
-            fetchAndGenerate: fetchAndGen,
+            fetchSpec,
+            generate,
         });
 
-        expect(fetchAndGen).toHaveBeenCalledWith({
+        expect(fetchSpec).toHaveBeenCalledWith({
             baseUrl: 'http://localhost:8080',
             specPath: '/v3/api-docs',
-            outDir: '/tmp/generated',
             auth: { username: 'admin', password: 'secret' },
+            strategy: undefined,
+            sessionManager: undefined,
         });
+        expect(generate).toHaveBeenCalledWith({
+            spec: { paths: {} },
+            outDir: '/tmp/generated',
+        });
+    });
+
+    test('threads strategy and sessionManager through to fetchSpec', async () => {
+        const strategy = {} as AuthStrategy;
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve({ headers: {} } as AuthSession)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const fetchSpec = mock(() => Promise.resolve({ paths: {} } as unknown));
+        const generate = mock(() => Promise.resolve());
+
+        await generateAction({
+            env: { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
+            specPath: '/v3/api-docs',
+            outDir: '/tmp/generated',
+            strategy,
+            sessionManager,
+            fetchSpec,
+            generate,
+        });
+
+        const [opts] = fetchSpec.mock.calls[0] as unknown as [Record<string, unknown>];
+        expect(opts.strategy).toBe(strategy);
+        expect(opts.sessionManager).toBe(sessionManager);
     });
 
     test('throws when no active environment', () => {
@@ -24,7 +58,8 @@ describe('generateAction', () => {
             env: null,
             specPath: '/v3/api-docs',
             outDir: '/tmp/generated',
-            fetchAndGenerate: mock(() => Promise.resolve()),
+            fetchSpec: mock(() => Promise.resolve({})),
+            generate: mock(() => Promise.resolve()),
         })).rejects.toThrow('No active environment');
     });
 });

--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -1,12 +1,22 @@
 import { Command } from 'commander';
 import { getActiveEnvConfig } from '../../config';
-import { fetchAndGenerate as defaultFetchAndGenerate } from '../../codegen/index';
+import {
+    fetchSpec as defaultFetchSpec,
+    generate as defaultGenerate,
+    type FetchSpecOptions,
+    type GenerateOptions,
+} from '../../codegen/index';
+import type { AuthStrategy } from '../../auth/types';
+import type { SessionManager } from '../../session';
 
 export interface GenerateInput {
     env: { url: string; user: string; password: string } | null;
     specPath: string;
     outDir: string;
-    fetchAndGenerate: (opts: { baseUrl: string; specPath: string; outDir: string; auth: { username: string; password: string } }) => Promise<void>;
+    strategy?: AuthStrategy;
+    sessionManager?: SessionManager;
+    fetchSpec: (opts: FetchSpecOptions) => Promise<unknown>;
+    generate: (opts: GenerateOptions) => Promise<void>;
 }
 
 export async function generateAction(input: GenerateInput): Promise<void> {
@@ -14,11 +24,17 @@ export async function generateAction(input: GenerateInput): Promise<void> {
         throw new Error('No active environment.');
     }
 
-    await input.fetchAndGenerate({
+    const spec = await input.fetchSpec({
         baseUrl: input.env.url,
         specPath: input.specPath,
-        outDir: input.outDir,
         auth: { username: input.env.user, password: input.env.password },
+        strategy: input.strategy,
+        sessionManager: input.sessionManager,
+    });
+
+    await input.generate({
+        spec: spec as GenerateOptions['spec'],
+        outDir: input.outDir,
     });
 }
 
@@ -28,6 +44,8 @@ export function registerGenerateCommand(
     specPath: string,
     generatedDir: string,
     configOpts?: { configPath: string },
+    strategy?: AuthStrategy,
+    sessionManager?: SessionManager | null,
 ): void {
     program
         .command('generate')
@@ -40,7 +58,10 @@ export function registerGenerateCommand(
                     env,
                     specPath,
                     outDir: generatedDir,
-                    fetchAndGenerate: defaultFetchAndGenerate,
+                    strategy,
+                    sessionManager: sessionManager ?? undefined,
+                    fetchSpec: defaultFetchSpec,
+                    generate: defaultGenerate,
                 });
                 console.log(`Generated files written to ${generatedDir}`);
             } catch (err) {


### PR DESCRIPTION
Closes #61

## Summary

`generate` was hardcoded to HTTP Basic auth and ignored the project's `AuthStrategy`. For any API behind a session/cookie/2FA flow, this meant the spec fetch returned 401 even though the rest of the CLI authenticated fine — so consumers had to shadow `generate` with custom code (e.g., rrc-cli ships ~75 lines of boilerplate).

This PR follows Approach 3 from the issue: extract a new exported `fetchSpec` helper that handles both Basic and session-strategy paths, with once-on-401 invalidate-and-retry. `fetchAndGenerate` becomes a thin `fetchSpec → generate` composition (public signature unchanged). Strategy + sessionManager are threaded through `GenerateInput` and `registerGenerateCommand`. The cli-builder is reordered so `generate` registers after `strategy`/`sessionMgr` are computed.

## What changes

### `src/codegen/index.ts`

- New exported `FetchSpecOptions` interface and `fetchSpec` function
- `fetchSpec` builds headers from either `strategy + sessionManager + auth` (resolves a session, copies its headers) or falls back to Basic from `auth`
- On a 401 with strategy + sessionManager, calls `sessionManager.invalidate()` and retries once
- `fetchAndGenerate` becomes `fetchSpec → generate`; signature unchanged

### `src/commands/generate/generate.ts`

- `GenerateInput` now exposes `strategy?`, `sessionManager?`, and separate `fetchSpec` + `generate` injection points (replacing the single `fetchAndGenerate` injection)
- `generateAction` calls `fetchSpec` then `generate` directly
- `registerGenerateCommand` accepts optional `strategy` and `sessionManager` and threads them through

### `src/cli-builder.ts`

- `registerGenerateCommand` moved from step 3 (before auth resolution) to a new step 5b (after `strategy` and `sessionMgr` are computed). Registration just defines the action callback — execution still happens at `parseAsync()` time, so the reorder is purely about thread-through, not behavior.

### Tests

- New `src/codegen/index.test.ts`: Basic-only path, strategy path, 401-invalidate-retry success, 401-retry-still-fails, no-retry-without-strategy
- Updated `src/commands/generate/generate.test.ts`: new injection shape, plus a test that strategy + sessionManager are threaded to fetchSpec

## Acceptance criteria

- [x] New exported `fetchSpec` accepts `auth`, `strategy`, `sessionManager`
- [x] 401 triggers a single `sessionManager.invalidate()` + retry
- [x] `fetchAndGenerate` keeps its public signature; becomes `fetchSpec → generate`
- [x] `src/codegen/index.test.ts` covers Basic, strategy, 401-retry-success, 401-retry-fail
- [x] `generateAction` calls `fetchSpec` then `generate`, threading optional `strategy` + `sessionManager`
- [x] `cli-builder.ts` passes `strategy` + `sessionMgr` to `registerGenerateCommand`
- [x] Existing `generate.test.ts` updated for new inputs
- [x] A 2FA/session-gated consumer (e.g., rrc-cli) can drop its `commands/generate.ts` shadow

## Test plan

- [x] `bun test` — 841 pass / 0 fail
- [x] `bun run lint` — 0 errors on changed files
- [x] Independent code review (subagent) — no Critical/Important issues; verdict ready to commit

## Backwards compatibility

- `fetchAndGenerate` keeps its exact public signature
- `GenerateInput` is internal (not part of the public API surface)
- Generated code paths unchanged
