### PR TITLE
chore: pin gh auth to project owner across skill scripts

### DIFF
--- a/.claude/skills/final-review/scripts/find-final-review-candidate.sh
+++ b/.claude/skills/final-review/scripts/find-final-review-candidate.sh
@@ -16,6 +16,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 min_age="${1:-240}"
 repo="normalled/apijack"
 threshold=$(( $(date -u +%s) - min_age ))

--- a/.claude/skills/final-review/scripts/merge-pr.sh
+++ b/.claude/skills/final-review/scripts/merge-pr.sh
@@ -10,6 +10,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 pr="${1:?pr number required}"
 head_sha="${2:?head sha required}"
 merge_method="${3:-merge}"

--- a/.claude/skills/next-deployer/scripts/comment-deployed.sh
+++ b/.claude/skills/next-deployer/scripts/comment-deployed.sh
@@ -10,6 +10,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 issue="${1:?issue number required}"
 next_version="${2:?next version required}"
 repo="normalled/apijack"

--- a/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
+++ b/.claude/skills/next-deployer/scripts/wait-for-publish-next.sh
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 commit_sha="${1:?commit sha required}"
 repo="normalled/apijack"
 

--- a/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
+++ b/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 title="${1:?title required}"
 body_file="${2:?body file required}"
 repo="normalled/apijack"

--- a/.claude/skills/review-issue/scripts/ensure-review-labels.sh
+++ b/.claude/skills/review-issue/scripts/ensure-review-labels.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 ensure() {
     local name="$1" color="$2" desc="$3"
     if gh label list --json name --jq '.[].name' | grep -qxF "$name"; then

--- a/.claude/skills/review-issue/scripts/find-review-candidate.sh
+++ b/.claude/skills/review-issue/scripts/find-review-candidate.sh
@@ -15,6 +15,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 repo="normalled/apijack"
 
 # One API call: list candidate PRs with labels + head SHA.

--- a/.claude/skills/review-issue/scripts/post-review.sh
+++ b/.claude/skills/review-issue/scripts/post-review.sh
@@ -12,6 +12,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 3 ]; then
     echo "usage: $0 <pr-number> <comment|request-changes|approve> <body-file>" >&2
     exit 2

--- a/.claude/skills/review-issue/scripts/set-review-label.sh
+++ b/.claude/skills/review-issue/scripts/set-review-label.sh
@@ -12,6 +12,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 2 ]; then
     echo "usage: $0 <pr-number> <label>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/add-triage-flag.sh
+++ b/.claude/skills/triage-issue/scripts/add-triage-flag.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 2 ]; then
     echo "usage: $0 <issue-number> <flag>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/ensure-triage-labels.sh
+++ b/.claude/skills/triage-issue/scripts/ensure-triage-labels.sh
@@ -3,6 +3,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 ensure() {
     local name="$1" color="$2" desc="$3"
     if gh label list --json name --jq '.[].name' | grep -qxF "$name"; then

--- a/.claude/skills/triage-issue/scripts/lock-issue.sh
+++ b/.claude/skills/triage-issue/scripts/lock-issue.sh
@@ -9,6 +9,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 1 ]; then
     echo "usage: $0 <issue-number>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/sanitize-issue.sh
+++ b/.claude/skills/triage-issue/scripts/sanitize-issue.sh
@@ -26,6 +26,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 1 ]; then
     echo "usage: $0 <issue-number>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/set-triage-label.sh
+++ b/.claude/skills/triage-issue/scripts/set-triage-label.sh
@@ -14,6 +14,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 2 ]; then
     echo "usage: $0 <issue-number> <label>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/snapshot-issue.sh
+++ b/.claude/skills/triage-issue/scripts/snapshot-issue.sh
@@ -11,6 +11,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 1 ]; then
     echo "usage: $0 <issue-number>" >&2
     exit 2

--- a/.claude/skills/triage-issue/scripts/verify-snapshot.sh
+++ b/.claude/skills/triage-issue/scripts/verify-snapshot.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -ne 2 ]; then
     echo "usage: $0 <issue-number> <expected-sha256>" >&2
     exit 2

