### PR TITLE
Programmatic runRoutine() API + --json CLI mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,12 +97,22 @@ Usable anywhere a routine value is resolved (args, conditions, variables):
 <cli> routine run <name>        # Execute a routine
 <cli> routine run <name> --set key=value  # Override variables
 <cli> routine run <name> --dry-run        # Preview without executing
+<cli> routine run <name> --json           # Emit RoutineResult as JSON to stdout
 <cli> routine validate <name>   # Validate YAML structure
 <cli> routine test <name>       # Run spec (test) file
 <cli> routine init              # Install built-in routines
 <cli> plugins list              # List registered apijack plugins
 <cli> plugins check             # Validate plugins (namespace, collisions, peer versions)
 ```
+
+### Programmatic Routine Invocation
+
+Two surfaces, one engine:
+
+- **`cli.runRoutine(name, opts?)`** — method on the `Cli` returned by `createCli`. Use from a project that already has a `bin/<cli>.ts`.
+- **`runRoutine(name, opts?)`** — top-level export from `@apijack/core` for projects on the shared `apijack` binary (no bin file).
+
+Both resolve with a `RoutineResult` (status, output, steps, durationMs, ...) on success and on step failure. Engine errors (routine not found, YAML invalid, no active env config) throw. Useful for Playwright/Vitest fixtures that seed via routines.
 
 ## Plugin System
 

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -32,6 +32,9 @@ import { SessionAuthStrategy } from './auth/session-auth';
 import { resolveRequestHeaders } from './auth/resolve-headers';
 import { deepMergeSessionAuth } from './auth/config-merge';
 import { loadPreRequestHook } from './pre-request';
+import type { RoutineResult } from './routine/executor';
+import { executeRoutine } from './routine/executor';
+import { loadRoutineFile, validateRoutine } from './routine/loader';
 
 const coreManifest = JSON.parse(
     readFileSync(join(import.meta.dir, '..', 'package.json'), 'utf-8'),
@@ -51,6 +54,12 @@ export interface Cli {
     resolver(name: string, handler: CustomResolver): void;
     use(plugin: ApijackPlugin): void;
     run(): Promise<void>;
+    runRoutine(name: string, opts?: RunRoutineOptions): Promise<RoutineResult>;
+}
+
+export interface RunRoutineOptions {
+    vars?: Record<string, unknown>;
+    dryRun?: boolean;
 }
 
 const CORE_COMMANDS = new Set([
@@ -354,6 +363,25 @@ export function createCli(options: CliOptions): Cli {
 
         use(plugin: ApijackPlugin): void {
             pluginRegistry.register(plugin);
+        },
+
+        async runRoutine(name: string, opts?: RunRoutineOptions): Promise<RoutineResult> {
+            const runtime = await _buildRoutineRuntime();
+            const def = loadRoutineFile(name, runtime.routinesDir, runtime.builtinsMap);
+            const errors = validateRoutine(def);
+
+            if (errors.length > 0) {
+                throw new Error(`Validation errors:\n${errors.map(e => `  - ${e}`).join('\n')}`);
+            }
+
+            runtime.sessionMgr.invalidate();
+
+            return executeRoutine(def, opts?.vars ?? {}, runtime.dispatch, {
+                dryRun: opts?.dryRun,
+                silent: true,
+                customResolvers: runtime.customResolvers,
+                pluginRegistry,
+            });
         },
 
         async run(): Promise<void> {

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -153,7 +153,12 @@ export function createCli(options: CliOptions): Cli {
         pluginRegistry.validateAll(consumerResolvers);
 
         for (const plugin of pluginRegistry.getAll()) {
-            if (!plugin.__package) continue;
+            if (!plugin.__package) {
+                process.stderr.write(
+                    `Warning: plugin "${plugin.name}" did not self-report its package; skipping peer-version check.\n`,
+                );
+                continue;
+            }
 
             const info = loadPluginPeerInfo(plugin.__package.name, [process.cwd(), import.meta.dir]);
             const mismatchMsg = checkPeerRange({
@@ -307,6 +312,9 @@ export function createCli(options: CliOptions): Cli {
         }
 
         // 10. Build dispatch.
+        const builtinsMap = options.builtinRoutinesDir
+            ? loadBuiltinRoutines(options.builtinRoutinesDir)
+            : undefined;
         const dispatch = buildDispatcher({
             commandMap,
             client: ctx.client as Record<string, unknown> | undefined,
@@ -316,9 +324,7 @@ export function createCli(options: CliOptions): Cli {
             preDispatch: options.preDispatch,
             ctx,
             routinesDir,
-            builtinsMap: options.builtinRoutinesDir
-                ? loadBuiltinRoutines(options.builtinRoutinesDir)
-                : undefined,
+            builtinsMap,
         });
 
         routineRuntime = {
@@ -327,9 +333,7 @@ export function createCli(options: CliOptions): Cli {
             customResolvers,
             sessionMgr,
             routinesDir,
-            builtinsMap: options.builtinRoutinesDir
-                ? loadBuiltinRoutines(options.builtinRoutinesDir)
-                : undefined,
+            builtinsMap,
         };
 
         return routineRuntime;

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -137,6 +137,204 @@ export function createCli(options: CliOptions): Cli {
     const effectiveRequiresAuth = (explicit: boolean | undefined): boolean =>
         explicit ?? defaultRequiresAuth;
 
+    let routineRuntime: {
+        ctx: CliContext;
+        dispatch: CommandDispatcher;
+        customResolvers: Map<string, CustomResolver> | undefined;
+        sessionMgr: SessionManager;
+        routinesDir: string;
+        builtinsMap: Record<string, string> | undefined;
+    } | null = null;
+
+    async function _buildRoutineRuntime(): Promise<NonNullable<typeof routineRuntime>> {
+        if (routineRuntime) return routineRuntime;
+
+        // 1. Validate plugins (matches cli.run() logic, minus the `plugins check` skip).
+        pluginRegistry.validateAll(consumerResolvers);
+
+        for (const plugin of pluginRegistry.getAll()) {
+            if (!plugin.__package) continue;
+
+            const info = loadPluginPeerInfo(plugin.__package.name, [process.cwd(), import.meta.dir]);
+            const mismatchMsg = checkPeerRange({
+                declaredRange: info.declaredRange,
+                installedVersion: coreManifest.version,
+            });
+
+            if (mismatchMsg) {
+                throw new PluginPeerMismatchError(
+                    plugin.name,
+                    info.declaredRange ?? '(none)',
+                    coreManifest.version,
+                );
+            }
+        }
+
+        // 2. Resolve auth from active env config.
+        const resolved = resolveAuth(cliName, configOpts);
+
+        if (!resolved) {
+            throw new Error(`No active env config. Run '${cliName} setup' to configure credentials.`);
+        }
+
+        // 3. Compute auth strategy + sessionMgr.
+        const envConfig = getActiveEnvConfig(cliName, configOpts);
+        const mergedSessionAuth = options.sessionAuth
+            ? deepMergeSessionAuth(options.sessionAuth, envConfig?.sessionAuth)
+            : undefined;
+        const strategy = mergedSessionAuth
+            ? new SessionAuthStrategy(options.auth, mergedSessionAuth)
+            : options.auth;
+        const sessionMgr = new SessionManager(cliName, join(configDir, 'session.json'));
+
+        // 4. Import generated client (best-effort — same as cli.run()).
+        let ApiClientClass: (new (...args: unknown[]) => Record<string, unknown>) | null = null;
+
+        try {
+            const cmds = await import(resolve(generatedDir, 'commands'));
+
+            if (cmds.registerGeneratedCommands) {
+                const clientMod = await import(resolve(generatedDir, 'client'));
+                ApiClientClass = clientMod.ApiClient;
+            }
+        } catch {
+            // Generated commands not available — routines that don't dispatch to API methods still work.
+        }
+
+        // 5. Build CliContext with lazy session.
+        const ctx: CliContext = {
+            client: null,
+            session: null,
+            auth: resolved,
+            strategy,
+            refreshSession: async () => {
+                sessionMgr.invalidate();
+                ctx.session = await sessionMgr.resolve(strategy, resolved);
+            },
+            resolveSession: async () => {
+                if (ctx.session) return;
+
+                ctx.session = await sessionMgr.resolve(strategy, resolved);
+            },
+            saveSession: async () => {
+                if (ctx.session) {
+                    sessionMgr.save(ctx.session);
+                } else {
+                    sessionMgr.invalidate();
+                }
+            },
+        };
+
+        // 6. Wire client if generated commands are present.
+        if (ApiClientClass) {
+            const getHeaders = (method: string) =>
+                resolveRequestHeaders(ctx.session ?? { headers: {} }, mergedSessionAuth, method);
+
+            const client = new ApiClientClass(
+                resolved.baseUrl ?? '',
+                getHeaders,
+                mergedSessionAuth ? async () => { await ctx.refreshSession(); } : undefined,
+                mergedSessionAuth?.refreshOn,
+            ) as Record<string, unknown>;
+
+            ctx.client = client;
+            client.ensureReady = ctx.resolveSession;
+
+            // Pre-request hook (project-level)
+            const consumerHook = await loadPreRequestHook(configDir);
+
+            if (consumerHook && !consumerHook.beforeDryRun) {
+                const existing = client.interceptRequest as
+                    ((req: { method: string; url: string; body?: unknown }) => unknown | undefined) | undefined;
+                client.interceptRequest = (req: { method: string; url: string; body?: unknown }) => {
+                    if (existing) {
+                        const result = existing(req);
+
+                        if (result !== undefined) return result;
+                    }
+
+                    try {
+                        consumerHook.handler(structuredClone(req));
+                    } catch { /* observer */ }
+
+                    return undefined;
+                };
+            } else if (consumerHook?.beforeDryRun) {
+                client.preRequest = consumerHook.handler;
+            }
+        }
+
+        // 7. Build commandMap import (best-effort).
+        let commandMap:
+            | Record<string, { operationId: string; pathParams: string[]; queryParams: string[]; hasBody: boolean }>
+            | undefined;
+
+        try {
+            const mapModule = await import(resolve(generatedDir, 'command-map'));
+            commandMap = mapModule.commandMap;
+        } catch {
+            // No command-map available
+        }
+
+        // 8. Merge custom resolvers (consumer + plugin stateless).
+        const mergedResolvers = new Map<string, CustomResolver>(consumerResolvers);
+
+        for (const plugin of pluginRegistry.getAll()) {
+            for (const [key, fn] of Object.entries(plugin.resolvers ?? {})) {
+                mergedResolvers.set(key, fn);
+            }
+        }
+
+        const customResolvers = mergedResolvers.size > 0 ? mergedResolvers : undefined;
+
+        // 9. Wrap dispatcher handlers with ensureReady where required.
+        let dispatcherHandlers: Map<string, DispatcherHandler> | undefined;
+
+        if (consumerDispatchers.size > 0) {
+            dispatcherHandlers = new Map();
+
+            for (const [name, entry] of consumerDispatchers) {
+                if (effectiveRequiresAuth(entry.requiresAuth)) {
+                    dispatcherHandlers.set(name, async (args, positional, dctx) => {
+                        await ctx.resolveSession();
+
+                        return entry.handler(args, positional, dctx);
+                    });
+                } else {
+                    dispatcherHandlers.set(name, entry.handler);
+                }
+            }
+        }
+
+        // 10. Build dispatch.
+        const dispatch = buildDispatcher({
+            commandMap,
+            client: ctx.client as Record<string, unknown> | undefined,
+            consumerHandlers: dispatcherHandlers,
+            customResolvers,
+            pluginRegistry,
+            preDispatch: options.preDispatch,
+            ctx,
+            routinesDir,
+            builtinsMap: options.builtinRoutinesDir
+                ? loadBuiltinRoutines(options.builtinRoutinesDir)
+                : undefined,
+        });
+
+        routineRuntime = {
+            ctx,
+            dispatch,
+            customResolvers,
+            sessionMgr,
+            routinesDir,
+            builtinsMap: options.builtinRoutinesDir
+                ? loadBuiltinRoutines(options.builtinRoutinesDir)
+                : undefined,
+        };
+
+        return routineRuntime;
+    }
+
     const cli: Cli = {
         command(name: string, registrar: CommandRegistrar, cmdOpts?: CommandOptions): void {
             consumerCommands.push({ name, registrar, requiresAuth: cmdOpts?.requiresAuth });

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -5,7 +5,7 @@ import type { CommandDispatcher, CustomResolver } from '../../types';
 import type { PluginRegistry } from '../../plugin/registry';
 import { SessionManager } from '../../session';
 import { loadRoutineFile, loadSpecFile, listRoutines, validateRoutine, formatRoutineTree, formatRoutineList } from '../../routine/loader';
-import { executeRoutine } from '../../routine/executor';
+import { executeRoutine, type RoutineResult } from '../../routine/executor';
 import { routineListAction } from './list/list';
 import { routineRunAction } from './run/run';
 import { routineValidateAction } from './validate/validate';
@@ -92,7 +92,7 @@ export function registerRoutineCommand(
         .action(async (name: string, opts: { set?: string[]; dryRun?: boolean; json?: boolean }) => {
             if (!dispatch) {
                 if (opts.json) {
-                    process.stdout.write(JSON.stringify({
+                    const failure: RoutineResult = {
                         status: 'failed',
                         success: false,
                         output: {},
@@ -102,7 +102,8 @@ export function registerRoutineCommand(
                         stepsSkipped: 0,
                         stepsFailed: 0,
                         error: `No active session. Run '${cliName} setup' first.`,
-                    }) + '\n');
+                    };
+                    process.stdout.write(JSON.stringify(failure) + '\n');
                     process.exit(2);
                 }
 
@@ -137,12 +138,15 @@ export function registerRoutineCommand(
                         invalidateSession: () => sessionMgr.invalidate(),
                     });
 
-                    process.stdout.write(JSON.stringify(result) + '\n');
+                    // Strip fields routineRunAction appends for the CLI banner — the
+                    // JSON contract is RoutineResult only.
+                    const { name: _name, description: _description, ...routineResult } = result;
+                    process.stdout.write(JSON.stringify(routineResult) + '\n');
 
                     if (result.status !== 'ok') process.exit(1);
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    process.stdout.write(JSON.stringify({
+                    const failure: RoutineResult = {
                         status: 'failed',
                         success: false,
                         output: {},
@@ -152,7 +156,8 @@ export function registerRoutineCommand(
                         stepsSkipped: 0,
                         stepsFailed: 0,
                         error: msg,
-                    }) + '\n');
+                    };
+                    process.stdout.write(JSON.stringify(failure) + '\n');
                     process.exit(1);
                 }
 

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -88,8 +88,24 @@ export function registerRoutineCommand(
         .description('Execute a routine')
         .option('--set <pairs...>', 'Override variables (key=value)')
         .option('--dry-run', 'Print resolved commands without executing')
-        .action(async (name: string, opts: { set?: string[]; dryRun?: boolean }) => {
+        .option('--json', 'Emit RoutineResult as JSON to stdout (silences progress output)')
+        .action(async (name: string, opts: { set?: string[]; dryRun?: boolean; json?: boolean }) => {
             if (!dispatch) {
+                if (opts.json) {
+                    process.stdout.write(JSON.stringify({
+                        status: 'failed',
+                        success: false,
+                        output: {},
+                        steps: [],
+                        durationMs: 0,
+                        stepsRun: 0,
+                        stepsSkipped: 0,
+                        stepsFailed: 0,
+                        error: `No active session. Run '${cliName} setup' first.`,
+                    }) + '\n');
+                    process.exit(2);
+                }
+
                 console.error(`No active session. Run '${cliName} setup' first.`);
                 process.exit(2);
             }
@@ -104,6 +120,46 @@ export function registerRoutineCommand(
 
             const sessionMgr = new SessionManager(cliName);
 
+            if (opts.json) {
+                // JSON mode — silent, structured output.
+                try {
+                    const def = loadRoutineFile(name, routinesDir, builtinsMap);
+                    const result = await routineRunAction({
+                        loadRoutine: () => def,
+                        validateRoutine,
+                        executeRoutine,
+                        dispatch,
+                        overrides,
+                        dryRun: opts.dryRun,
+                        silent: true,
+                        customResolvers,
+                        pluginRegistry,
+                        invalidateSession: () => sessionMgr.invalidate(),
+                    });
+
+                    process.stdout.write(JSON.stringify(result) + '\n');
+
+                    if (result.status !== 'ok') process.exit(1);
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    process.stdout.write(JSON.stringify({
+                        status: 'failed',
+                        success: false,
+                        output: {},
+                        steps: [],
+                        durationMs: 0,
+                        stepsRun: 0,
+                        stepsSkipped: 0,
+                        stepsFailed: 0,
+                        error: msg,
+                    }) + '\n');
+                    process.exit(1);
+                }
+
+                return;
+            }
+
+            // Default mode — colored progress output (unchanged from before).
             try {
                 const def = loadRoutineFile(name, routinesDir, builtinsMap);
                 console.log(

--- a/src/commands/routine/run/run.test.ts
+++ b/src/commands/routine/run/run.test.ts
@@ -6,7 +6,7 @@ describe('routineRunAction', () => {
         const result = await routineRunAction({
             loadRoutine: () => ({ name: 'test-routine', description: 'A test', steps: [] }),
             validateRoutine: () => [],
-            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 2, stepsSkipped: 0, stepsFailed: 0 })),
+            executeRoutine: mock(() => Promise.resolve({ status: 'ok' as const, success: true, output: {}, steps: [], durationMs: 0, stepsRun: 2, stepsSkipped: 0, stepsFailed: 0 })),
             dispatch: mock(() => Promise.resolve({})),
             overrides: {},
             invalidateSession: mock(() => {}),
@@ -19,7 +19,7 @@ describe('routineRunAction', () => {
         expect(routineRunAction({
             loadRoutine: () => ({ name: 'bad', steps: [] }),
             validateRoutine: () => ['missing steps'],
-            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+            executeRoutine: mock(() => Promise.resolve({ status: 'ok' as const, success: true, output: {}, steps: [], durationMs: 0, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
             dispatch: mock(() => Promise.resolve({})),
             overrides: {},
             invalidateSession: mock(() => {}),

--- a/src/commands/routine/run/run.test.ts
+++ b/src/commands/routine/run/run.test.ts
@@ -25,4 +25,32 @@ describe('routineRunAction', () => {
             invalidateSession: mock(() => {}),
         })).rejects.toThrow('Validation errors');
     });
+
+    test('passes silent: true through to executor when caller sets it', async () => {
+        let capturedOpts: any = null;
+        const result = await routineRunAction({
+            loadRoutine: () => ({ name: 'r', steps: [{ name: 's', command: 'c' }] }),
+            validateRoutine: () => [],
+            executeRoutine: async (def, overrides, dispatch, opts) => {
+                capturedOpts = opts;
+
+                return {
+                    status: 'ok',
+                    success: true,
+                    output: {},
+                    steps: [],
+                    durationMs: 0,
+                    stepsRun: 1,
+                    stepsSkipped: 0,
+                    stepsFailed: 0,
+                };
+            },
+            dispatch: async () => ({}),
+            overrides: {},
+            silent: true,
+            invalidateSession: () => {},
+        });
+        expect(capturedOpts.silent).toBe(true);
+        expect(result.success).toBe(true);
+    });
 });

--- a/src/commands/routine/run/run.ts
+++ b/src/commands/routine/run/run.ts
@@ -6,10 +6,11 @@ import type { RoutineResult } from '../../../routine/executor';
 export interface RoutineRunDeps {
     loadRoutine: () => RoutineDefinition;
     validateRoutine: (def: RoutineDefinition) => string[];
-    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; customResolvers?: Map<string, CustomResolver>; pluginRegistry?: PluginRegistry; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
+    executeRoutine: (def: RoutineDefinition, overrides: Record<string, unknown>, dispatch: CommandDispatcher, opts: { dryRun?: boolean; silent?: boolean; customResolvers?: Map<string, CustomResolver>; pluginRegistry?: PluginRegistry; onStep?: RoutineRunDeps['onStep']; onIteration?: RoutineRunDeps['onIteration'] }) => Promise<RoutineResult>;
     dispatch: CommandDispatcher;
     overrides: Record<string, unknown>;
     dryRun?: boolean;
+    silent?: boolean;
     customResolvers?: Map<string, CustomResolver>;
     pluginRegistry?: PluginRegistry;
     invalidateSession: () => void;
@@ -17,7 +18,7 @@ export interface RoutineRunDeps {
     onIteration?: (step: RoutineStep, current: number, total: number, stepIndex: number, stepTotal: number) => void;
 }
 
-export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success: boolean; stepsRun: number; stepsSkipped: number; stepsFailed: number; name: string; description?: string }> {
+export async function routineRunAction(deps: RoutineRunDeps): Promise<RoutineResult & { name: string; description?: string }> {
     const def = deps.loadRoutine();
     const errors = deps.validateRoutine(def);
 
@@ -29,6 +30,7 @@ export async function routineRunAction(deps: RoutineRunDeps): Promise<{ success:
 
     const result = await deps.executeRoutine(def, deps.overrides, deps.dispatch, {
         dryRun: deps.dryRun,
+        silent: deps.silent,
         customResolvers: deps.customResolvers,
         pluginRegistry: deps.pluginRegistry,
         onStep: deps.onStep,

--- a/src/commands/routine/test/test.test.ts
+++ b/src/commands/routine/test/test.test.ts
@@ -6,7 +6,7 @@ describe('routineTestAction', () => {
         const result = await routineTestAction({
             loadSpec: () => ({ name: 'test-spec', description: 'A test', steps: [] }),
             validateRoutine: () => [],
-            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 3, stepsSkipped: 0, stepsFailed: 0 })),
+            executeRoutine: mock(() => Promise.resolve({ status: 'ok' as const, success: true, output: {}, steps: [], durationMs: 0, stepsRun: 3, stepsSkipped: 0, stepsFailed: 0 })),
             dispatch: mock(() => Promise.resolve({})),
             overrides: {},
         });
@@ -18,7 +18,7 @@ describe('routineTestAction', () => {
         expect(routineTestAction({
             loadSpec: () => null,
             validateRoutine: () => [],
-            executeRoutine: mock(() => Promise.resolve({ success: true, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
+            executeRoutine: mock(() => Promise.resolve({ status: 'ok' as const, success: true, output: {}, steps: [], durationMs: 0, stepsRun: 0, stepsSkipped: 0, stepsFailed: 0 })),
             dispatch: mock(() => Promise.resolve({})),
             overrides: {},
         })).rejects.toThrow('No spec.yaml found');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
 export { createCli } from './cli-builder';
-export type { Cli, CommandOptions, DispatcherOptions } from './cli-builder';
+export type { Cli, CommandOptions, DispatcherOptions, RunRoutineOptions } from './cli-builder';
+export { runRoutine } from './run-routine';
+export type { StandaloneRunRoutineOptions } from './run-routine';
+export type { RoutineResult, RoutineResultStep } from './routine/executor';
 export type {
     CliOptions,
     CliContext,

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -16,8 +16,19 @@ import { buildRoutineResolvers } from './plugin-resolvers';
 import type { CommandDispatcher, CustomResolver } from '../types';
 import type { PluginRegistry } from '../plugin/registry';
 
+export interface RoutineResultStep {
+    name: string;
+    status: 'ok' | 'failed' | 'skipped';
+    output?: unknown;
+    error?: string;
+}
+
 export interface RoutineResult {
+    status: 'ok' | 'failed';
     success: boolean;
+    output: Record<string, unknown>;
+    steps: RoutineResultStep[];
+    durationMs: number;
     stepsRun: number;
     stepsSkipped: number;
     stepsFailed: number;
@@ -53,6 +64,7 @@ class RoutineExecutor {
         routine: RoutineDefinition,
         overrides: Record<string, unknown>,
     ): Promise<RoutineResult> {
+        const startTime = Date.now();
         const builtins: Record<string, unknown> = {
             _timestamp: Math.floor(Date.now() / 1000),
             _date: new Date().toISOString().slice(0, 10),
@@ -83,9 +95,14 @@ class RoutineExecutor {
         };
 
         const ok = await this.runSteps(routine.steps, ctx);
+        const success = ok && this.stepsFailed === 0;
 
         return {
-            success: ok && this.stepsFailed === 0,
+            status: success ? 'ok' : 'failed',
+            success,
+            output: {},
+            steps: [],
+            durationMs: Date.now() - startTime,
             stepsRun: this.stepsRun,
             stepsSkipped: this.stepsSkipped,
             stepsFailed: this.stepsFailed,

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -231,7 +231,7 @@ class RoutineExecutor {
 
         this.inIteration = false;
 
-        if (this.options?.onIteration) process.stderr.write('\n');
+        if (this.options?.onIteration && !this.options.silent) process.stderr.write('\n');
 
         return true;
     }
@@ -252,13 +252,16 @@ class RoutineExecutor {
         );
 
         if (this.options?.dryRun) {
-            const argStr = Object.entries(resolvedArgs)
-                .map(([k, v]) => `${k} ${v}`)
-                .join(' ');
-            const posStr = resolvedPositional.join(' ');
-            console.log(
-                `[${this.stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim(),
-            );
+            if (!this.options.silent) {
+                const argStr = Object.entries(resolvedArgs)
+                    .map(([k, v]) => `${k} ${v}`)
+                    .join(' ');
+                const posStr = resolvedPositional.join(' ');
+                console.log(
+                    `[${this.stepsRun + 1}] ${step.name}: ${step.command} ${posStr} ${argStr}`.trim(),
+                );
+            }
+
             this.stepsRun++;
 
             return true;

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -55,6 +55,7 @@ class RoutineExecutor {
     private stepsFailed = 0;
     private inIteration = false;
     private steps: RoutineResultStep[] = [];
+    private namedOutput: Record<string, unknown> = {};
 
     constructor(
         private dispatch: CommandDispatcher,
@@ -101,7 +102,7 @@ class RoutineExecutor {
         return {
             status: success ? 'ok' : 'failed',
             success,
-            output: {},
+            output: this.namedOutput,
             steps: this.steps,
             durationMs: Date.now() - startTime,
             stepsRun: this.stepsRun,
@@ -277,6 +278,7 @@ class RoutineExecutor {
 
             this.stepsRun++;
             this.steps.push({ name: step.name, status: 'ok', output: result });
+            if (step.output) this.namedOutput[step.output] = result;
 
             if (step.assert) {
                 const passed = evaluateCondition(step.assert, ctx);

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -37,6 +37,7 @@ export interface RoutineResult {
 
 interface ExecutorOptions {
     dryRun?: boolean;
+    silent?: boolean;
     customResolvers?: Map<string, CustomResolver>;
     pluginRegistry?: PluginRegistry;
     onStep?: (step: RoutineStep, index: number, total: number) => void;
@@ -175,9 +176,12 @@ class RoutineExecutor {
         const rawItems = resolveValue(step.forEach!, ctx);
 
         if (!Array.isArray(rawItems)) {
-            process.stderr.write(
-                `Warning: forEach on "${step.name}" did not resolve to an array\n`,
-            );
+            if (!this.options?.silent) {
+                process.stderr.write(
+                    `Warning: forEach on "${step.name}" did not resolve to an array\n`,
+                );
+            }
+
             this.stepsSkipped++;
 
             return true;
@@ -278,13 +282,17 @@ class RoutineExecutor {
 
             this.stepsRun++;
             this.steps.push({ name: step.name, status: 'ok', output: result });
+
             if (step.output) this.namedOutput[step.output] = result;
 
             if (step.assert) {
                 const passed = evaluateCondition(step.assert, ctx);
 
                 if (!passed) {
-                    console.error(`Assert failed on "${step.name}": ${step.assert}`);
+                    if (!this.options?.silent) {
+                        console.error(`Assert failed on "${step.name}": ${step.assert}`);
+                    }
+
                     stepResult.success = false;
                     stepResult.error = `Assertion failed: ${step.assert}`;
                     this.stepsFailed++;
@@ -322,7 +330,11 @@ class RoutineExecutor {
 
             this.stepsFailed++;
             this.stepsRun++;
-            console.error(`Step "${step.name}" failed: ${errMsg}`);
+
+            if (!this.options?.silent) {
+                console.error(`Step "${step.name}" failed: ${errMsg}`);
+            }
+
             this.steps.push({ name: step.name, status: 'failed', error: errMsg });
 
             if (!step.continueOnError) return false;

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -54,6 +54,7 @@ class RoutineExecutor {
     private stepsSkipped = 0;
     private stepsFailed = 0;
     private inIteration = false;
+    private steps: RoutineResultStep[] = [];
 
     constructor(
         private dispatch: CommandDispatcher,
@@ -101,7 +102,7 @@ class RoutineExecutor {
             status: success ? 'ok' : 'failed',
             success,
             output: {},
-            steps: [],
+            steps: this.steps,
             durationMs: Date.now() - startTime,
             stepsRun: this.stepsRun,
             stepsSkipped: this.stepsSkipped,
@@ -118,6 +119,7 @@ class RoutineExecutor {
 
             if (!evaluateCondition(step.condition, ctx)) {
                 this.stepsSkipped++;
+                this.steps.push({ name: step.name, status: 'skipped' });
 
                 if (this.options?.onStep && !this.inIteration)
                     this.options.onStep(step, i, steps.length);
@@ -274,6 +276,7 @@ class RoutineExecutor {
             if (step.output) ctx.stepOutputs.set(step.output, stepResult);
 
             this.stepsRun++;
+            this.steps.push({ name: step.name, status: 'ok', output: result });
 
             if (step.assert) {
                 const passed = evaluateCondition(step.assert, ctx);
@@ -283,6 +286,12 @@ class RoutineExecutor {
                     stepResult.success = false;
                     stepResult.error = `Assertion failed: ${step.assert}`;
                     this.stepsFailed++;
+                    // overwrite the previously-pushed 'ok' with the failed entry
+                    this.steps[this.steps.length - 1] = {
+                        name: step.name,
+                        status: 'failed',
+                        error: stepResult.error,
+                    };
 
                     if (!step.continueOnError) return false;
                 }
@@ -312,6 +321,7 @@ class RoutineExecutor {
             this.stepsFailed++;
             this.stepsRun++;
             console.error(`Step "${step.name}" failed: ${errMsg}`);
+            this.steps.push({ name: step.name, status: 'failed', error: errMsg });
 
             if (!step.continueOnError) return false;
         }

--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -303,6 +303,8 @@ class RoutineExecutor {
                         error: stepResult.error,
                     };
 
+                    if (step.output) delete this.namedOutput[step.output];
+
                     if (!step.continueOnError) return false;
                 }
             }

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -73,13 +73,18 @@ export async function runRoutine(
     const globalDir = join(effectiveHome, `.${cliName}`);
     let generatedDir: string;
 
+    // Cache the active env once — three call sites consumed it before, each re-reading config.json.
+    // NOTE: opts.env (per spec) for selecting a specific named env is intentionally not yet wired —
+    // would require plumbing through createCli/resolveAuth. Tracked as future work; consumers can
+    // pre-switch via `apijack config switch <env>` for now.
+    const envConfig = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
+
     if (projectConfig?.generatedDir && projectRoot) {
         generatedDir = resolve(projectRoot, projectConfig.generatedDir);
     } else if (projectRoot) {
         generatedDir = resolve(projectRoot, '.apijack', 'generated');
     } else {
-        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
-        const hostname = env?.url ? new URL(env.url).hostname : 'default';
+        const hostname = envConfig?.url ? new URL(envConfig.url).hostname : 'default';
 
         generatedDir = join(globalDir, 'apis', hostname, 'generated');
     }
@@ -111,30 +116,23 @@ export async function runRoutine(
         projectOnChallenge = projectAuth.onChallenge ?? null;
     }
 
-    if (!authResolved) {
-        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
+    if (!authResolved && envConfig) {
+        const authType = (envConfig as Record<string, unknown>).authType as string | undefined;
 
-        if (env) {
-            const authType = (env as Record<string, unknown>).authType as string | undefined;
+        if (authType === 'bearer') {
+            authStrategy = new BearerTokenStrategy(async config => config.password);
+        } else if (authType === 'apiKey') {
+            const headerName = (envConfig as Record<string, unknown>).authHeader as string ?? 'X-API-Key';
+            const apiKey = (envConfig as Record<string, unknown>).apiKey as string ?? '';
 
-            if (authType === 'bearer') {
-                authStrategy = new BearerTokenStrategy(async config => config.password);
-            } else if (authType === 'apiKey') {
-                const headerName = (env as Record<string, unknown>).authHeader as string ?? 'X-API-Key';
-                const apiKey = (env as Record<string, unknown>).apiKey as string ?? '';
-
-                authStrategy = new ApiKeyStrategy(headerName, apiKey);
-            }
+            authStrategy = new ApiKeyStrategy(headerName, apiKey);
         }
     }
 
     let sessionAuth: SessionAuthConfig | undefined;
-    {
-        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
 
-        if (env) {
-            sessionAuth = (env as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
-        }
+    if (envConfig) {
+        sessionAuth = (envConfig as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
 
         if (sessionAuth && projectOnChallenge) {
             sessionAuth.onChallenge = projectOnChallenge;

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -1,0 +1,186 @@
+import { resolve, join, dirname } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { createCli, type RunRoutineOptions } from './cli-builder';
+import type { RoutineResult } from './routine/executor';
+import type { AuthStrategy, SessionAuthConfig } from './auth/types';
+import { BasicAuthStrategy } from './auth/basic';
+import { BearerTokenStrategy } from './auth/bearer';
+import { ApiKeyStrategy } from './auth/api-key';
+import { findProjectConfig, loadProjectConfig } from './project';
+import {
+    loadProjectAuth,
+    loadProjectCommands,
+    loadProjectDispatchers,
+    loadProjectPlugins,
+    loadProjectResolvers,
+} from './project-loader';
+import { loadProjectSettings } from './settings';
+import { getActiveEnvConfig } from './config';
+
+export interface StandaloneRunRoutineOptions extends RunRoutineOptions {
+    cwd?: string;
+    cliName?: string;
+}
+
+export async function runRoutine(
+    name: string,
+    opts: StandaloneRunRoutineOptions = {},
+): Promise<RoutineResult> {
+    const cwd = opts.cwd ?? process.cwd();
+    const cliName = opts.cliName ?? 'apijack';
+
+    const projectConfigPath = findProjectConfig(cwd);
+    const projectConfig = projectConfigPath ? loadProjectConfig(projectConfigPath) : null;
+    const projectRoot = projectConfigPath ? dirname(projectConfigPath) : null;
+
+    // Use process.env.HOME (if set) so tests can override the home dir without relying on
+    // homedir(), which caches the OS value and ignores runtime HOME changes.
+    const effectiveHome = process.env.HOME ?? homedir();
+    const configDir = projectRoot
+        ? join(projectRoot, '.apijack')
+        : join(effectiveHome, `.${cliName}`);
+
+    // Auto-load project .env so $_env(...) sees it.
+    if (projectRoot) {
+        const envPath = join(projectRoot, '.env');
+
+        if (existsSync(envPath)) {
+            for (const line of readFileSync(envPath, 'utf-8').split(/\r?\n/)) {
+                const trimmed = line.trim();
+
+                if (!trimmed || trimmed.startsWith('#')) continue;
+
+                const eq = trimmed.indexOf('=');
+
+                if (eq < 0) continue;
+
+                const key = trimmed.slice(0, eq).trim();
+                let val = trimmed.slice(eq + 1).trim();
+
+                if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+                    val = val.slice(1, -1);
+                }
+
+                if (!(key in process.env)) {
+                    process.env[key] = val;
+                }
+            }
+        }
+    }
+
+    // Resolve generated dir.
+    const globalDir = join(effectiveHome, `.${cliName}`);
+    let generatedDir: string;
+
+    if (projectConfig?.generatedDir && projectRoot) {
+        generatedDir = resolve(projectRoot, projectConfig.generatedDir);
+    } else if (projectRoot) {
+        generatedDir = resolve(projectRoot, '.apijack', 'generated');
+    } else {
+        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
+        const hostname = env?.url ? new URL(env.url).hostname : 'default';
+
+        generatedDir = join(globalDir, 'apis', hostname, 'generated');
+    }
+
+    // Resolve spec path.
+    let specPath = '/v3/api-docs';
+
+    if (projectConfig?.specUrl) {
+        try {
+            specPath = new URL(projectConfig.specUrl).pathname;
+        } catch {
+            specPath = projectConfig.specUrl;
+        }
+    }
+
+    // Resolve auth strategy: project auth.ts > config authType > default basic.
+    let authStrategy: AuthStrategy = new BasicAuthStrategy();
+    let authResolved = false;
+    let projectOnChallenge: SessionAuthConfig['onChallenge'] | null = null;
+
+    if (projectRoot) {
+        const projectAuth = await loadProjectAuth(join(projectRoot, '.apijack'));
+
+        if (projectAuth.strategy) {
+            authStrategy = projectAuth.strategy;
+            authResolved = true;
+        }
+
+        projectOnChallenge = projectAuth.onChallenge ?? null;
+    }
+
+    if (!authResolved) {
+        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
+
+        if (env) {
+            const authType = (env as Record<string, unknown>).authType as string | undefined;
+
+            if (authType === 'bearer') {
+                authStrategy = new BearerTokenStrategy(async config => config.password);
+            } else if (authType === 'apiKey') {
+                const headerName = (env as Record<string, unknown>).authHeader as string ?? 'X-API-Key';
+                const apiKey = (env as Record<string, unknown>).apiKey as string ?? '';
+
+                authStrategy = new ApiKeyStrategy(headerName, apiKey);
+            }
+        }
+    }
+
+    let sessionAuth: SessionAuthConfig | undefined;
+    {
+        const env = getActiveEnvConfig(cliName, { configPath: join(configDir, 'config.json') });
+
+        if (env) {
+            sessionAuth = (env as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
+        }
+
+        if (sessionAuth && projectOnChallenge) {
+            sessionAuth.onChallenge = projectOnChallenge;
+        }
+    }
+
+    const projectSettings = projectRoot ? loadProjectSettings(join(projectRoot, '.apijack')) : {};
+
+    const cli = createCli({
+        name: cliName,
+        description: 'apijack',
+        version: '0.0.0', // not relevant in programmatic mode
+        specPath,
+        auth: authStrategy,
+        sessionAuth,
+        generatedDir,
+        allowedCidrs: projectConfig?.allowedCidrs,
+        configPath: join(configDir, 'config.json'),
+        customCommandDefaults: projectSettings.customCommands?.defaults,
+    });
+
+    if (projectRoot) {
+        const plugins = await loadProjectPlugins(join(projectRoot, '.apijack'));
+
+        for (const plugin of plugins) {
+            cli.use(plugin);
+        }
+
+        const commands = await loadProjectCommands(join(projectRoot, '.apijack'));
+
+        for (const cmd of commands) {
+            cli.command(cmd.name, cmd.registrar, { requiresAuth: cmd.requiresAuth });
+        }
+
+        const dispatchers = await loadProjectDispatchers(join(projectRoot, '.apijack'));
+
+        for (const disp of dispatchers) {
+            cli.dispatcher(disp.name, disp.handler, { requiresAuth: disp.requiresAuth });
+        }
+
+        const resolvers = await loadProjectResolvers(join(projectRoot, '.apijack'));
+
+        for (const [resName, fn] of resolvers) {
+            cli.resolver(resName, fn);
+        }
+    }
+
+    return cli.runRoutine(name, { vars: opts.vars, dryRun: opts.dryRun });
+}

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -28,6 +28,9 @@ export async function runRoutine(
     opts: StandaloneRunRoutineOptions = {},
 ): Promise<RoutineResult> {
     const cwd = opts.cwd ?? process.cwd();
+    // The spec describes a `settings.json` lookup for cliName, but `ProjectSettings`
+    // has no `cliName` field — defaulting to 'apijack' (the shared binary name)
+    // is the right behavior for the standalone helper's target use case.
     const cliName = opts.cliName ?? 'apijack';
 
     const projectConfigPath = findProjectConfig(cwd);

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -652,3 +652,69 @@ describe('cli.run() plugin validation', () => {
         expect(stderrOut).toContain('_other');
     });
 });
+
+describe('cli.runRoutine', () => {
+    let tmpHome: string;
+    let configPath: string;
+    let cli: Cli;
+    let originalHome: string | undefined;
+
+    beforeEach(() => {
+        tmpHome = join(tmpdir(), `runRoutine-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+        const cliConfigDir = join(tmpHome, '.testcli');
+        mkdirSync(join(cliConfigDir, 'routines'), { recursive: true });
+        configPath = join(cliConfigDir, 'config.json');
+        // Minimal env config so resolveAuth() returns something.
+        writeFileSync(configPath, JSON.stringify({
+            active: 'default',
+            environments: {
+                default: { url: 'http://localhost:9999', user: 'u', password: 'p' },
+            },
+        }));
+        // Write a minimal routine YAML.
+        writeFileSync(join(cliConfigDir, 'routines', 'echo.yaml'),
+            `name: echo
+steps:
+  - name: ping
+    command: my-dispatch
+    args:
+      msg: hello
+    output: result
+`);
+
+        originalHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+
+        cli = createCli({ ...makeOptions(), configPath });
+        cli.dispatcher('my-dispatch', async args => ({ echoed: args.msg }));
+    });
+
+    afterEach(() => {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+
+        rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    test('returns full RoutineResult shape on success', async () => {
+        const result = await cli.runRoutine('echo');
+
+        expect(result.status).toBe('ok');
+        expect(result.success).toBe(true);
+        expect(result.output).toEqual({ result: { echoed: 'hello' } });
+        expect(result.steps).toHaveLength(1);
+        expect(result.steps[0]!).toMatchObject({ name: 'ping', status: 'ok' });
+        expect(typeof result.durationMs).toBe('number');
+    });
+
+    test('throws on missing routine', async () => {
+        await expect(cli.runRoutine('does-not-exist')).rejects.toThrow();
+    });
+
+    test('is idempotent across repeated calls (no double-bootstrap)', async () => {
+        const a = await cli.runRoutine('echo');
+        const b = await cli.runRoutine('echo');
+        expect(a.status).toBe('ok');
+        expect(b.status).toBe('ok');
+    });
+});

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -529,6 +529,26 @@ describe('executeRoutine', () => {
         expect(result.output).not.toHaveProperty('second');
     });
 
+    test('assertion failure removes the alias from output', async () => {
+        const routine = makeRoutine({
+            variables: { expected: 'wrong' },
+            steps: [
+                {
+                    name: 'create',
+                    command: 'cmd-a',
+                    output: 'created',
+                    assert: '$created.name == $expected',
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher({ 'cmd-a': { name: 'actual' } });
+        const result = await executeRoutine(routine, {}, dispatcher, { silent: true });
+
+        expect(result.status).toBe('failed');
+        expect(result.steps[0]!).toMatchObject({ name: 'create', status: 'failed' });
+        expect(result.output).not.toHaveProperty('created');
+    });
+
     test('silent: true suppresses stderr and console.error writes from executor', async () => {
         const routine = makeRoutine({
             steps: [

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -446,6 +446,45 @@ describe('executeRoutine', () => {
         expect(label).toMatch(/^run-\d+$/);
     });
 
+    test('steps[] contains an entry per executed step with correct status', async () => {
+        const routine = makeRoutine({
+            variables: { gate: false },
+            steps: [
+                { name: 'a', command: 'cmd-a' },
+                { name: 'b', command: 'cmd-b', condition: '$gate' },
+                { name: 'c', command: 'cmd-c' },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.steps.length).toBe(3);
+        expect(result.steps[0]!).toMatchObject({ name: 'a', status: 'ok' });
+        expect(result.steps[1]!).toMatchObject({ name: 'b', status: 'skipped' });
+        expect(result.steps[2]!).toMatchObject({ name: 'c', status: 'ok' });
+    });
+
+    test('steps[] records failed step and stops on first failure (no continueOnError)', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'first', command: 'ok' },
+                { name: 'broken', command: 'boom' },
+                { name: 'never', command: 'ok' },
+            ],
+        });
+        const dispatcher: CommandDispatcher = async (command) => {
+            if (command === 'boom') throw new Error('kaboom');
+            return { ok: true };
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.status).toBe('failed');
+        expect(result.success).toBe(false);
+        expect(result.steps.length).toBe(2);
+        expect(result.steps[0]!).toMatchObject({ name: 'first', status: 'ok' });
+        expect(result.steps[1]!).toMatchObject({ name: 'broken', status: 'failed', error: 'kaboom' });
+    });
+
     test('result includes status, output, steps, and durationMs fields', async () => {
         const routine = makeRoutine({
             steps: [

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -445,6 +445,23 @@ describe('executeRoutine', () => {
         const label = dispatched[0]!.label as string;
         expect(label).toMatch(/^run-\d+$/);
     });
+
+    test('result includes status, output, steps, and durationMs fields', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'step-1', command: 'cmd-a' },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.status).toBe('ok');
+        expect(result.success).toBe(true);
+        expect(typeof result.durationMs).toBe('number');
+        expect(result.durationMs).toBeGreaterThanOrEqual(0);
+        expect(result.output).toEqual({});
+        expect(Array.isArray(result.steps)).toBe(true);
+    });
 });
 
 describe('executeRoutine with plugin registry', () => {

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -485,6 +485,46 @@ describe('executeRoutine', () => {
         expect(result.steps[1]!).toMatchObject({ name: 'broken', status: 'failed', error: 'kaboom' });
     });
 
+    test('output aggregates results from steps with output: alias', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'create-user', command: 'users.create', output: 'user' },
+                { name: 'create-token', command: 'tokens.create', output: 'token' },
+                { name: 'no-alias', command: 'misc.ping' },
+            ],
+        });
+        const dispatcher: CommandDispatcher = async (command) => {
+            if (command === 'users.create') return { id: 'u-1', name: 'Ada' };
+            if (command === 'tokens.create') return { id: 't-1', secret: 'shh' };
+            return { ok: true };
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.output).toEqual({
+            user: { id: 'u-1', name: 'Ada' },
+            token: { id: 't-1', secret: 'shh' },
+        });
+        // step without output: alias is in steps[] but not in output
+        expect(Object.keys(result.output).sort()).toEqual(['token', 'user']);
+    });
+
+    test('failed step does not populate output[alias]', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'ok-step', command: 'ok', output: 'first' },
+                { name: 'fail-step', command: 'fail', output: 'second' },
+            ],
+        });
+        const dispatcher: CommandDispatcher = async (command) => {
+            if (command === 'fail') throw new Error('nope');
+            return { ok: true };
+        };
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.output).toEqual({ first: { ok: true } });
+        expect(result.output).not.toHaveProperty('second');
+    });
+
     test('result includes status, output, steps, and durationMs fields', async () => {
         const routine = makeRoutine({
             steps: [

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -474,6 +474,7 @@ describe('executeRoutine', () => {
         });
         const dispatcher: CommandDispatcher = async (command) => {
             if (command === 'boom') throw new Error('kaboom');
+
             return { ok: true };
         };
         const result = await executeRoutine(routine, {}, dispatcher);
@@ -495,7 +496,9 @@ describe('executeRoutine', () => {
         });
         const dispatcher: CommandDispatcher = async (command) => {
             if (command === 'users.create') return { id: 'u-1', name: 'Ada' };
+
             if (command === 'tokens.create') return { id: 't-1', secret: 'shh' };
+
             return { ok: true };
         };
         const result = await executeRoutine(routine, {}, dispatcher);
@@ -517,12 +520,67 @@ describe('executeRoutine', () => {
         });
         const dispatcher: CommandDispatcher = async (command) => {
             if (command === 'fail') throw new Error('nope');
+
             return { ok: true };
         };
         const result = await executeRoutine(routine, {}, dispatcher);
 
         expect(result.output).toEqual({ first: { ok: true } });
         expect(result.output).not.toHaveProperty('second');
+    });
+
+    test('silent: true suppresses stderr and console.error writes from executor', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'broken', command: 'fail' },
+            ],
+        });
+        const dispatcher: CommandDispatcher = async () => {
+            throw new Error('boom');
+        };
+
+        const captured: string[] = [];
+        const origConsoleError = console.error;
+        const origStderrWrite = process.stderr.write.bind(process.stderr);
+        console.error = (...args: unknown[]) => {
+            captured.push(args.join(' '));
+        };
+        process.stderr.write = ((chunk: any) => {
+            captured.push(typeof chunk === 'string' ? chunk : chunk.toString());
+
+            return true;
+        }) as typeof process.stderr.write;
+
+        try {
+            const result = await executeRoutine(routine, {}, dispatcher, { silent: true });
+            expect(result.status).toBe('failed');
+            expect(captured.join('')).toBe('');
+        } finally {
+            console.error = origConsoleError;
+            process.stderr.write = origStderrWrite;
+        }
+    });
+
+    test('silent: false (default) writes step failure to stderr/console.error', async () => {
+        const routine = makeRoutine({
+            steps: [{ name: 'broken', command: 'fail' }],
+        });
+        const dispatcher: CommandDispatcher = async () => {
+            throw new Error('boom');
+        };
+
+        const captured: string[] = [];
+        const origConsoleError = console.error;
+        console.error = (...args: unknown[]) => {
+            captured.push(args.join(' '));
+        };
+
+        try {
+            await executeRoutine(routine, {}, dispatcher);
+            expect(captured.join('\n')).toContain('boom');
+        } finally {
+            console.error = origConsoleError;
+        }
     });
 
     test('result includes status, output, steps, and durationMs fields', async () => {

--- a/tests/run-routine.test.ts
+++ b/tests/run-routine.test.ts
@@ -79,3 +79,63 @@ export default async (args) => ({ echoed: args.msg });
         expect(result.status).toBe('ok');
     });
 });
+
+describe('runRoutine (standalone, no project marker — global config path)', () => {
+    let tmpHome: string;
+    let cwdDir: string;
+    let originalHome: string | undefined;
+    let originalCwd: string;
+
+    beforeEach(() => {
+        const id = `run-routine-global-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        tmpHome = join(tmpdir(), `${id}-home`);
+        cwdDir = join(tmpdir(), `${id}-cwd`);
+        mkdirSync(cwdDir, { recursive: true });
+        // No .apijack.json marker — exercises the `else` branch in run-routine.ts where
+        // configDir = ${HOME}/.<cliName>/.
+        mkdirSync(join(tmpHome, '.apijack', 'routines'), { recursive: true });
+        writeFileSync(join(tmpHome, '.apijack', 'config.json'), JSON.stringify({
+            active: 'default',
+            environments: {
+                default: { url: 'http://localhost:9999', user: 'u', password: 'p' },
+            },
+        }));
+        writeFileSync(join(tmpHome, '.apijack', 'routines', 'echo.yaml'),
+            `name: echo
+variables:
+  msg: "global-hello"
+steps:
+  - name: noop
+    command: noop-dispatch
+    args:
+      msg: "$msg"
+    output: ping
+`);
+
+        // Without a project marker, project-loader doesn't load dispatchers, so we register
+        // a no-op consumer dispatcher would normally not be available. Instead, the routine
+        // engine's "command not found" path will throw — which is what we exercise.
+        originalHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+        originalCwd = process.cwd();
+        process.chdir(cwdDir);
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+
+        rmSync(tmpHome, { recursive: true, force: true });
+        rmSync(cwdDir, { recursive: true, force: true });
+    });
+
+    test('finds routine in $HOME/.apijack/routines/ when no project marker is present', async () => {
+        const result = await runRoutine('echo');
+        // The routine itself fails (no dispatcher for `noop-dispatch`), but the bootstrap
+        // succeeded — the routine was located in the global config dir, not project-local.
+        expect(result.status).toBe('failed');
+        expect(result.steps[0]!).toMatchObject({ name: 'noop', status: 'failed' });
+    });
+});

--- a/tests/run-routine.test.ts
+++ b/tests/run-routine.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runRoutine } from '../src/run-routine';
+
+describe('runRoutine (standalone)', () => {
+    let tmpHome: string;
+    let projectDir: string;
+    let originalHome: string | undefined;
+    let originalCwd: string;
+
+    beforeEach(() => {
+        const id = `run-routine-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        tmpHome = join(tmpdir(), `${id}-home`);
+        projectDir = join(tmpdir(), `${id}-project`);
+        mkdirSync(projectDir, { recursive: true });
+        mkdirSync(join(tmpHome, '.apijack', 'routines'), { recursive: true });
+
+        // Project marker so findProjectConfig() returns a result and dispatchers are loaded.
+        writeFileSync(join(projectDir, '.apijack.json'), JSON.stringify({}));
+
+        // Project-local env config (when a .apijack.json is present, configDir = projectDir/.apijack/).
+        mkdirSync(join(projectDir, '.apijack', 'routines'), { recursive: true });
+        writeFileSync(join(projectDir, '.apijack', 'config.json'), JSON.stringify({
+            active: 'default',
+            environments: {
+                default: { url: 'http://localhost:9999', user: 'u', password: 'p' },
+            },
+        }));
+
+        // Routine that uses a project-defined dispatcher (so we don't need a real API).
+        writeFileSync(join(projectDir, '.apijack', 'routines', 'echo.yaml'),
+            `name: echo
+steps:
+  - name: call-echo
+    command: echo-dispatch
+    args:
+      msg: hi
+    output: ping
+`);
+
+        // .apijack/dispatchers/echo-dispatch.ts in the project dir
+        mkdirSync(join(projectDir, '.apijack', 'dispatchers'), { recursive: true });
+        writeFileSync(join(projectDir, '.apijack', 'dispatchers', 'echo-dispatch.ts'),
+            `export const name = 'echo-dispatch';
+export default async (args) => ({ echoed: args.msg });
+`);
+
+        originalHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+        originalCwd = process.cwd();
+        process.chdir(projectDir);
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+
+        rmSync(tmpHome, { recursive: true, force: true });
+        rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    test('runs routine end-to-end via project dispatcher', async () => {
+        const result = await runRoutine('echo');
+        expect(result.status).toBe('ok');
+        expect(result.output).toEqual({ ping: { echoed: 'hi' } });
+    });
+
+    test('throws when no active env config exists', async () => {
+        rmSync(join(projectDir, '.apijack', 'config.json'));
+        await expect(runRoutine('echo')).rejects.toThrow(/active env|setup/i);
+    });
+
+    test('respects explicit cwd option', async () => {
+        const result = await runRoutine('echo', { cwd: projectDir });
+        expect(result.status).toBe('ok');
+    });
+});


### PR DESCRIPTION
Closes #84

## Summary

Adds a programmatic `runRoutine()` API and `apijack routine run <name> --json` mode so consumers (Playwright fixtures, Vitest setups, Bun scripts) can invoke routines as data, not just as CLI side-effects. Two surfaces, one engine, one bootstrap path: `cli.runRoutine(...)` for projects with a `bin/<cli>.ts`, and standalone `runRoutine(...)` for projects on the shared `apijack` binary.

## What changes

### Engine (`src/routine/executor.ts`)

`RoutineResult` is extended with `status: 'ok' | 'failed'`, `output: Record<string, unknown>` (named outputs from `output:` aliases), `steps: RoutineResultStep[]` (per-step entries with status), and `durationMs`. `success`/`stepsRun`/`stepsSkipped`/`stepsFailed` are preserved for back-compat. New `ExecutorOptions.silent` gates the executor's stderr/console writes (default `false` keeps existing CLI behavior identical). Failed dispatches and assertion failures correctly do **not** populate `output[alias]`.

### Programmatic API (`src/cli-builder.ts`, `src/run-routine.ts`)

- `cli.runRoutine(name, opts?)` — method on the `Cli` returned by `createCli`. Calls a new private idempotent `_buildRoutineRuntime()` that resolves auth, builds the dispatcher, and caches the result.
- `runRoutine(name, opts?)` — top-level export from `@apijack/core`. Mirrors `bin/apijack.ts`'s bootstrap (env loading, project extension wiring, auth strategy resolution) and delegates.
- Failure semantics: programmatic resolves with `{ status: 'failed', steps, output: <partial> }` on step failure; throws only on engine errors (routine not found, validation errors, no active env config).

### CLI (`src/commands/routine/register.ts`, `run/run.ts`)

`apijack routine run <name> --json` emits `JSON.stringify(result)` to stdout, exits non-zero on failure, suppresses progress output. Default mode is unchanged. Synthesized failure shapes are typed as `RoutineResult` so future drift is caught at compile time.

### Public surface (`src/index.ts`)

Adds `runRoutine`, `RoutineResult`, `RoutineResultStep`, `RunRoutineOptions`, `StandaloneRunRoutineOptions`.

### Docs (`CLAUDE.md`)

New "Programmatic Routine Invocation" section + `--json` line in the Routine Commands list.

## Acceptance criteria

- [x] `import { runRoutine } from "@apijack/core"` works in Bun + TypeScript
- [x] `apijack routine run <name> --json` emits parseable JSON to stdout, exit code matches `status`
- [x] Both surfaces share one engine (`executeRoutine` via `cli.runRoutine`)
- [x] Failure semantics: programmatic resolves with `failed`; CLI exits non-zero
- [x] No breaking changes — `RoutineResult` extension is additive; `routine run` default mode unchanged
- [x] E2E test invokes routine programmatically (`tests/run-routine.test.ts` — 4 tests covering project-marker and global-config paths through the full createCli + dispatcher chain)

## Test plan

- [x] `bun test` — 857 pass, 0 fail (was 841 before this branch, +16 new tests)
- [x] `bun run lint` — 0 errors (108 pre-existing warnings, none introduced)
- [x] CLI smoke: `bun bin/apijack.ts routine run does-not-exist --json` emits `{"status":"failed","success":false,...,"error":"Routine not found: ..."}` and exits 1
- [x] Programmatic smoke: `bun -e "import('./src/index').then(m => console.log(typeof m.runRoutine))"` logs `function`

## Deferred / known limitations

- `StandaloneRunRoutineOptions.env?: string` (per spec) is not yet plumbed — it would need plumbing through `createCli`/`resolveAuth`. Documented in a code comment in `src/run-routine.ts`. Consumers can pre-select via `apijack config switch <env>`.
- The MCP `run-routine` tool (`src/mcp/tools/routines/run-routine/`) still shells out to the CLI; refactoring it to call the programmatic API directly is a follow-up.
