### PR TITLE
chore(triage): hygiene fixes from PR #49 review

### DIFF
--- a/.claude-jobs/_internal-authors.sh
+++ b/.claude-jobs/_internal-authors.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Single source of truth for the maintainer allowlist used by triage cron jobs.
+#
+# Sourced by:
+#   - .claude-jobs/triage-internal.yaml  (preflight + prompt_cmd)
+#   - .claude-jobs/triage-public.yaml    (preflight + prompt_cmd)
+#
+# Why a sourced snippet rather than per-block constants:
+#   The harness runs `preflight.run` and `claude.prompt_cmd` in separate shells
+#   with no shared environment. Duplicating the allowlist across both blocks
+#   (in two yamls) made drift between the gates likely as the list grows —
+#   silently changing which issues each gate accepts. Centralizing here keeps
+#   the four call sites in lockstep.
+#
+# Exports:
+#   INTERNAL_AUTHORS    — bash array of GitHub login names (used by triage-internal)
+#   INTERNAL_AUTHORS_RE — anchored regex alternation matching the same set
+#                         (used by triage-public's `jq test(...)` call)
+
+INTERNAL_AUTHORS=("garretpremo")
+
+# Build "^(a|b|c)$" from the array. Safe to regenerate on every source.
+INTERNAL_AUTHORS_RE="^($(IFS='|'; echo "${INTERNAL_AUTHORS[*]}"))$"
+
+export INTERNAL_AUTHORS INTERNAL_AUTHORS_RE

--- a/.claude-jobs/triage-internal.yaml
+++ b/.claude-jobs/triage-internal.yaml
@@ -25,7 +25,8 @@ auth: subscription
 preflight:
   run: |
     set -euo pipefail
-    INTERNAL_AUTHORS=("garretpremo")
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     found=""
     for author in "${INTERNAL_AUTHORS[@]}"; do
@@ -46,7 +47,8 @@ preflight:
 claude:
   prompt_cmd: |
     set -euo pipefail
