### PR TITLE
chore: extract next-deployer inline shell into scripts (#65)

### DIFF
--- a/.claude/skills/next-deployer/SKILL.md
+++ b/.claude/skills/next-deployer/SKILL.md
@@ -18,54 +18,49 @@ Phase 4 (terminal) of the apijack issue workflow. Roll `next` forward to `dev` a
 
 ## Steps
 
-### 1. Sync dev locally
+### 1. Check if next is behind dev
 
 ```bash
-git fetch origin
-git checkout dev && git pull origin dev
-```
-
-### 2. Check if next is behind dev
-
-```bash
-git fetch origin next
+git fetch origin dev next
 BEHIND=$(git rev-list --count origin/next..origin/dev)
 echo "next is behind dev by $BEHIND commits"
 ```
 
 If `BEHIND` is `0`: `next` is already up to date — skip to step 4.
 
-### 3. Fast-forward next from dev and push
+### 2. Fast-forward next from dev and push
+
+Run:
 
 ```bash
-git checkout next 2>/dev/null || git checkout -b next origin/next
-git merge --ff-only origin/dev
-git push origin next
+.claude/skills/next-deployer/scripts/ff-next-from-dev.sh
 ```
 
-If fast-forward fails (next has diverged), STOP and ask the user how to proceed — do not force-push.
+The script fetches origin, pulls `dev`, checks out `next` (creating it from `origin/next` if missing), fast-forwards it from `origin/dev`, pushes, and returns to `dev`. It exits non-zero on a non-fast-forward — no force-push.
 
-Return to `dev`:
+If it exits non-zero (next has diverged or push failed), STOP and ask the user how to proceed.
+
+### 3. Capture the published commit SHA
 
 ```bash
-git checkout dev
+NEXT_SHA=$(git rev-parse origin/next)
+echo "next is at $NEXT_SHA"
 ```
 
-### 4. Wait for publish-next workflow
+### 4. Wait for the publish-next workflow
+
+Run:
 
 ```bash
-# Find the run triggered by this push
-RUN_ID=$(gh run list --workflow publish.yml --branch next --limit 1 --json databaseId --jq '.[0].databaseId')
-gh run watch "$RUN_ID" --exit-status
+.claude/skills/next-deployer/scripts/wait-for-publish-next.sh "$NEXT_SHA"
 ```
 
-If the run fails:
+Inputs:
+- `$NEXT_SHA` — the commit SHA on `next` whose `publish.yml` run we want to watch.
 
-```bash
-gh run view "$RUN_ID" --log-failed
-```
+The script polls `gh run list` (handling the race where the workflow hasn't registered yet), then `gh run watch --exit-status`. On failure it dumps `gh run view --log-failed` and propagates the non-zero code.
 
-STOP, report the failure to the user, and do not comment on the issue.
+If the script exits non-zero, STOP, report the failure to the user, and do not comment on the issue.
 
 ### 5. Get the published version
 
@@ -78,24 +73,17 @@ Expect a value like `1.8.0-next.1`.
 
 ### 6. Comment on the issue and label it
 
-```bash
-gh issue comment <issue-number> --repo normalled/apijack --body "$(cat <<EOF
-Fix deployed to \`next\`. Install the exact version:
-
-\`\`\`bash
-bun install -g @apijack/core@$NEXT_VERSION
-\`\`\`
-EOF
-)"
-```
-
-Add the `deployed to next` label so the issue's lifecycle stage is visible at a glance:
+Run:
 
 ```bash
-gh issue edit <issue-number> --repo normalled/apijack --add-label "deployed to next"
+.claude/skills/next-deployer/scripts/comment-deployed.sh <issue-number> "$NEXT_VERSION"
 ```
 
-Substitute `<issue-number>` with the argument passed in from `review-issue`, or parse it from the merge commit body (`Closes #NN`).
+Inputs:
+- `<issue-number>` — passed in from `review-issue`, or parsed from the merge commit body (`Closes #NN`).
+- `$NEXT_VERSION` — the version string from step 5.
+
+The script writes the install-instructions markdown to a tempfile, posts it via `gh issue comment --body-file` (avoiding the inline-`--body` backtick-escape footgun), and applies the `deployed to next` label.
 
 ### 7. STOP
 

--- a/.claude/skills/next-deployer/scripts/comment-deployed.sh
+++ b/.claude/skills/next-deployer/scripts/comment-deployed.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Comment the @next install instructions on an issue and label it.
+#
+# Writes the install-instructions markdown to a tempfile and posts it via
+# `gh issue comment --body-file` (avoiding the inline-`--body` backtick-escape
+# footgun). Then applies the `deployed to next` label.
+#
+# Usage: comment-deployed.sh <issue-number> <next-version>
+#   Example: comment-deployed.sh 65 1.10.2-next.3
+
+set -euo pipefail
+
+issue="${1:?issue number required}"
+next_version="${2:?next version required}"
+repo="normalled/apijack"
+
+body_file=$(mktemp)
+trap 'rm -f "$body_file"' EXIT
+
+cat >"$body_file" <<EOF
+Fix deployed to \`next\`. Install the exact version:
+
+\`\`\`bash
+bun install -g @apijack/core@$next_version
+\`\`\`
+EOF
+
+gh issue comment "$issue" --repo "$repo" --body-file "$body_file"
+gh issue edit "$issue" --repo "$repo" --add-label "deployed to next"

--- a/.claude/skills/next-deployer/scripts/ff-next-from-dev.sh
+++ b/.claude/skills/next-deployer/scripts/ff-next-from-dev.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fast-forward the rolling `next` branch from `dev` and push.
+#
+# Aborts non-zero on any non-fast-forward situation rather than force-pushing.
+# After a successful push, returns the working tree to `dev`.
+#
+# Usage: ff-next-from-dev.sh
+#   No arguments. Operates on the current repository's `dev` and `next`
+#   branches against `origin`.
+
+set -euo pipefail
+
+git fetch origin
+
+git checkout dev
+git pull origin dev
+
+git fetch origin next
+
+# Ensure a local `next` exists tracking origin/next.
+git checkout next 2>/dev/null || git checkout -b next origin/next
+
+# Fail loudly on non-FF; do not force-push.
+git merge --ff-only origin/dev
+
+git push origin next
+
+git checkout dev

--- a/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
+++ b/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
@@ -20,13 +20,11 @@ while [ -z "$run_id" ] && [ "$attempts" -lt "$max_attempts" ]; do
     run_id=$(gh run list --repo "$repo" \
         --workflow publish.yml \
         --branch next \
-        --limit 20 \
-        --json databaseId,headSha \
-        --jq ".[] | select(.headSha == \"$commit_sha\") | .databaseId" \
-        | head -n1)
-    if [ -n "$run_id" ]; then
-        break
-    fi
+        --commit "$commit_sha" \
+        --limit 1 \
+        --json databaseId \
+        --jq '.[0].databaseId // empty')
+    [ -n "$run_id" ] && break
     attempts=$((attempts + 1))
     sleep 10
 done

--- a/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
+++ b/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
@@ -36,8 +36,9 @@ fi
 
 echo "Watching publish.yml run $run_id for $commit_sha"
 
-if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
-    rc=$?
+rc=0
+gh run watch "$run_id" --repo "$repo" --exit-status || rc=$?
+if [ "$rc" -ne 0 ]; then
     echo "publish.yml run $run_id failed (exit $rc); dumping failed logs:" >&2
     gh run view "$run_id" --repo "$repo" --log-failed >&2 || true
     exit "$rc"

--- a/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
+++ b/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Wait for the publish.yml workflow run on `next` matching a given commit SHA.
+#
+# Polls `gh run list` until a run for <commit-sha> appears (handles the race
+# where the workflow hasn't registered yet), then `gh run watch --exit-status`.
+# On non-zero exit, dumps `gh run view --log-failed` and propagates the code.
+#
+# Usage: wait-for-publish-next.sh <commit-sha>
+
+set -euo pipefail
+
+commit_sha="${1:?commit sha required}"
+repo="normalled/apijack"
+
+# Poll until the workflow run for our commit shows up.
+run_id=""
+attempts=0
+max_attempts=30   # ~5 minutes at 10s intervals
+while [ -z "$run_id" ] && [ "$attempts" -lt "$max_attempts" ]; do
+    run_id=$(gh run list --repo "$repo" \
+        --workflow publish.yml \
+        --branch next \
+        --limit 20 \
+        --json databaseId,headSha \
+        --jq ".[] | select(.headSha == \"$commit_sha\") | .databaseId" \
+        | head -n1)
+    if [ -n "$run_id" ]; then
+        break
+    fi
+    attempts=$((attempts + 1))
+    sleep 10
+done
+
+if [ -z "$run_id" ]; then
+    echo "No publish.yml run found for $commit_sha after $((max_attempts * 10))s" >&2
+    exit 1
+fi
+
+echo "Watching publish.yml run $run_id for $commit_sha"
+
+if ! gh run watch "$run_id" --repo "$repo" --exit-status; then
+    rc=$?
+    echo "publish.yml run $run_id failed (exit $rc); dumping failed logs:" >&2
+    gh run view "$run_id" --repo "$repo" --log-failed >&2 || true
+    exit "$rc"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ wiki/
 !.claude/skills/*-issue/scripts/
 !.claude/skills/*-issue/scripts/**
 .claude/skills/next*
+!.claude/skills/next-deployer/
+!.claude/skills/next-deployer/**
 
 # Local triage runtime artifacts (snapshots and sandboxed reports)
 .claude-jobs/triage-snapshots/


### PR DESCRIPTION
Closes #65

## Summary

Extracts the heaviest inline shell blocks from the `next-deployer` skill
into focused scripts under `.claude/skills/next-deployer/scripts/`,
following the no-inline-shell principle and mirroring the precedent set
by `.claude/skills/final-review/scripts/merge-pr.sh`.

The skill itself now describes only the script invocation and its
inputs — the agent doesn't need to read the script body to use it.

## What changes

### New scripts under `.claude/skills/next-deployer/scripts/`

- **`ff-next-from-dev.sh`** (no args) — replaces the 3-block fetch /
  branch-dance / push sequence:
  - `git fetch origin`
  - `git checkout dev && git pull origin dev`
  - `git checkout next 2>/dev/null || git checkout -b next origin/next`
  - `git merge --ff-only origin/dev` (aborts non-zero on non-FF; no
    force-push)
  - `git push origin next`
  - returns to `dev`

- **`wait-for-publish-next.sh <commit-sha>`** — polls
  `gh run list --workflow publish.yml --branch next` for a run whose
  `headSha` matches the argument (handles the race where the workflow
  hasn't registered yet, ~5 minute window at 10s intervals), then
  `gh run watch --exit-status`. On non-zero exit it dumps
  `gh run view --log-failed` and propagates the code.

- **`comment-deployed.sh <issue-number> <next-version>`** — writes the
  `@next` install markdown to a tempfile (via `mktemp` + `trap` cleanup)
  and posts it with `gh issue comment --body-file` (avoiding the inline-
  `--body` backtick-escape footgun called out in CLAUDE.md), then runs
  `gh issue edit --add-label "deployed to next"`.

All three scripts:
- start with `set -euo pipefail`
- include a `Usage:` header
- are committed `+x` (mode 755)

### `.claude/skills/next-deployer/SKILL.md`

Drops every inline-shell block that was extracted and replaces it with a
script invocation plus a short description of what the script does and
which inputs it expects. Step structure tightened from 7 to 7 (renumbered
after merging the original "sync dev locally" into the script and adding
a "capture pushed SHA" step that feeds `wait-for-publish-next.sh`).

### `.gitignore`

The existing `.claude/skills/next*` ignore was masking new files under
`next-deployer/`. Added an exception mirroring the existing
`*-issue/scripts/` allow-list pattern:

```
.claude/skills/next*
!.claude/skills/next-deployer/
!.claude/skills/next-deployer/**
```

## Acceptance criteria

- [x] `ff-next-from-dev.sh` exists, replaces the 3-block fetch/branch/push
      sequence, aborts non-zero on non-FF.
- [x] `wait-for-publish-next.sh <commit-sha>` exists, polls for the
      `publish.yml` run on `next` matching the SHA, then
      `gh run watch --exit-status`; on failure dumps
      `gh run view --log-failed`.
- [x] `comment-deployed.sh <issue> <next-version>` exists, writes
      install-instructions markdown to a tempfile and posts via
      `gh issue comment --body-file`, then
      `gh issue edit --add-label "deployed to next"`.
- [x] All three scripts are executable (mode 755), start with
      `set -euo pipefail`, include a `Usage:` header.
- [x] `SKILL.md` describes script invocations and inputs only — no
      extracted inline shell remains.
- [x] No `.claude-jobs/*.yaml` cron job invokes `next-deployer`, so no
      `allowed_tools` updates are required (verified via grep).

## Test plan

- [x] `bash -n` syntax-check on all three scripts (passes)
- [x] `bun test` — 841 pass / 0 fail
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `git ls-files` confirms the new scripts are tracked (the
      `.gitignore` allow-list exception works)

The end-to-end pipeline (cron-driven workflows on `next`) cannot be
exercised in the implementing agent's environment; per-script syntax
check plus this PR's review is the validation layer.

## Spec reference

See issue #65 and the `final-review` precedent at
`.claude/skills/final-review/scripts/merge-pr.sh`.
