### PR TITLE
v1.10.1: generate command honors project AuthStrategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.10.0",
+  "version": "1.10.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -220,7 +220,6 @@ export function createCli(options: CliOptions): Cli {
                 knownSites: options.knownSites,
                 allowedCidrs: options.allowedCidrs,
             });
-            registerGenerateCommand(program, cliName, options.specPath, generatedDir, configOpts);
             registerUpgradeCommand(program, options.version);
             registerMcpCommand(
                 program,
@@ -303,6 +302,17 @@ export function createCli(options: CliOptions): Cli {
                     : options.auth;
                 sessionMgr = new SessionManager(cliName, join(configDir, 'session.json'));
             }
+
+            // 5b. Register generate (depends on strategy + sessionMgr from step 5)
+            registerGenerateCommand(
+                program,
+                cliName,
+                options.specPath,
+                generatedDir,
+                configOpts,
+                strategy,
+                sessionMgr,
+            );
 
             // 6. Import generated commands (ALWAYS — no auth needed)
             let commandsModule: Record<string, unknown> | null = null;

--- a/src/codegen/index.test.ts
+++ b/src/codegen/index.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { fetchSpec } from './index';
+import type { AuthStrategy, AuthSession } from '../auth/types';
+import type { SessionManager } from '../session';
+
+const stubResponse = (status: number, body: unknown = {}) =>
+    new Response(JSON.stringify(body), { status });
+
+describe('fetchSpec', () => {
+    const originalFetch = globalThis.fetch;
+    let fetchMock: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+        fetchMock = mock(() => Promise.resolve(stubResponse(200, { paths: {} })));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('uses Basic auth when no strategy is provided', async () => {
+        await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        expect(url).toBe('http://localhost:8080/v3/api-docs');
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Authorization).toBe(
+            'Basic ' + btoa('admin:secret'),
+        );
+        expect(headers.Accept).toBe('application/json');
+    });
+
+    test('uses session headers from strategy when provided', async () => {
+        const session: AuthSession = {
+            headers: { Cookie: 'JSESSIONID=abc; X-XSRF=xyz' },
+        };
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve(session)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+            strategy,
+            sessionManager,
+        });
+
+        expect(sessionManager.resolve).toHaveBeenCalledWith(strategy, {
+            baseUrl: 'http://localhost:8080',
+            username: 'admin',
+            password: 'secret',
+        });
+        const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+        const headers = init.headers as Record<string, string>;
+        expect(headers.Cookie).toBe('JSESSIONID=abc; X-XSRF=xyz');
+        expect(headers.Authorization).toBeUndefined();
+    });
+
+    test('on 401, invalidates session and retries once', async () => {
+        const session: AuthSession = { headers: { Cookie: 'fresh' } };
+        const resolve = mock(() => Promise.resolve(session));
+        const invalidate = mock(() => {});
+        const sessionManager = { resolve, invalidate } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        let callCount = 0;
+        fetchMock = mock(() => {
+            callCount++;
+
+            return Promise.resolve(
+                callCount === 1
+                    ? stubResponse(401, {})
+                    : stubResponse(200, { paths: {} }),
+            );
+        });
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const spec = await fetchSpec({
+            baseUrl: 'http://localhost:8080',
+            specPath: '/v3/api-docs',
+            auth: { username: 'admin', password: 'secret' },
+            strategy,
+            sessionManager,
+        });
+
+        expect(invalidate).toHaveBeenCalledTimes(1);
+        expect(resolve).toHaveBeenCalledTimes(2);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(spec).toEqual({ paths: {} });
+    });
+
+    test('throws when retry after 401 still fails', async () => {
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve({ headers: {} } as AuthSession)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const strategy = {} as AuthStrategy;
+
+        fetchMock = mock(() => Promise.resolve(stubResponse(401, {})));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(
+            fetchSpec({
+                baseUrl: 'http://localhost:8080',
+                specPath: '/v3/api-docs',
+                auth: { username: 'admin', password: 'secret' },
+                strategy,
+                sessionManager,
+            }),
+        ).rejects.toThrow(/401/);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(sessionManager.invalidate).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not retry on 401 when no strategy is provided', async () => {
+        fetchMock = mock(() => Promise.resolve(stubResponse(401, {})));
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        await expect(
+            fetchSpec({
+                baseUrl: 'http://localhost:8080',
+                specPath: '/v3/api-docs',
+                auth: { username: 'admin', password: 'secret' },
+            }),
+        ).rejects.toThrow(/401/);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/codegen/index.ts
+++ b/src/codegen/index.ts
@@ -4,6 +4,8 @@ import { generateClient } from './client';
 import { generateCommands } from './commands';
 import { generateCommandMap } from './command-map';
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
+import type { AuthStrategy } from '../auth/types';
+import type { SessionManager } from '../session';
 
 export interface GenerateOptions {
     spec: {
@@ -11,6 +13,14 @@ export interface GenerateOptions {
         components?: { schemas?: Record<string, OpenApiSchema> };
     };
     outDir: string;
+}
+
+export interface FetchSpecOptions {
+    baseUrl: string;
+    specPath: string;
+    auth?: { username: string; password: string };
+    strategy?: AuthStrategy;
+    sessionManager?: SessionManager;
 }
 
 export interface FetchAndGenerateOptions {
@@ -37,18 +47,33 @@ export async function generate(opts: GenerateOptions): Promise<void> {
     await Bun.write(`${opts.outDir}/command-map.ts`, commandMapContent);
 }
 
-export async function fetchAndGenerate(
-    opts: FetchAndGenerateOptions,
-): Promise<void> {
-    const headers: Record<string, string> = { Accept: 'application/json' };
+export async function fetchSpec(opts: FetchSpecOptions): Promise<unknown> {
+    const buildHeaders = async (): Promise<Record<string, string>> => {
+        const headers: Record<string, string> = { Accept: 'application/json' };
 
-    if (opts.auth) {
-        headers.Authorization
-            = 'Basic ' + btoa(`${opts.auth.username}:${opts.auth.password}`);
-    }
+        if (opts.strategy && opts.sessionManager && opts.auth) {
+            const session = await opts.sessionManager.resolve(opts.strategy, {
+                baseUrl: opts.baseUrl,
+                username: opts.auth.username,
+                password: opts.auth.password,
+            });
+            Object.assign(headers, session.headers);
+        } else if (opts.auth) {
+            headers.Authorization
+                = 'Basic ' + btoa(`${opts.auth.username}:${opts.auth.password}`);
+        }
+
+        return headers;
+    };
 
     const url = `${opts.baseUrl}${opts.specPath}`;
-    const res = await fetch(url, { headers });
+    let res = await fetch(url, { headers: await buildHeaders() });
+
+    // Cached session may be stale — invalidate + retry once on 401
+    if (res.status === 401 && opts.strategy && opts.sessionManager) {
+        opts.sessionManager.invalidate();
+        res = await fetch(url, { headers: await buildHeaders() });
+    }
 
     if (!res.ok) {
         throw new Error(
@@ -56,6 +81,15 @@ export async function fetchAndGenerate(
         );
     }
 
-    const spec = await res.json();
-    await generate({ spec, outDir: opts.outDir });
+    return res.json();
+}
+
+export async function fetchAndGenerate(
+    opts: FetchAndGenerateOptions,
+): Promise<void> {
+    const spec = await fetchSpec(opts);
+    await generate({
+        spec: spec as GenerateOptions['spec'],
+        outDir: opts.outDir,
+    });
 }

--- a/src/commands/generate/generate.test.ts
+++ b/src/commands/generate/generate.test.ts
@@ -1,22 +1,56 @@
 import { describe, test, expect, mock } from 'bun:test';
 import { generateAction } from './generate';
+import type { AuthStrategy, AuthSession } from '../../auth/types';
+import type { SessionManager } from '../../session';
 
 describe('generateAction', () => {
-    test('calls fetchAndGenerate with correct params', async () => {
-        const fetchAndGen = mock(() => Promise.resolve());
+    test('calls fetchSpec and generate with correct params', async () => {
+        const fetchSpec = mock(() => Promise.resolve({ paths: {} } as unknown));
+        const generate = mock(() => Promise.resolve());
+
         await generateAction({
             env: { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
             specPath: '/v3/api-docs',
             outDir: '/tmp/generated',
-            fetchAndGenerate: fetchAndGen,
+            fetchSpec,
+            generate,
         });
 
-        expect(fetchAndGen).toHaveBeenCalledWith({
+        expect(fetchSpec).toHaveBeenCalledWith({
             baseUrl: 'http://localhost:8080',
             specPath: '/v3/api-docs',
-            outDir: '/tmp/generated',
             auth: { username: 'admin', password: 'secret' },
+            strategy: undefined,
+            sessionManager: undefined,
         });
+        expect(generate).toHaveBeenCalledWith({
+            spec: { paths: {} },
+            outDir: '/tmp/generated',
+        });
+    });
+
+    test('threads strategy and sessionManager through to fetchSpec', async () => {
+        const strategy = {} as AuthStrategy;
+        const sessionManager = {
+            resolve: mock(() => Promise.resolve({ headers: {} } as AuthSession)),
+            invalidate: mock(() => {}),
+        } as unknown as SessionManager;
+        const fetchSpec = mock(() => Promise.resolve({ paths: {} } as unknown));
+        const generate = mock(() => Promise.resolve());
+
+        await generateAction({
+            env: { url: 'http://localhost:8080', user: 'admin', password: 'secret' },
+            specPath: '/v3/api-docs',
+            outDir: '/tmp/generated',
+            strategy,
+            sessionManager,
+            fetchSpec,
+            generate,
+        });
+
+        const [opts] = fetchSpec.mock.calls[0] as unknown as [Record<string, unknown>];
+        expect(opts.strategy).toBe(strategy);
+        expect(opts.sessionManager).toBe(sessionManager);
     });
 
     test('throws when no active environment', () => {
@@ -24,7 +58,8 @@ describe('generateAction', () => {
             env: null,
             specPath: '/v3/api-docs',
             outDir: '/tmp/generated',
-            fetchAndGenerate: mock(() => Promise.resolve()),
+            fetchSpec: mock(() => Promise.resolve({})),
+            generate: mock(() => Promise.resolve()),
         })).rejects.toThrow('No active environment');
     });
 });

--- a/src/commands/generate/generate.ts
+++ b/src/commands/generate/generate.ts
@@ -1,12 +1,22 @@
 import { Command } from 'commander';
 import { getActiveEnvConfig } from '../../config';
-import { fetchAndGenerate as defaultFetchAndGenerate } from '../../codegen/index';
+import {
+    fetchSpec as defaultFetchSpec,
+    generate as defaultGenerate,
+    type FetchSpecOptions,
+    type GenerateOptions,
+} from '../../codegen/index';
+import type { AuthStrategy } from '../../auth/types';
+import type { SessionManager } from '../../session';
 
 export interface GenerateInput {
     env: { url: string; user: string; password: string } | null;
     specPath: string;
     outDir: string;
-    fetchAndGenerate: (opts: { baseUrl: string; specPath: string; outDir: string; auth: { username: string; password: string } }) => Promise<void>;
+    strategy?: AuthStrategy;
+    sessionManager?: SessionManager;
+    fetchSpec: (opts: FetchSpecOptions) => Promise<unknown>;
+    generate: (opts: GenerateOptions) => Promise<void>;
 }
 
 export async function generateAction(input: GenerateInput): Promise<void> {
@@ -14,11 +24,17 @@ export async function generateAction(input: GenerateInput): Promise<void> {
         throw new Error('No active environment.');
     }
 
-    await input.fetchAndGenerate({
+    const spec = await input.fetchSpec({
         baseUrl: input.env.url,
         specPath: input.specPath,
-        outDir: input.outDir,
         auth: { username: input.env.user, password: input.env.password },
+        strategy: input.strategy,
+        sessionManager: input.sessionManager,
+    });
+
+    await input.generate({
+        spec: spec as GenerateOptions['spec'],
+        outDir: input.outDir,
     });
 }
 
@@ -28,6 +44,8 @@ export function registerGenerateCommand(
     specPath: string,
     generatedDir: string,
     configOpts?: { configPath: string },
+    strategy?: AuthStrategy,
+    sessionManager?: SessionManager | null,
 ): void {
     program
         .command('generate')
@@ -40,7 +58,10 @@ export function registerGenerateCommand(
                     env,
                     specPath,
                     outDir: generatedDir,
-                    fetchAndGenerate: defaultFetchAndGenerate,
+                    strategy,
+                    sessionManager: sessionManager ?? undefined,
+                    fetchSpec: defaultFetchSpec,
+                    generate: defaultGenerate,
                 });
                 console.log(`Generated files written to ${generatedDir}`);
             } catch (err) {


### PR DESCRIPTION
Patch release: `generate` now drives the project's configured `AuthStrategy` instead of being hardcoded to HTTP Basic.

## 🐛 Fixes

- **`generate` honors project AuthStrategy** (#62) — APIs behind session/cookie/2FA flows no longer 401 on spec fetch. New exported `fetchSpec` helper handles both Basic and session paths, with once-on-401 invalidate-and-retry. Consumers (e.g. rrc-cli) can drop their `commands/generate.ts` shadow.

---

Shipped via `scripts/ship.sh`.