--- a/scripts/gh-pin-account.sh
+++ b/scripts/gh-pin-account.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# gh-pin-account.sh — source from other scripts in this repo to pin `gh`
+# authentication to a known account. Cron-driven skills otherwise fire under
+# whichever account happens to be active, which leaves wrong-author reviews
+# and comments on PRs (see the gpremo-re posts on PR #80 that motivated this).
+#
+# Falls back silently to the active account if the pinned user isn't
+# configured locally — non-owner checkouts of this repo keep working under
+# whatever credentials they have.
+#
+# Override the default user with GH_PIN_USER, e.g. for testing:
+#   GH_PIN_USER=other-account some-script.sh
+#
+# Usage from any consumer script in this repo:
+#   source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
+__gh_pin_user="${GH_PIN_USER:-garretpremo}"
+__gh_pin_token="$(gh auth token --user "$__gh_pin_user" 2>/dev/null || true)"
+if [ -n "$__gh_pin_token" ]; then
+    export GH_TOKEN="$__gh_pin_token"
+fi
+unset __gh_pin_user __gh_pin_token

--- a/scripts/pr-comment.sh
+++ b/scripts/pr-comment.sh
@@ -20,6 +20,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [ $# -lt 2 ] || [ $# -gt 3 ]; then
     echo "usage: $0 <pr-or-issue-number> <body-string-or-path> [--target=pr|issue]" >&2
     exit 2

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 # ship.sh — Automates the dev→main shipping pipeline
 # Usage: ./scripts/ship.sh
 #

--- a/scripts/wait-for-review.sh
+++ b/scripts/wait-for-review.sh
@@ -13,6 +13,8 @@
 
 set -euo pipefail
 
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <pr-number>" >&2
     exit 1


### PR DESCRIPTION
## Summary

Fixes the root cause of the wrong-author actions on PR #80. `gh` has no per-invocation `--user` flag, so cron-driven skills inherit whichever account `gh auth switch` last picked — interactive sessions and crons fight for global state, and the `gpremo-re` work account leaked through to apijack PR reviews.

New `scripts/gh-pin-account.sh` is sourced from every script that calls `gh`. It exports `GH_TOKEN` scoped to `garretpremo` (override via `GH_PIN_USER`), with a silent fallback to whichever account is active locally. `GH_TOKEN` is per-process, so concurrent runs no longer step on each other.

## What changes

- **`scripts/gh-pin-account.sh`** — new helper. Tries `gh auth token --user garretpremo`; on success exports `GH_TOKEN`. Otherwise no-op so fork/clone users keep working under whatever auth they have.
- **19 consumer scripts updated** — one `source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"` line right after `set -euo pipefail` in each:
  - `scripts/`: `ship.sh`, `wait-for-review.sh`, `pr-comment.sh`
  - `final-review/scripts/`: `find-final-review-candidate.sh`, `merge-pr.sh`
  - `next-deployer/scripts/`: `comment-deployed.sh`, `wait-for-publish-next.sh`
  - `patch-deployer/scripts/`: `upsert-release-pr.sh`
  - `review-issue/scripts/`: 4 files
  - `triage-issue/scripts/`: 7 files

`scripts/collect-closes-refs.sh` (introduced by PR #80) is intentionally **not** included here — that file lives on a different branch. It'll get the same treatment as a follow-up once #80 merges.

## Acceptance criteria

- [x] Helper exports `GH_TOKEN` for `garretpremo` and verifies via `${GH_TOKEN:0:8}` matching that account's token (verified `gho_VD2m...` vs `gpremo-re`'s `gho_E9WS...`).
- [x] Helper silently no-ops when the pinned user isn't configured, leaving `gh` to use the active account.
- [x] `bash -n` clean on all 19 modified consumers.
- [x] Override path works: `GH_PIN_USER=other-account` overrides the default.

## Test plan

- [x] Standalone helper test: `(source scripts/gh-pin-account.sh && echo "${GH_TOKEN:0:8}")` prints garretpremo's token prefix.
- [x] Syntax check: `bash -n` on all modified scripts.
- [ ] Real-world verification: re-enable the `final-review` and `review-issue` crons (currently disabled), watch the next cycle's reviews come through under `garretpremo`.
