### PR TITLE
chore: hard-stop ship.sh on major bumps until explicitly confirmed

### DIFF
--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -67,6 +67,31 @@ else
     BUMP_LEVEL="patch"
 fi
 
+# Major-bump safeguard. The v2.0.0 misship (apijack#59) shipped a major bump
+# from a commit body that documented a breaking gate without actually
+# introducing one. Major bumps must be confirmed explicitly — refuse to
+# proceed silently.
+if [ "$BUMP_LEVEL" = "major" ]; then
+    fail "Detected a MAJOR version bump."
+    echo ""
+    warn "Commits containing BREAKING CHANGE:"
+    git log "$RANGE" --grep="BREAKING CHANGE" --pretty=format:"  %h %s"
+    echo ""
+    echo ""
+    if [ "${SHIP_ALLOW_MAJOR:-}" = "1" ]; then
+        warn "SHIP_ALLOW_MAJOR=1 set — proceeding."
+    elif [ -t 0 ]; then
+        read -r -p "Type 'major' to confirm, anything else aborts: " CONFIRM
+        if [ "$CONFIRM" != "major" ]; then
+            fail "Aborted."
+            exit 1
+        fi
+    else
+        fail "Non-interactive run. Set SHIP_ALLOW_MAJOR=1 to proceed."
+        exit 1
+    fi
+fi
+
 CURRENT_VERSION=$(node -p "require('./package.json').version")
 npm version "$BUMP_LEVEL" --no-git-tag-version --quiet >/dev/null
 NEW_VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

Adds a hard-stop in `scripts/ship.sh` when the bump-level scan detects a major bump. Refuses to proceed without explicit confirmation, before any version bump or push happens.

Motivated by the v2.0.0 misship (#59) — that incident's fix tightened *detection* (anchoring `BREAKING CHANGE` to footer lines, scanning subjects only for `feat`), but a future false positive or genuinely unintended major would still ship silently. This adds the missing gate.

## What changes

- If `BUMP_LEVEL=major`:
  - Lists every commit containing `BREAKING CHANGE` in its message.
  - Interactive runs: prompt `Type 'major' to confirm, anything else aborts:`.
  - Non-interactive runs: abort unless `SHIP_ALLOW_MAJOR=1` is set in the environment.
- Patch and minor bumps are unaffected.

## Acceptance criteria

- [x] Major bump on TTY → script halts, prints offending commits, prompts for confirmation, aborts on anything other than literal `major`.
- [x] Major bump non-interactive without `SHIP_ALLOW_MAJOR=1` → script aborts with clear message.
- [x] Major bump non-interactive with `SHIP_ALLOW_MAJOR=1` → script proceeds.
- [x] Patch / minor bumps → no behavior change.
- [x] Gate runs *before* `npm version` and `git push` — no side effects on abort.

## Test plan

- [x] Bump-level scanner verified on a synthetic repo: `feat: foo` + `BREAKING CHANGE:` body → `major`; plain `fix:` → `patch`.
- [x] `bash -n scripts/ship.sh` — syntax clean.
- [ ] Will exercise on next real major release (whenever that lands).
