### PR TITLE
feat(cli): honor projectConfig display fields (#83)

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -138,10 +138,15 @@ const projectSettings = projectRoot
     : {};
 
 // 9. Create CLI
+//    `name` stays apijack so storage paths (~/.apijack/) and env-var prefix
+//    (APIJACK_*) are unaffected. `programName`, `description`, and `version`
+//    pull from .apijack.json when present so a delegating consumer brands its
+//    own --help / setup output.
 const cli = createCli({
     name: CLI_NAME,
-    description: 'Jack into any OpenAPI spec and rip a full-featured CLI',
-    version: VERSION,
+    programName: projectConfig?.name ?? CLI_NAME,
+    description: projectConfig?.description ?? 'Jack into any OpenAPI spec and rip a full-featured CLI',
+    version: projectConfig?.version ?? VERSION,
     specPath,
     auth: authStrategy,
     sessionAuth,

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -76,7 +76,7 @@ const CORE_COMMANDS = new Set([
 
 function showCustomHelp(
     program: Command,
-    cliName: string,
+    displayName: string,
     showAll: boolean,
     customCommandNames: Set<string>,
 ): void {
@@ -123,11 +123,11 @@ function showCustomHelp(
         }
     } else if (api.length > 0) {
         console.log(
-            `\n  ${api.length} API command groups available — run '${cliName} --help' to list all`,
+            `\n  ${api.length} API command groups available — run '${displayName} --help' to list all`,
         );
     }
 
-    console.log(`\nRun '${cliName} <command> --help' for details on any command.`);
+    console.log(`\nRun '${displayName} <command> --help' for details on any command.`);
 }
 
 export function createCli(options: CliOptions): Cli {
@@ -136,6 +136,7 @@ export function createCli(options: CliOptions): Cli {
     const consumerResolvers = new Map<string, CustomResolver>();
     const pluginRegistry = new PluginRegistry();
     const cliName = options.name;
+    const displayName = options.programName ?? options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
     const configDir = options.configPath
         ? resolve(options.configPath, '..')
@@ -188,7 +189,7 @@ export function createCli(options: CliOptions): Cli {
         const resolved = resolveAuth(cliName, configOpts);
 
         if (!resolved) {
-            throw new Error(`No active env config. Run '${cliName} setup' to configure credentials.`);
+            throw new Error(`No active env config. Run '${displayName} setup' to configure credentials.`);
         }
 
         // 3. Compute auth strategy + sessionMgr.
@@ -421,7 +422,7 @@ export function createCli(options: CliOptions): Cli {
 
             // 1. Build Commander program
             program
-                .name(cliName)
+                .name(displayName)
                 .description(options.description)
                 .version(options.version);
 
@@ -444,6 +445,7 @@ export function createCli(options: CliOptions): Cli {
             registerSetupCommand(program, cliName, {
                 allowedCidrs: options.allowedCidrs,
                 configPath: options.configPath,
+                displayName,
             });
             registerConfigCommand(program, cliName, {
                 configPath: options.configPath,
@@ -486,7 +488,7 @@ export function createCli(options: CliOptions): Cli {
                 && !skipAuthCommands.has(cmd)
                 && !isHelpOrVersion
             ) {
-                console.log(`${cliName} Setup\n`);
+                console.log(`${displayName} Setup\n`);
                 const envName = await prompt('Environment name [default]: ', 'default');
                 const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
                 const user = await prompt('Username/Email: ');
@@ -507,7 +509,7 @@ export function createCli(options: CliOptions): Cli {
                         console.log('Credentials verified.');
                     }
 
-                    console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+                    console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
                 } else {
                     console.error('Setup cancelled.');
@@ -574,7 +576,7 @@ export function createCli(options: CliOptions): Cli {
             // Shared session resolver — lazy, runs on first API request or explicit consumer call
             const resolveSession = async (): Promise<void> => {
                 if (!resolved || !sessionMgr) {
-                    throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                    throw new Error(`Not authenticated. Run '${displayName} setup' to configure credentials.`);
                 }
 
                 if (ctx && ctx.session) return;
@@ -600,7 +602,7 @@ export function createCli(options: CliOptions): Cli {
                     resolveSession,
                     saveSession: async () => {
                         if (!sessionMgr) {
-                            throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                            throw new Error(`Not authenticated. Run '${displayName} setup' to configure credentials.`);
                         }
 
                         if (ctx!.session) {
@@ -913,7 +915,7 @@ export function createCli(options: CliOptions): Cli {
                 const showAll
                     = userArgs[0] === '--help' || userArgs[0] === '-h';
                 const customCommandNames = new Set(consumerCommands.map(c => c.name));
-                showCustomHelp(program, cliName, showAll, customCommandNames);
+                showCustomHelp(program, displayName, showAll, customCommandNames);
                 process.exit(0);
             }
 

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -509,7 +509,7 @@ export function createCli(options: CliOptions): Cli {
                         console.log('Credentials verified.');
                     }
 
-                    console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
+                    console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
                 } else {
                     console.error('Setup cancelled.');

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -42,10 +42,13 @@ export function registerSetupCommand(
     opts?: {
         allowedCidrs?: string[];
         configPath?: string;
+        /** Display name for user-facing output. Defaults to cliName. */
+        displayName?: string;
     },
 ): void {
+    const displayName = opts?.displayName ?? cliName;
     const action = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
-        console.log(`${cliName} Setup\n`);
+        console.log(`${displayName} Setup\n`);
 
         const envName = await prompt('Environment name [default]: ', 'default');
         const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
@@ -81,7 +84,7 @@ export function registerSetupCommand(
             console.log('Credentials verified.');
         }
 
-        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+        console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
         console.log(`Switched to '${envName}'\n`);
     };
 

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -84,7 +84,7 @@ export function registerSetupCommand(
             console.log('Credentials verified.');
         }
 
-        console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
+        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
         console.log(`Switched to '${envName}'\n`);
     };
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -4,6 +4,8 @@ import { homedir } from 'os';
 
 export interface ProjectConfig {
     name?: string;
+    description?: string;
+    version?: string;
     specUrl?: string;
     generatedDir?: string;
     auth?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,14 @@ export interface AuthedCliContext extends CliContext {
 }
 
 export interface CliOptions {
+    /** Storage / session / env-var-prefix identity. Determines on-disk paths
+     *  (~/.<name>/), the env-var prefix (NAME_URL/NAME_USER/NAME_PASS), and
+     *  config namespacing. Should not change once a CLI ships. */
     name: string;
+    /** Display-only name used in --help, the setup banner, and "Run '<cli> setup'"
+     *  hints. Defaults to `name`. Lets a downstream CLI delegating to the shared
+     *  `apijack` binary brand its own user-facing output without altering storage. */
+    programName?: string;
     description: string;
     version: string;
     specPath: string;

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -334,6 +334,67 @@ describe('built-in commands', () => {
         expect(output).toContain('My custom CLI tool');
     });
 
+    test('without programName, help and hints show storage name (cliName)', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'apijack',
+                description: 'Default branding',
+            }),
+        );
+        cli.command('extra', (program) => {
+            program.command('extra').description('extra command');
+        });
+
+        // No --help flag triggers showCustomHelp's compact path that emits the
+        // "run '<cliName> --help'" hint.
+        process.argv = ['node', 'apijack'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('Usage: apijack');
+        expect(output).toContain("Run 'apijack <command> --help'");
+    });
+
+    test('programName overrides display name in help and hints, leaves cliName for storage', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'apijack',           // storage identity (unchanged)
+                programName: 'rrc',        // display-only branding
+                description: 'RRCloud CLI',
+            }),
+        );
+        cli.command('extra', (program) => {
+            program.command('extra').description('extra command');
+        });
+
+        process.argv = ['node', 'rrc'];
+
+        const output = await captureOutput(() => cli.run());
+
+        // Display strings show the override.
+        expect(output).toContain('Usage: rrc');
+        expect(output).toContain('RRCloud CLI');
+        expect(output).toContain("Run 'rrc <command> --help'");
+        // The bare "apijack" identity should NOT appear in user-facing branding.
+        expect(output).not.toMatch(/Usage: apijack/);
+        expect(output).not.toMatch(/Run 'apijack /);
+    });
+
+    test('programName defaults to name when omitted', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'foo',
+                description: 'Foo CLI',
+            }),
+        );
+
+        process.argv = ['node', 'foo', '--help'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('Usage: foo');
+    });
+
     test('--dry-run flag is registered', async () => {
         const cli = createCli(makeOptions());
 

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -81,6 +81,20 @@ describe('loadProjectConfig()', () => {
         expect(result!.auth).toBe('basic');
         expect(result!.allowedCidrs).toEqual(['192.168.1.0/24']);
     });
+
+    test('loads display branding fields (description, version)', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(join(testRoot, '.apijack.json'), JSON.stringify({
+            name: 'rrc',
+            description: 'RRCloud CLI',
+            version: '2.5.0',
+        }));
+
+        const result = loadProjectConfig(join(testRoot, '.apijack.json'));
+        expect(result!.name).toBe('rrc');
+        expect(result!.description).toBe('RRCloud CLI');
+        expect(result!.version).toBe('2.5.0');
+    });
 });
 
 describe('resolveConfigDir()', () => {


### PR DESCRIPTION
Closes #83

## Summary

When a downstream CLI delegates to `@apijack/core/bin/apijack.ts` via the `.apijack/` extension-dir pattern, the resulting binary previously branded itself as `apijack` in `--help`, the setup banner, and "Run '<cli> setup'" hints — even though the consumer set `name` in `.apijack.json`. This PR threads the consumer's branding through to user-facing display strings while keeping storage paths (`~/.apijack/`), the env-var prefix (`APIJACK_*`), and the global MCP routines dir anchored to apijack's identity.

The split (display name vs. storage identity) is intentional: a single substitution would silently relocate config and env-var lookups, which is a larger migration story tracked separately. Display branding is the high-value, low-risk slice.

## What changes

### `src/project.ts`

Extend `ProjectConfig` with two optional fields:

```ts
export interface ProjectConfig {
    name?: string;
    description?: string;   // NEW
    version?: string;       // NEW
    // ...existing fields
}
```

### `src/types.ts` — `CliOptions` gains `programName`

```ts
export interface CliOptions {
    /** Storage / session / env-var-prefix identity. Determines on-disk paths
     *  (~/.<name>/), the env-var prefix (NAME_URL/NAME_USER/NAME_PASS), and
     *  config namespacing. Should not change once a CLI ships. */
    name: string;
    /** Display-only name used in --help, the setup banner, and "Run '<cli> setup'"
     *  hints. Defaults to `name`. Lets a downstream CLI delegating to the shared
     *  `apijack` binary brand its own user-facing output without altering storage. */
    programName?: string;
    // ...existing fields
}
```

### `src/cli-builder.ts` — thread `displayName` through display sites

Resolves `const displayName = options.programName ?? options.name` once and uses it in:

- `program.name(displayName)`
- Custom help output (`Run '<cli> --help'` and `Run '<cli> <command> --help'` hints)
- The interactive setup banner and "Saved environment to ~/.{cli}/config.json" log
- "Not authenticated. Run '<cli> setup'…" errors (both fire sites)
- "No active env config. Run '<cli> setup'…" error in `cli.runRoutine` setup

`cliName` (the storage identity) remains in use for `SessionManager`, `resolveAuth`, `getActiveEnvConfig`, and the config/generate/mcp/routine/plugins command registrars — nothing about on-disk layout or env-var resolution changes.

### `src/commands/setup/setup.ts`

`registerSetupCommand` accepts an optional `displayName` and uses it for the setup banner + saved-env log. Defaults to `cliName` when omitted, preserving backward compatibility for existing consumers.

### `bin/apijack.ts` — wire project config through

```ts
const cli = createCli({
    name: CLI_NAME,                                                       // unchanged: storage stays under ~/.apijack/
    programName: projectConfig?.name ?? CLI_NAME,                         // NEW
    description: projectConfig?.description ?? 'Jack into any OpenAPI spec and rip a full-featured CLI',
    version: projectConfig?.version ?? VERSION,
    // ...
});
```

### Tests

- `tests/project.test.ts` — verifies `description` and `version` round-trip through `loadProjectConfig`.
- `tests/cli-builder.test.ts` — three new cases:
  - Without `programName`, help and hints show the storage `name` (current behavior, unchanged).
  - With `programName` set distinct from `name`, help and hints show the override; the storage `name` does NOT leak into user-facing strings.
  - `programName` defaults to `name` when omitted.

## Acceptance criteria

- [x] `.apijack.json` with `{ "name": "rrc", "description": "RRCloud CLI" }` causes `rrc --help` to show `Usage: rrc …` and "RRCloud CLI" — covered by the new `programName` test in `tests/cli-builder.test.ts`.
- [x] No change to `~/.apijack/` storage, `APIJACK_*` env-var prefix, or `~/.apijack/routines` for projects that don't set `name` / set `name: "apijack"` — `cliName` (storage identity) is unchanged in all storage-path call sites; only display strings consume `displayName`.
- [x] Existing CLIs that don't supply `programName` are unaffected — `displayName` defaults to `name`, verified by the "without programName" test.

## Test plan

- [x] `bun test` — 861 pass / 0 fail (was 857 before; +4 from new tests)
- [x] `bun run lint` — 0 errors (108 pre-existing warnings unchanged)
- [x] Manual trace: when `bin/apijack.ts` runs with no `.apijack.json`, `programName` is `'apijack'` (no behavior change). When `.apijack.json` declares `name: "rrc"`, `programName` becomes `"rrc"` and flows into Commander's `program.name()`, so `rrc --help` renders `Usage: rrc [options] [command]`. Storage paths stay at `~/.apijack/`.
