### PR TITLE
chore: extract start-issue-branch and sync-dev-from-main scripts (#67)

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -20,35 +20,21 @@ Do not invoke this skill before triage is complete. If the issue has not been tr
 
 Slugify the issue title: lowercase, hyphenated, drop filler words, aim for 3–5 words. The branch name is `issues/<number>-<short-slug>` (e.g., `issues/37-opt-in-auth` for issue #37 "Make auth opt-in").
 
-Always work off an up-to-date `dev`. Prefer a worktree for full isolation.
-
-**Worktree (preferred):**
+Always work off an up-to-date `dev`. Prefer a worktree for full isolation — pass `--worktree` to also create a sibling worktree at `../apijack-<short-slug>`.
 
 ```bash
-git fetch origin
-git worktree add ../apijack-<short-slug> -b issues/<number>-<short-slug> origin/dev
-cd ../apijack-<short-slug>
+./.claude/skills/implement-issue/scripts/start-issue-branch.sh <issue-number> <short-slug> --worktree
+# or, in-place branch in the current repo:
+./.claude/skills/implement-issue/scripts/start-issue-branch.sh <issue-number> <short-slug>
 ```
 
-**In-place branch (if not using a worktree):**
+If `dev` is behind `main` (e.g., right after a release), sync it first, then re-run the script:
 
 ```bash
-git fetch origin
-git checkout -b issues/<number>-<short-slug> origin/dev
+./.claude/skills/implement-issue/scripts/sync-dev-from-main.sh
 ```
 
-If `dev` is behind `main` (e.g., right after a release), sync it first before branching:
-
-```bash
-git checkout dev
-git pull origin dev
-git merge origin/main   # bring release commits into dev
-git push origin dev
-```
-
-Then branch off the synced `dev`.
-
-> **Note:** that `git push origin dev` is the **only** push to `dev` this skill performs — a maintenance sync, not feature work. Everything else operates on the feature branch and PRs into `dev`.
+> **Note:** the push inside `sync-dev-from-main.sh` is the **only** push to `dev` this skill performs — a maintenance sync, not feature work. Everything else operates on the feature branch and PRs into `dev`.
 
 ### 2. Plan or implement
 

--- a/.claude/skills/implement-issue/scripts/start-issue-branch.sh
+++ b/.claude/skills/implement-issue/scripts/start-issue-branch.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Create the issue branch (and optionally a sibling worktree) for implement-issue step 1.
+#
+# Usage: start-issue-branch.sh <issue-number> <short-slug> [--worktree]
+#   With --worktree: creates a sibling worktree at ../apijack-<slug>.
+#   Without:         checks out the new branch in the current repo.
+#
+# Always branches from origin/dev after a fetch. The worktree path is printed on
+# stdout so callers can `cd` into it themselves.
+
+set -euo pipefail
+
+if [[ $# -lt 2 || $# -gt 3 ]]; then
+    echo "Usage: $0 <issue-number> <short-slug> [--worktree]" >&2
+    exit 1
+fi
+
+issue="$1"
+slug="$2"
+mode="${3:-}"
+
+if [[ -n "$mode" && "$mode" != "--worktree" ]]; then
+    echo "Unknown flag: $mode (expected --worktree)" >&2
+    exit 1
+fi
+
+branch="issues/${issue}-${slug}"
+
+git fetch origin
+
+if [[ "$mode" == "--worktree" ]]; then
+    worktree_path="../apijack-${slug}"
+    git worktree add "$worktree_path" -b "$branch" origin/dev
+    cd "$worktree_path"
+    echo "Worktree ready: $(pwd)"
+    echo "Branch: $branch"
+else
+    git checkout -b "$branch" origin/dev
+    echo "Branch ready: $branch"
+fi

--- a/.claude/skills/implement-issue/scripts/sync-dev-from-main.sh
+++ b/.claude/skills/implement-issue/scripts/sync-dev-from-main.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Bring release commits from main back into dev. Idempotent.
+#
+# Usage: sync-dev-from-main.sh
+#
+# Steps: checkout dev, pull, merge origin/main, push. Aborts on conflicts with a
+# clear message. Exits 0 if dev is already up to date with origin/main (no push).
+
+set -euo pipefail
+
+git fetch origin
+
+git checkout dev
+git pull --ff-only origin dev
+
+# Already up to date? origin/main is an ancestor of dev — nothing to merge or push.
+if git merge-base --is-ancestor origin/main HEAD; then
+    echo "dev is already up to date with origin/main — nothing to do."
+    exit 0
+fi
+
+if ! git merge --no-edit origin/main; then
+    echo "Merge conflict while bringing origin/main into dev." >&2
+    echo "Resolve manually, then re-run this script (or finish the merge and push)." >&2
+    git merge --abort 2>/dev/null || true
+    exit 1
+fi
+
+git push origin dev
+echo "dev synced with origin/main and pushed."


### PR DESCRIPTION
Closes #67

## Summary

Extract the two routine bits from `implement-issue` step 1 — branch creation (worktree vs in-place) and the dev←main sync — into dedicated scripts. The skill text now describes inputs only, matching the no-inline-shell precedent set by `final-review/scripts/merge-pr.sh`, `triage-issue/scripts/lock-issue.sh`, and friends.

## What changes

### New scripts

`.claude/skills/implement-issue/scripts/start-issue-branch.sh`

```bash
start-issue-branch.sh <issue-number> <short-slug> [--worktree]
```

- Fetches `origin`, then creates `issues/<n>-<slug>` off `origin/dev`.
- `--worktree`: also creates a sibling worktree at `../apijack-<slug>`.
- Otherwise: in-place `git checkout -b`.

`.claude/skills/implement-issue/scripts/sync-dev-from-main.sh`

- `git fetch origin`, `git checkout dev`, `git pull --ff-only origin dev`.
- Early-exits 0 when `origin/main` is already an ancestor of `dev` (idempotent).
- Otherwise `git merge --no-edit origin/main` then `git push origin dev`.
- On merge conflict: prints a clear message, runs `git merge --abort`, exits 1.

### Modified

`.claude/skills/implement-issue/SKILL.md` step 1 — replaces the four inline `bash` blocks (worktree, in-place branch, four-line sync, "branch off the synced dev" prose) with two short script invocations. The "Option A / Option B" framing for branch creation is gone — the `--worktree` flag handles it.

## Acceptance criteria

- [x] `start-issue-branch.sh <n> <slug> [--worktree]` creates `issues/<n>-<slug>` from `origin/dev`.
- [x] With `--worktree`, also creates sibling worktree at `../apijack-<slug>`.
- [x] Without `--worktree`, checks out the new branch in place.
- [x] `sync-dev-from-main.sh` runs the four-step sync.
- [x] Aborts on merge conflicts with a clear message.
- [x] Idempotent — exits 0 when `dev` is already up to date with `main`.
- [x] SKILL.md step 1 calls both scripts; "Option A / Option B" prose dropped.

## Test plan

- [x] `bash -n` syntax-checks both scripts.
- [x] `bun test` — 841 pass / 0 fail.
- [x] `bun run lint` — 0 errors (107 pre-existing warnings).
- [x] Both scripts staged with mode `100755` (executable).
- [x] Per the issue caution, the live branch flow was not exercised against this in-flight branch — the next `implement-issue` invocation will be the integration test.
