### PR TITLE
v1.11.1: forward-port Closes #N keywords into release PRs

### DIFF
--- a/.claude/skills/patch-deployer/SKILL.md
+++ b/.claude/skills/patch-deployer/SKILL.md
@@ -54,6 +54,14 @@ There must be **zero** entries in a "Features" or "Changed" bucket — the gate 
 
 For each fix commit, look up the PR number (`(#NN)` in the subject, or `gh pr list --state merged --search "<subject>"`).
 
+### 3a. Collect closing references
+
+```bash
+./scripts/collect-closes-refs.sh
+```
+
+Prints `Closes #N` lines for every issue closed by the issue PRs in this range. These MUST be placed at the top of the release PR body (step 4) — without them, GitHub will not auto-close the issues when dev → main merges, because the originating PRs landed on `dev` (a non-default branch). Empty output is fine if no tracked issues were resolved.
+
 ### 4. Draft the PR body
 
 Use the `Write` tool — never inline in a heredoc — to avoid backtick-escaping. Write to `.claude-jobs/release-bodies/dev-to-main.md`.
@@ -65,6 +73,10 @@ Use the `Write` tool — never inline in a heredoc — to avoid backtick-escapin
 #### Body template
 
 ```markdown
+Closes #N
+Closes #M
+...
+
 <1-sentence thesis describing the focus of the patch — usually "Bug fixes and internal cleanup since vX.Y.Z-1." or similar.>
 
 ## 🐛 Fixes

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -56,6 +56,16 @@ For each commit, look up the PR number (often `(#NN)` in the subject, or `gh pr 
 
 **Write for humans, not for git.** A bullet should answer "what does this do for the user?" not restate the commit subject.
 
+### Collect closing references
+
+```bash
+./scripts/collect-closes-refs.sh
+```
+
+Prints `Closes #N` lines for every issue referenced by the issue PRs merged in this range. These MUST go at the top of the release PR body (step 3) — without them, GitHub will not auto-close the issues when dev → main merges, because issue PRs merged into `dev` don't trigger closure on the non-default branch. Forward-porting the closing keywords into the release PR body is the only path that works.
+
+If the output is empty, no issues will be auto-closed by this release — that's fine for chore-only releases that didn't resolve any tracked issues.
+
 ## Step 3: Draft the PR title and body
 
 **Title format:** `v<NEW_VERSION>: <comma-separated highlights>`
@@ -77,6 +87,10 @@ The PR body is pasted verbatim into the GitHub release. Keep it skimmable.
 **Body structure** (omit sections that have no entries):
 
 ```markdown
+Closes #N
+Closes #M
+...
+
 <1–2 sentence thesis describing the release's focus.>
 
 ## ✨ Features

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,8 @@ bun.lockb
 .local
 .apijack/
 
-# Superpowers docs (plans & specs)
-docs/superpowers/
-docs/icons/
+# Local docs (plans, specs, audits — never shipped)
+docs/
 wiki/
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ wiki/
 
 # Review-body files staged for `gh pr review --body-file` — local-only
 .claude-jobs/review-bodies/
+.claude-jobs/release-bodies/
 
 # Operator-private threat-model docs (kept locally, never shipped)
 .claude-jobs/*.private.md

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.11.0",
+  "version": "1.11.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/scripts/collect-closes-refs.sh
+++ b/scripts/collect-closes-refs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# collect-closes-refs.sh
+#
+# Print deduped 'Closes #N' lines for every issue referenced by the issue PRs
+# merged in the current release range. Used by ship-release and patch-deployer
+# to forward-port closing keywords from per-issue PR bodies into the release PR
+# body — without these lines, GitHub never auto-closes the issues when the
+# release PR merges into main.
+#
+# Reads from /tmp/apijack-ship-commits.txt by default (the file produced by
+# gather-release-commits.sh), or from $1 if provided.
+#
+# Output: one 'Closes #N' line per unique issue, sorted ascending. Empty if
+# no closing references were found.
+
+set -euo pipefail
+
+COMMITS_FILE="${1:-/tmp/apijack-ship-commits.txt}"
+
+if [ ! -f "$COMMITS_FILE" ]; then
+    echo "Commits file not found: $COMMITS_FILE" >&2
+    exit 1
+fi
+
+# Extract every #NN reference from commit subjects. This catches both merge
+# commits ('Merge pull request #74 ...') and squash subjects ('chore: foo (#74)').
+# Issue numbers that show up will fail `gh pr view` and be skipped silently.
+PR_NUMS=$(grep -oE '#[0-9]+' "$COMMITS_FILE" | sed 's/#//' | sort -un)
+
+declare -A SEEN
+for pr in $PR_NUMS; do
+    BODY=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null) || continue
+    [ -z "$BODY" ] && continue
+    while IFS= read -r num; do
+        [ -z "$num" ] && continue
+        SEEN["$num"]=1
+    done < <(echo "$BODY" | grep -ioE '(Closes|Fixes|Resolves)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' || true)
+done
+
+for num in "${!SEEN[@]}"; do
+    echo "Closes #$num"
+done | sort -V

--- a/scripts/collect-closes-refs.sh
+++ b/scripts/collect-closes-refs.sh
@@ -25,7 +25,10 @@ fi
 # Extract every #NN reference from commit subjects. This catches both merge
 # commits ('Merge pull request #74 ...') and squash subjects ('chore: foo (#74)').
 # Issue numbers that show up will fail `gh pr view` and be skipped silently.
-PR_NUMS=$(grep -oE '#[0-9]+' "$COMMITS_FILE" | sed 's/#//' | sort -un)
+# `|| true` on the pipeline: grep exits 1 when nothing matches, which would
+# abort the script under `set -eo pipefail` — but a chore-only release with
+# no referenced PRs is a legitimate empty-output case, not a failure.
+PR_NUMS=$(grep -oE '#[0-9]+' "$COMMITS_FILE" | sed 's/#//' | sort -un || true)
 
 declare -A SEEN
 for pr in $PR_NUMS; do


### PR DESCRIPTION
Internal release-tooling cleanup since v1.11.0 — the `ship-release` / `patch-deployer` skills now forward-port `Closes #N` keywords from issue PRs into the release PR body so GitHub auto-closes those issues when dev → main merges.

## 🧹 Internal

- New `scripts/collect-closes-refs.sh` walks each PR in the release range, scrapes `Closes/Fixes/Resolves #N` from their bodies, and emits deduped `Closes #N` lines for the release PR template (#81, #82). Both release skills consume it. Empty output is fine for chore-only releases.

---

Shipped via `scripts/ship.sh`.
