### PR TITLE
chore: extract gather-release-commits.sh shared by ship-release and patch-deployer (#68)

### DIFF
--- a/.claude/skills/patch-deployer/SKILL.md
+++ b/.claude/skills/patch-deployer/SKILL.md
@@ -26,21 +26,16 @@ If the bump is `minor` or `major`, this skill must abort and leave the work for 
 
 Expected: prints the commit count, exits 0. If it exits non-zero, STOP — something changed between preflight and now (e.g., a `feat:` commit landed during the run).
 
-### 2. Verify local working state
+### 2. Verify local working state and gather commits
 
 ```bash
-git branch --show-current      # must be `dev`
-git status --porcelain         # must be empty
-git fetch origin
-git log origin/main..HEAD --oneline
+COMMITS_FILE=$(./scripts/gather-release-commits.sh)
+cat "$COMMITS_FILE"
 ```
 
-If any of:
-- not on `dev`
-- working tree dirty
-- local HEAD ≠ origin/dev
+`gather-release-commits.sh` verifies the branch is `dev` and the working tree is clean, runs `git fetch origin`, and writes `origin/main..HEAD` (default format `%h %s`) to `/tmp/apijack-ship-commits.txt`. The printed path is the canonical commit list for the rest of this skill — step 4 reads from it instead of re-running `git log`.
 
-…STOP. The cron should not silently switch branches or stash user WIP.
+If the script exits non-zero, STOP. Also STOP if local HEAD ≠ origin/dev (the cron should not silently switch branches or stash user WIP).
 
 ### 3. Check for an existing dev → main PR
 
@@ -53,7 +48,7 @@ If a PR already exists with a curated body, skip to step 6 (run ship.sh). If a b
 ### 4. Categorize commits
 
 ```bash
-git log origin/main..HEAD --pretty=format:"%h %s"
+cat "$COMMITS_FILE"   # written by gather-release-commits.sh in step 2
 ```
 
 Group into buckets, **skipping merge commits and any prior `chore(release):` bump**:

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -13,27 +13,26 @@ The PR that merges `dev` into `main` *is* the release notes on GitHub. `scripts/
 - There are commits on `dev` that are not yet on `main`
 - **Not** for mid-development PRs targeting `dev` (use `triage-issue` → `implement-issue` for those)
 
-## Preflight
+## Step 1: Preflight + gather commits
 
 ```bash
-git branch --show-current          # must be dev
-git status --porcelain             # must be empty
-git fetch origin
-git log origin/main..HEAD --oneline
+COMMITS_FILE=$(./scripts/gather-release-commits.sh)
+cat "$COMMITS_FILE"
 ```
 
+`gather-release-commits.sh` verifies the branch is `dev` and the working tree is clean, runs `git fetch origin`, writes `origin/main..HEAD` (default format `%h %s`) to `/tmp/apijack-ship-commits.txt`, and prints that path on stdout. It exits non-zero with a clear message on any preflight failure.
+
 Abort and tell the user if:
-- Not on `dev`, or working tree is dirty
-- No commits ahead of main (nothing to ship)
+- The script exits non-zero (not on `dev`, or working tree dirty)
+- The output file is empty (no commits ahead of main, nothing to ship)
 - An open PR already exists from `dev` → `main` with a curated body (check `gh pr list --head dev --base main`). If so, skip to step 5.
 
-## Step 1: Compute the next version
+### Compute the next version
 
-Mirror the logic in `scripts/ship.sh`:
+Mirror the logic in `scripts/ship.sh`. The bump-level scan needs subjects + bodies, so re-run `git log` with that format:
 
 ```bash
-RANGE=origin/main..HEAD
-git log $RANGE --pretty=format:"%s%n%b" > /tmp/ship-commits.txt
+git log origin/main..HEAD --pretty=format:"%s%n%b"
 ```
 
 - Contains `BREAKING CHANGE` → **major**

--- a/scripts/gather-release-commits.sh
+++ b/scripts/gather-release-commits.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Gather the commit log for a pending dev → main release.
+#
+# Verifies preflight (on dev, working tree clean), fetches origin, writes the
+# `origin/main..HEAD` log to a stable temp file, and prints that path on
+# stdout. Used by both the ship-release and patch-deployer skills.
+#
+# Usage: gather-release-commits.sh [--format=<git-format-string>]
+#   --format    git log --pretty format string (default: "%h %s")
+
+set -euo pipefail
+
+FORMAT="%h %s"
+OUT="/tmp/apijack-ship-commits.txt"
+
+usage() {
+    echo "Usage: gather-release-commits.sh [--format=<git-format-string>]" >&2
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --format=*)
+            FORMAT="${arg#--format=}"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
+
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "dev" ]; then
+    echo "Must be on the dev branch (currently on: $BRANCH)" >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Working tree is dirty. Commit or stash changes first." >&2
+    exit 1
+fi
+
+git fetch origin --quiet
+
+git log origin/main..HEAD --pretty=format:"$FORMAT" > "$OUT"
+
+echo "$OUT"


### PR DESCRIPTION
Closes #68

## Summary

`ship-release` and `patch-deployer` both inlined the same preflight-then-`git log`-to-`/tmp` block. Extracted it into `scripts/gather-release-commits.sh` (repo-root, alongside `ship.sh` and `wait-for-review.sh`) so both skills call one script instead of duplicating the shell. Follows the [no-inline-shell principle](../docs/automation-audit.md).

## What changes

### New `scripts/gather-release-commits.sh`

- Verifies current branch is `dev`; aborts with `Must be on the dev branch (currently on: <branch>)` otherwise.
- Verifies working tree is clean; aborts with `Working tree is dirty. Commit or stash changes first.` otherwise.
- Runs `git fetch origin --quiet`.
- Writes `git log origin/main..HEAD` to `/tmp/apijack-ship-commits.txt` and prints that path on stdout.
- Optional `--format=<git-format-string>` flag, default `%h %s`.
- `set -euo pipefail`; mirrors the style of `.claude/skills/final-review/scripts/merge-pr.sh` (header comment + brief `Usage:`).

### Skill updates

- `.claude/skills/ship-release/SKILL.md` — collapsed the old "Preflight" + step 1 commit-gathering blocks into a single `## Step 1: Preflight + gather commits` that calls `./scripts/gather-release-commits.sh` and reads `$COMMITS_FILE`. The bump-level scan still runs `git log ... %s%n%b` inline because it needs commit bodies (a different format than the script writes).
- `.claude/skills/patch-deployer/SKILL.md` — step 2 now calls the script and captures `$COMMITS_FILE`; step 4 reads from `$COMMITS_FILE` instead of re-running `git log`. The `local HEAD ≠ origin/dev` warning stays in the skill prose (out of scope for the script per the issue).

## Acceptance criteria

- [x] Script verifies branch is `dev`, aborts with clear error
- [x] Script verifies working tree is clean, aborts with clear error
- [x] Runs `git fetch origin`
- [x] Writes `origin/main..HEAD` log to `/tmp/apijack-ship-commits.txt`
- [x] Prints path on stdout
- [x] Optional `--format=<git-format-string>` flag, default `%h %s`
- [x] Wired into `.claude/skills/ship-release/SKILL.md` step 1
- [x] Wired into `.claude/skills/patch-deployer/SKILL.md` step 2

## Test plan

- [x] `bun test` — 841 pass / 0 fail
- [x] `bun run lint` — 0 errors (107 pre-existing warnings)
- [x] `bash -n scripts/gather-release-commits.sh` — syntax OK
- [x] Wrong-branch abort: ran on `issues/68-...` → `Must be on the dev branch (currently on: issues/68-gather-release-commits)`, exit 1
- [x] Dirty-tree abort: ran on `dev` with untracked file → `Working tree is dirty. Commit or stash changes first.`, exit 1
- [x] Happy path (clean dev worktree): exit 0, prints `/tmp/apijack-ship-commits.txt`, file contains `<sha> <subject>` lines
- [x] `--format='%H %s'`: file contains full SHAs
- [x] Unknown arg: exit 2 with usage message
- [x] `--help`: exit 0 with usage message