-    INTERNAL_AUTHORS=("garretpremo")
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     for author in "${INTERNAL_AUTHORS[@]}"; do
       n=$(gh issue list --repo "$repo" \

--- a/.claude-jobs/triage-public.yaml
+++ b/.claude-jobs/triage-public.yaml
@@ -21,7 +21,8 @@ preflight:
   run: |
     set -euo pipefail
     # Find one open `needs triage` issue NOT authored by an internal user.
-    INTERNAL_AUTHORS_RE='^(garretpremo)$'
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     n=$(gh issue list --repo "$repo" \
           --state open \
@@ -34,7 +35,8 @@ preflight:
 claude:
   prompt_cmd: |
     set -euo pipefail
-    INTERNAL_AUTHORS_RE='^(garretpremo)$'
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     n=$(gh issue list --repo "$repo" \
           --state open \

--- a/.claude/skills/triage-issue/scripts/_canonical-fields.sh
+++ b/.claude/skills/triage-issue/scripts/_canonical-fields.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Shared canonical-fields template used by snapshot-issue.sh and verify-snapshot.sh.
+#
+# Both scripts must hash the SAME set of fields in the SAME order — otherwise
+# verify-snapshot.sh starts reporting spurious "edited" results when the field
+# lists drift apart. Source this file from both to keep the template in one
+# place.
+#
+# Usage (after sourcing):
+#   build_canonical_snapshot "$issue_json" "$comments_json"
+#
+# Inputs:
+#   $1 — issue JSON (object) from `gh api repos/<repo>/issues/<n>`
+#   $2 — comments JSON (array) from
+#        `gh api --paginate repos/<repo>/issues/<n>/comments | jq -s 'add // []'`
+#        (i.e. already flattened across pages, but NOT yet projected — this
+#        function does the projection so the comment-field list lives here too)
+#
+# Output:
+#   The canonical snapshot JSON is printed to stdout. Callers decide whether to
+#   pretty-print it for storage (snapshot-issue.sh) or compact-and-hash it for
+#   verification (verify-snapshot.sh).
+
+build_canonical_snapshot() {
+    local issue_json="$1"
+    local comments_json="$2"
+    local projected_comments
+    projected_comments=$(jq 'map({id, user: .user.login, body, updated_at})' <<<"$comments_json")
+
+    jq -n \
+        --argjson issue "$issue_json" \
+        --argjson comments "$projected_comments" \
+        '{
+            number:     $issue.number,
+            title:      $issue.title,
+            body:       $issue.body,
+            author:     $issue.user.login,
+            created_at: $issue.created_at,
+            updated_at: $issue.updated_at,
+            locked:     $issue.locked,
+            comments:   $comments
+        }'
+}

--- a/.claude/skills/triage-issue/scripts/add-triage-flag.sh
+++ b/.claude/skills/triage-issue/scripts/add-triage-flag.sh
@@ -35,5 +35,12 @@ if [ "$valid" -ne 1 ]; then
 fi
 
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+current=$(gh api "repos/$repo/issues/$issue/labels" --jq '.[].name')
+if grep -qxF "$flag" <<<"$current"; then
+    echo "'$flag' already set on issue #$issue"
+    exit 0
+fi
+
 gh api -X POST "repos/$repo/issues/$issue/labels" -f "labels[]=$flag" >/dev/null
 echo "added '$flag' to issue #$issue"

--- a/.claude/skills/triage-issue/scripts/sanitize-issue.sh
+++ b/.claude/skills/triage-issue/scripts/sanitize-issue.sh
@@ -36,34 +36,32 @@ fi
 issue="$1"
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
+# Pre-fetch and flatten paginated comments via jq (mirrors snapshot-issue.sh).
+# Avoids brittle bracket-pair regex parsing of `gh api --paginate`'s
+# concatenated JSON arrays — that regex mishandles bracket-bearing comment
+# bodies (e.g. comments containing `[link](url)` text).
+issue_json=$(gh api "repos/$repo/issues/$issue")
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
+
+# Combine into a single JSON object passed via a temp file — sidesteps both
+# ARG_MAX (argv/env limit) and the heredoc-vs-stdin conflict.
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+jq -n \
+    --argjson issue "$issue_json" \
+    --argjson comments "$comments_json" \
+    '{issue: $issue, comments: $comments}' > "$payload_file"
+
 # Strip zero-width / tag / bidi chars and HTML comments and markdown images.
 # Implemented in a small python because sed's unicode handling is uneven.
-python3 - "$repo" "$issue" <<'PY'
-import json, re, subprocess, sys
+ISSUE_NUMBER="$issue" PAYLOAD_FILE="$payload_file" python3 - <<'PY'
+import json, os, re
 
-repo, issue = sys.argv[1], sys.argv[2]
-
-def gh_api(path, paginate=False):
-    cmd = ["gh", "api"]
-    if paginate:
-        cmd.append("--paginate")
-    cmd.append(path)
-    return subprocess.check_output(cmd, text=True)
-
-issue_obj = json.loads(gh_api(f"repos/{repo}/issues/{issue}"))
-comments_raw = gh_api(f"repos/{repo}/issues/{issue}/comments", paginate=True)
-# --paginate concatenates JSON arrays; merge them.
-comments = []
-for chunk in re.findall(r'\[.*?\](?=\s*\[|\s*$)', comments_raw, re.DOTALL):
-    try:
-        comments.extend(json.loads(chunk))
-    except json.JSONDecodeError:
-        pass
-if not comments:
-    try:
-        comments = json.loads(comments_raw)
-    except json.JSONDecodeError:
-        comments = []
+issue     = os.environ["ISSUE_NUMBER"]
+with open(os.environ["PAYLOAD_FILE"]) as f:
+    payload = json.load(f)
+issue_obj = payload["issue"]
+comments  = payload["comments"]
 
 ZW = "".join(chr(c) for c in (0x200B, 0x200C, 0x200D, 0xFEFF))
 TAG_RE = re.compile(r"[\U000E0000-\U000E007F]")

--- a/.claude/skills/triage-issue/scripts/set-triage-label.sh
+++ b/.claude/skills/triage-issue/scripts/set-triage-label.sh
@@ -54,8 +54,11 @@ for l in "${state_labels[@]}"; do
     gh api -X DELETE "repos/$repo/issues/$issue/labels/$encoded" >/dev/null
 done
 
-if ! grep -qxF "$target" <<<"$current"; then
+if grep -qxF "$target" <<<"$current"; then
+    echo "'$target' already set on issue #$issue"
+else
     gh api -X POST "repos/$repo/issues/$issue/labels" -f "labels[]=$target" >/dev/null
+    echo "added '$target' to issue #$issue"
 fi
 
 echo "issue #$issue labels:"

--- a/.claude/skills/triage-issue/scripts/snapshot-issue.sh
+++ b/.claude/skills/triage-issue/scripts/snapshot-issue.sh
@@ -12,6 +12,8 @@
 set -euo pipefail
 
 source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+# shellcheck source=_canonical-fields.sh
+source "$(dirname "$0")/_canonical-fields.sh"
 
 if [ $# -ne 1 ]; then
     echo "usage: $0 <issue-number>" >&2
@@ -26,22 +28,9 @@ mkdir -p "$(dirname "$out")"
 
 # Pull canonical fields. Comments are paginated, so use --paginate.
 issue_json=$(gh api "repos/$repo/issues/$issue")
-comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" \
-    | jq -s 'add // [] | map({id, user: .user.login, body, updated_at})')
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
 
-snapshot=$(jq -n \
-    --argjson issue "$issue_json" \
-    --argjson comments "$comments_json" \
-    '{
-        number:     $issue.number,
-        title:      $issue.title,
-        body:       $issue.body,
-        author:     $issue.user.login,
-        created_at: $issue.created_at,
-        updated_at: $issue.updated_at,
-        locked:     $issue.locked,
-        comments:   $comments
-    }')
+snapshot=$(build_canonical_snapshot "$issue_json" "$comments_json")
 
 printf '%s\n' "$snapshot" > "$out"
 

--- a/.claude/skills/triage-issue/scripts/verify-snapshot.sh
+++ b/.claude/skills/triage-issue/scripts/verify-snapshot.sh
@@ -7,6 +7,8 @@
 set -euo pipefail
 
 source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+# shellcheck source=_canonical-fields.sh
+source "$(dirname "$0")/_canonical-fields.sh"
 
 if [ $# -ne 2 ]; then
     echo "usage: $0 <issue-number> <expected-sha256>" >&2
@@ -18,22 +20,10 @@ expected="$2"
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 issue_json=$(gh api "repos/$repo/issues/$issue")
-comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" \
-    | jq -s 'add // [] | map({id, user: .user.login, body, updated_at})')
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
 
-actual=$(jq -nSc \
-    --argjson issue "$issue_json" \
-    --argjson comments "$comments_json" \
-    '{
-        number:     $issue.number,
-        title:      $issue.title,
-        body:       $issue.body,
-        author:     $issue.user.login,
-        created_at: $issue.created_at,
-        updated_at: $issue.updated_at,
-        locked:     $issue.locked,
-        comments:   $comments
-    }' | sha256sum | awk '{print $1}')
+actual=$(build_canonical_snapshot "$issue_json" "$comments_json" \
+    | jq -Sc . | sha256sum | awk '{print $1}')
 
 if [ "$actual" = "$expected" ]; then
     echo "snapshot verified for issue #$issue"


### PR DESCRIPTION
Closes #50
Closes #51
Closes #52
Closes #53

## Summary

Bundle of four small hygiene fixes spawned from the automated review of PR #49. All four touch the triage scripts (`.claude/skills/triage-issue/scripts/`) and triage cron yamls (`.claude-jobs/triage-*.yaml`); the file sets are disjoint from any concurrent feature work, which is why they are bundled into a single chore PR rather than four separate ones.

No public-API surface changes — none of `@apijack/core`'s exported behavior is touched, so the conventional-commit prefix is `chore(triage):` (patch-level).

## What changes

### #50 — `sanitize-issue.sh`: replace bracket-pair regex with `jq -s 'add'`

The previous parser used `re.findall(r'\[.*?\](?=\s*\[|\s*$)', ...)` to split `gh api --paginate`'s concatenated JSON arrays. That regex matches the first `]` it finds, so a comment body containing `[link](url)` text could be cut mid-payload and silently dropped by the `try: json.loads(chunk) except: pass` fallback.

Now flattens the same way `snapshot-issue.sh` already does:

```bash
comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
```

The combined `{issue, comments}` payload is then passed to the in-script python sanitizer via a temp file (instead of argv) to avoid ARG_MAX limits on issues with large bodies or many comments.

### #51 — single source for `INTERNAL_AUTHORS`

`triage-internal.yaml` previously defined `INTERNAL_AUTHORS=("garretpremo")` in both its `preflight` and `prompt_cmd` blocks; `triage-public.yaml` defined `INTERNAL_AUTHORS_RE='^(garretpremo)$'` in two parallel locations. As the allowlist grows, drift between these four sites would silently change which issues each gate accepts.

New `.claude-jobs/_internal-authors.sh` is the single source. Both yamls now `source` it from each call site:

```bash
# shellcheck source=_internal-authors.sh
source ".claude-jobs/_internal-authors.sh"
```

The snippet exports the array and derives the anchored regex from it, so adding a maintainer is a one-line edit:

```bash
INTERNAL_AUTHORS=("garretpremo")
INTERNAL_AUTHORS_RE="^($(IFS='|'; echo "${INTERNAL_AUTHORS[*]}"))$"
```

The `garretpremo` mention in `triage-internal.yaml`'s `append_system_prompt` is descriptive prose for the LLM (not executable) and remains as-is.

### #52 — accurate "added" vs "already set" messaging

`add-triage-flag.sh` and `set-triage-label.sh` previously printed `added '<label>'` unconditionally, even when the label was already present (the GitHub API silently no-ops). Both now mirror the pattern in `lock-issue.sh`: pre-check current labels, print `'<label>' already set on issue #N` when no-op, otherwise print `added '<label>'`.

`set-triage-label.sh` keeps its trailing label-list dump as a useful diagnostic.

### #53 — shared canonical-fields template

`snapshot-issue.sh` and `verify-snapshot.sh` each defined the same `jq -n '{number, title, body, ...}'` template inline. If the field list ever changed in one place but not the other, the verifier would silently start failing for unrelated reasons (legitimate non-edits showing up as edits).

New `.claude/skills/triage-issue/scripts/_canonical-fields.sh` exports `build_canonical_snapshot "$issue_json" "$comments_json"`. Both scripts source it; the comment-projection (`map({id, user: .user.login, body, updated_at})`) lives inside the function too so the comment-field list is also single-sourced.

A bit-for-bit equivalence test (sample issue + comment) confirms the canonical SHA is identical to the previous inline template — existing on-disk snapshots remain valid.

## Acceptance criteria

- [x] `sanitize-issue.sh` no longer uses a bracket-pair regex; uses `jq -s 'add'` flattening (#50)
- [x] `INTERNAL_AUTHORS` and `INTERNAL_AUTHORS_RE` defined in exactly one place; both yamls source it from each call site (#51)
- [x] `add-triage-flag.sh` and `set-triage-label.sh` print `already set` when the label is present, `added` otherwise (#52)
- [x] Canonical snapshot template defined in exactly one shared file; sourced by both `snapshot-issue.sh` and `verify-snapshot.sh` (#53)
- [x] No regression in canonical SHA shape — existing on-disk snapshot hashes remain valid

## Test plan

- [x] `bash -n` clean on all 7 modified/new scripts
- [x] YAML parse check (`python3 -c "yaml.safe_load(...)"`) clean on both job yamls
- [x] Functional test: `_internal-authors.sh` sources cleanly under `set -euo pipefail`, produces `INTERNAL_AUTHORS_RE='^(garretpremo)$'` (matches the original literal)
- [x] Functional test: `build_canonical_snapshot` on a synthetic issue + comment produces the same JSON (and therefore same SHA) as the previous inline template
- [x] Functional test: `jq -s 'add // []'` flattens two synthetic comment pages with bracket-bearing bodies, preserving `[link](url)` and `[brackets]` intact

No `bun test` / `bun run lint` runs were needed — these are shell-only changes touching scripts not referenced from the TypeScript build (`grep` confirms no `.ts`/`.js` imports them).

## Why bundled

Per the user's bundling instruction: all four issues were spawned from the automated review of PR #49 on the same date, touch a disjoint file set from any concurrent issue-branch work, and are individually too small to warrant a full PR cycle each. Bundling them keeps the review/merge overhead proportional to the change.
