### PR TITLE
chore: label release PRs and skip them in auto-labeler

### DIFF
--- a/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
+++ b/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
@@ -20,10 +20,16 @@ existing=$(gh pr list --repo "$repo" --head dev --base main --state open --json 
 
 if [ -n "$existing" ]; then
     gh pr edit "$existing" --repo "$repo" --title "$title" --body-file "$body_file" >/dev/null
-    echo "$existing"
+    pr="$existing"
 else
     git push -u origin dev
     url=$(gh pr create --repo "$repo" --base main --head dev \
         --title "$title" --body-file "$body_file")
-    echo "${url##*/}"
+    pr="${url##*/}"
 fi
+
+# Add `release` label via the REST API. `gh pr edit --add-label` is currently
+# broken by the projects-classic deprecation (exits 1 with a GraphQL warning).
+gh api -X POST "repos/$repo/issues/$pr/labels" -f 'labels[]=release' >/dev/null
+
+echo "$pr"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -20,7 +20,7 @@ jobs:
         run: gh issue edit "$ISSUE_URL" --add-label "needs triage"
 
   label-new-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -153,6 +153,11 @@ fi
 
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
+# Apply `release` label idempotently. `gh pr edit --add-label` is currently
+# broken by the projects-classic deprecation (exits 1), so use the REST API.
+gh api -X POST "repos/normalled/apijack/issues/$PR_NUM/labels" \
+    -f 'labels[]=release' >/dev/null
+
 # ── Step 5: Wait for CI checks ─────────────────────────────────────
 
 info "Waiting for CI checks..."


### PR DESCRIPTION
## Summary

- Stamp the `release` label on every `dev → main` release PR so they're easy to filter and the GitHub release-notes pipeline can key off it.
- Skip the auto-labeler's `label-new-pr` job when the PR base is `main`, so release PRs no longer get the misleading `needs review` label (release PRs go through `final-review`, not the issue-PR review flow).

## What changes

- **`.claude/skills/patch-deployer/scripts/upsert-release-pr.sh`** — after find-or-create, POST to `repos/.../issues/<n>/labels` to add `release`. Idempotent. Uses the REST API because `gh pr edit --add-label` currently exits 1 due to the projects-classic deprecation upstream.
- **`scripts/ship.sh`** — same label-add right after `PR_NUM` is determined, so `ship.sh` stamps the label whether the PR was created by `upsert-release-pr.sh`, by `ship.sh`'s own fallback, or already existed.
- **`.github/workflows/auto-labeler.yml`** — `label-new-pr` job gains a `&& github.event.pull_request.base.ref != 'main'` condition. Issue-PR labeling is unchanged.

Both gh-using scripts already source `scripts/gh-pin-account.sh`, so the new `gh api` calls inherit the pinned `GH_TOKEN`.

## Acceptance criteria

- [x] Running `upsert-release-pr.sh` produces a PR with the `release` label (idempotent on re-run).
- [x] Running `ship.sh` stamps the `release` label whether or not `upsert-release-pr.sh` ran first.
- [x] A new PR opened with base `main` no longer triggers the `label-new-pr` job (workflow `if` short-circuits).
- [x] A new PR opened with base `dev` still gets `needs review` (issue-PR labeling unchanged).

## Test plan

- [x] `bash -n` passes on both shell files.
- [x] Verified `gh api -X POST repos/normalled/apijack/issues/87/labels -f 'labels[]=release'` returns the label JSON (PR #87 used as a sandbox; label is now present).
- [x] Verified `gh pr edit --add-label release` exits 1 today, justifying the API workaround.
