### PR TITLE
chore: extract upsert-release-pr.sh from patch-deployer skill (#69)

### DIFF
--- a/.claude/skills/patch-deployer/SKILL.md
+++ b/.claude/skills/patch-deployer/SKILL.md
@@ -42,15 +42,7 @@ If any of:
 
 …STOP. The cron should not silently switch branches or stash user WIP.
 
-### 3. Check for an existing dev → main PR
-
-```bash
-gh pr list --repo normalled/apijack --head dev --base main --state open --json number,body
-```
-
-If a PR already exists with a curated body, skip to step 6 (run ship.sh). If a bland `dev → main (N commits)` PR exists, edit it with the curated body from step 5.
-
-### 4. Categorize commits
+### 3. Categorize commits
 
 ```bash
 git log origin/main..HEAD --pretty=format:"%h %s"
@@ -67,7 +59,7 @@ There must be **zero** entries in a "Features" or "Changed" bucket — the gate 
 
 For each fix commit, look up the PR number (`(#NN)` in the subject, or `gh pr list --state merged --search "<subject>"`).
 
-### 5. Draft the PR body
+### 4. Draft the PR body
 
 Use the `Write` tool — never inline in a heredoc — to avoid backtick-escaping. Write to `.claude-jobs/release-bodies/dev-to-main.md`.
 
@@ -100,26 +92,17 @@ Concision rules from `ship-release`:
 - Internal section is one line — `"misc CI and skill tweaks"` beats listing every chore
 - If the body is longer than ~15 lines, cut
 
-### 6. Create / update the PR
-
-If no PR exists:
+### 5. Create / update the PR
 
 ```bash
-git push -u origin dev
-gh pr create --repo normalled/apijack --base main --head dev \
-    --title "<title>" \
-    --body-file .claude-jobs/release-bodies/dev-to-main.md
+.claude/skills/patch-deployer/scripts/upsert-release-pr.sh \
+    "<title>" \
+    .claude-jobs/release-bodies/dev-to-main.md
 ```
 
-If a bland PR already exists:
+The script edits the open `dev → main` PR if one exists, otherwise pushes `dev` and creates it. PR number is printed on stdout.
 
-```bash
-gh pr edit <num> --repo normalled/apijack \
-    --title "<title>" \
-    --body-file .claude-jobs/release-bodies/dev-to-main.md
-```
-
-### 7. Run ship.sh
+### 6. Run ship.sh
 
 ```bash
 ./scripts/ship.sh
@@ -135,14 +118,14 @@ gh pr edit <num> --repo normalled/apijack \
 
 If ship.sh exits non-zero, leave the PR in place for a human and stop.
 
-### 8. Report
+### 7. Report
 
 When ship.sh succeeds, report:
 - New tag (`vX.Y.Z`)
 - Release URL (`https://github.com/normalled/apijack/releases/tag/vX.Y.Z`)
 - npm package URL
 
-The publish workflow's release-notes pipeline (post-#54) uses the merged PR body verbatim, so the GitHub release will match what was drafted in step 5.
+The publish workflow's release-notes pipeline (post-#54) uses the merged PR body verbatim, so the GitHub release will match what was drafted in step 4.
 
 ## Red Flags — Do Not Ship
 

--- a/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
+++ b/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Find-or-create the open dev → main release PR.
+#
+# If a PR with --head dev --base main is already open, edit its title/body.
+# Otherwise push dev and create one. Either way, prints the PR number.
+#
+# Usage: upsert-release-pr.sh <title> <body-file>
+
+set -euo pipefail
+
+title="${1:?title required}"
+body_file="${2:?body file required}"
+repo="normalled/apijack"
+
+[ -f "$body_file" ] || { echo "body file not found: $body_file" >&2; exit 1; }
+
+existing=$(gh pr list --repo "$repo" --head dev --base main --state open --json number --jq '.[0].number')
+
+if [ -n "$existing" ]; then
+    gh pr edit "$existing" --repo "$repo" --title "$title" --body-file "$body_file" >/dev/null
+    echo "$existing"
+else
+    git push -u origin dev
+    url=$(gh pr create --repo "$repo" --base main --head dev \
+        --title "$title" --body-file "$body_file")
+    echo "${url##*/}"
+fi


### PR DESCRIPTION
Closes #69

## Summary

Extracts the find-or-create release-PR shell from `patch-deployer/SKILL.md` into a reusable script. The skill now delegates the `dev → main` PR upsert to a single command instead of inlining the two-branch `gh pr list` / `gh pr create` / `gh pr edit` flow.

Continues the [no-inline-shell push](../docs/automation-audit.md) — `find-patch-deploy-candidate.sh` and `final-review/scripts/merge-pr.sh` set the precedent.

## What changes

### New script

`.claude/skills/patch-deployer/scripts/upsert-release-pr.sh <title> <body-file>`:

- Looks for an open PR with `--head dev --base main` via `gh pr list --json number`.
- If found: `gh pr edit <num> --title "$1" --body-file "$2"`.
- If not found: `git push -u origin dev`, then `gh pr create --base main --head dev --title "$1" --body-file "$2"`.
- Prints the PR number on stdout (parsed from `gh pr create`'s URL output — no extra round trip).

Conventions follow the precedents:

- `set -euo pipefail`
- Brief `Usage:` header
- Executable bit set
- Required args fail fast via `${1:?...}`

### Skill update

`.claude/skills/patch-deployer/SKILL.md`:

- Removed step 3 ("Check for an existing dev → main PR") — script handles it.
- Step 6 ("Create / update the PR") collapsed from two inline `gh` invocations into a single `upsert-release-pr.sh` call. One sentence of prose explains the script's behavior.
- Renumbered downstream steps (4→3, 5→4, 6→5, 7→6, 8→7) and updated the in-text reference.

## Acceptance criteria

- [x] `upsert-release-pr.sh <title> <body-file>` exists and is executable.
- [x] Script finds existing open `dev → main` PR via `gh pr list --json number`.
- [x] On match: edits the PR with the new title and body file.
- [x] On no match: pushes `dev` and creates the PR with the title and body file.
- [x] Script prints the PR number on stdout.
- [x] `SKILL.md` calls `upsert-release-pr.sh` instead of the inline `gh pr list` / `gh pr create` / `gh pr edit` branching.
- [x] Prose explaining the branching is dropped.

## Test plan

- [x] `bash -n upsert-release-pr.sh` — syntax-clean.
- [x] `bun test` — 841 pass / 0 fail.
- [x] `bun run lint` — 0 errors (107 pre-existing warnings).
- [ ] End-to-end against GitHub state (push + PR create/edit) — not safely runnable in the agent's environment; will be exercised on the next patch-deployer cron tick.
