### PR TITLE
v1.12.0: consumer-CLI display branding via projectConfig

### DIFF
--- a/.claude-jobs/_internal-authors.sh
+++ b/.claude-jobs/_internal-authors.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Single source of truth for the maintainer allowlist used by triage cron jobs.
+#
+# Sourced by:
+#   - .claude-jobs/triage-internal.yaml  (preflight + prompt_cmd)
+#   - .claude-jobs/triage-public.yaml    (preflight + prompt_cmd)
+#
+# Why a sourced snippet rather than per-block constants:
+#   The harness runs `preflight.run` and `claude.prompt_cmd` in separate shells
+#   with no shared environment. Duplicating the allowlist across both blocks
+#   (in two yamls) made drift between the gates likely as the list grows —
+#   silently changing which issues each gate accepts. Centralizing here keeps
+#   the four call sites in lockstep.
+#
+# Exports:
+#   INTERNAL_AUTHORS    — bash array of GitHub login names (used by triage-internal)
+#   INTERNAL_AUTHORS_RE — anchored regex alternation matching the same set
+#                         (used by triage-public's `jq test(...)` call)
+
+INTERNAL_AUTHORS=("garretpremo")
+
+# Build "^(a|b|c)$" from the array. Safe to regenerate on every source.
+INTERNAL_AUTHORS_RE="^($(IFS='|'; echo "${INTERNAL_AUTHORS[*]}"))$"
+
+export INTERNAL_AUTHORS INTERNAL_AUTHORS_RE

--- a/.claude-jobs/triage-internal.yaml
+++ b/.claude-jobs/triage-internal.yaml
@@ -25,7 +25,8 @@ auth: subscription
 preflight:
   run: |
     set -euo pipefail
-    INTERNAL_AUTHORS=("garretpremo")
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     found=""
     for author in "${INTERNAL_AUTHORS[@]}"; do
@@ -46,7 +47,8 @@ preflight:
 claude:
   prompt_cmd: |
     set -euo pipefail
-    INTERNAL_AUTHORS=("garretpremo")
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     for author in "${INTERNAL_AUTHORS[@]}"; do
       n=$(gh issue list --repo "$repo" \

--- a/.claude-jobs/triage-public.yaml
+++ b/.claude-jobs/triage-public.yaml
@@ -21,7 +21,8 @@ preflight:
   run: |
     set -euo pipefail
     # Find one open `needs triage` issue NOT authored by an internal user.
-    INTERNAL_AUTHORS_RE='^(garretpremo)$'
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     n=$(gh issue list --repo "$repo" \
           --state open \
@@ -34,7 +35,8 @@ preflight:
 claude:
   prompt_cmd: |
     set -euo pipefail
-    INTERNAL_AUTHORS_RE='^(garretpremo)$'
+    # shellcheck source=_internal-authors.sh
+    source ".claude-jobs/_internal-authors.sh"
     repo="normalled/apijack"
     n=$(gh issue list --repo "$repo" \
           --state open \

--- a/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
+++ b/.claude/skills/patch-deployer/scripts/upsert-release-pr.sh
@@ -20,10 +20,16 @@ existing=$(gh pr list --repo "$repo" --head dev --base main --state open --json 
 
 if [ -n "$existing" ]; then
     gh pr edit "$existing" --repo "$repo" --title "$title" --body-file "$body_file" >/dev/null
-    echo "$existing"
+    pr="$existing"
 else
     git push -u origin dev
     url=$(gh pr create --repo "$repo" --base main --head dev \
         --title "$title" --body-file "$body_file")
-    echo "${url##*/}"
+    pr="${url##*/}"
 fi
+
+# Add `release` label via the REST API. `gh pr edit --add-label` is currently
+# broken by the projects-classic deprecation (exits 1 with a GraphQL warning).
+gh api -X POST "repos/$repo/issues/$pr/labels" -f 'labels[]=release' >/dev/null
+
+echo "$pr"

--- a/.claude/skills/triage-issue/scripts/_canonical-fields.sh
+++ b/.claude/skills/triage-issue/scripts/_canonical-fields.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Shared canonical-fields template used by snapshot-issue.sh and verify-snapshot.sh.
+#
+# Both scripts must hash the SAME set of fields in the SAME order — otherwise
+# verify-snapshot.sh starts reporting spurious "edited" results when the field
+# lists drift apart. Source this file from both to keep the template in one
+# place.
+#
+# Usage (after sourcing):
+#   build_canonical_snapshot "$issue_json" "$comments_json"
+#
+# Inputs:
+#   $1 — issue JSON (object) from `gh api repos/<repo>/issues/<n>`
+#   $2 — comments JSON (array) from
+#        `gh api --paginate repos/<repo>/issues/<n>/comments | jq -s 'add // []'`
+#        (i.e. already flattened across pages, but NOT yet projected — this
+#        function does the projection so the comment-field list lives here too)
+#
+# Output:
+#   The canonical snapshot JSON is printed to stdout. Callers decide whether to
+#   pretty-print it for storage (snapshot-issue.sh) or compact-and-hash it for
+#   verification (verify-snapshot.sh).
+
+build_canonical_snapshot() {
+    local issue_json="$1"
+    local comments_json="$2"
+    local projected_comments
+    projected_comments=$(jq 'map({id, user: .user.login, body, updated_at})' <<<"$comments_json")
+
+    jq -n \
+        --argjson issue "$issue_json" \
+        --argjson comments "$projected_comments" \
+        '{
+            number:     $issue.number,
+            title:      $issue.title,
+            body:       $issue.body,
+            author:     $issue.user.login,
+            created_at: $issue.created_at,
+            updated_at: $issue.updated_at,
+            locked:     $issue.locked,
+            comments:   $comments
+        }'
+}

--- a/.claude/skills/triage-issue/scripts/add-triage-flag.sh
+++ b/.claude/skills/triage-issue/scripts/add-triage-flag.sh
@@ -35,5 +35,12 @@ if [ "$valid" -ne 1 ]; then
 fi
 
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+current=$(gh api "repos/$repo/issues/$issue/labels" --jq '.[].name')
+if grep -qxF "$flag" <<<"$current"; then
+    echo "'$flag' already set on issue #$issue"
+    exit 0
+fi
+
 gh api -X POST "repos/$repo/issues/$issue/labels" -f "labels[]=$flag" >/dev/null
 echo "added '$flag' to issue #$issue"

--- a/.claude/skills/triage-issue/scripts/sanitize-issue.sh
+++ b/.claude/skills/triage-issue/scripts/sanitize-issue.sh
@@ -36,34 +36,32 @@ fi
 issue="$1"
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
+# Pre-fetch and flatten paginated comments via jq (mirrors snapshot-issue.sh).
+# Avoids brittle bracket-pair regex parsing of `gh api --paginate`'s
+# concatenated JSON arrays — that regex mishandles bracket-bearing comment
+# bodies (e.g. comments containing `[link](url)` text).
+issue_json=$(gh api "repos/$repo/issues/$issue")
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
+
+# Combine into a single JSON object passed via a temp file — sidesteps both
+# ARG_MAX (argv/env limit) and the heredoc-vs-stdin conflict.
+payload_file=$(mktemp)
+trap 'rm -f "$payload_file"' EXIT
+jq -n \
+    --argjson issue "$issue_json" \
+    --argjson comments "$comments_json" \
+    '{issue: $issue, comments: $comments}' > "$payload_file"
+
 # Strip zero-width / tag / bidi chars and HTML comments and markdown images.
 # Implemented in a small python because sed's unicode handling is uneven.
-python3 - "$repo" "$issue" <<'PY'
-import json, re, subprocess, sys
+ISSUE_NUMBER="$issue" PAYLOAD_FILE="$payload_file" python3 - <<'PY'
+import json, os, re
 
-repo, issue = sys.argv[1], sys.argv[2]
-
-def gh_api(path, paginate=False):
-    cmd = ["gh", "api"]
-    if paginate:
-        cmd.append("--paginate")
-    cmd.append(path)
-    return subprocess.check_output(cmd, text=True)
-
-issue_obj = json.loads(gh_api(f"repos/{repo}/issues/{issue}"))
-comments_raw = gh_api(f"repos/{repo}/issues/{issue}/comments", paginate=True)
-# --paginate concatenates JSON arrays; merge them.
-comments = []
-for chunk in re.findall(r'\[.*?\](?=\s*\[|\s*$)', comments_raw, re.DOTALL):
-    try:
-        comments.extend(json.loads(chunk))
-    except json.JSONDecodeError:
-        pass
-if not comments:
-    try:
-        comments = json.loads(comments_raw)
-    except json.JSONDecodeError:
-        comments = []
+issue     = os.environ["ISSUE_NUMBER"]
+with open(os.environ["PAYLOAD_FILE"]) as f:
+    payload = json.load(f)
+issue_obj = payload["issue"]
+comments  = payload["comments"]
 
 ZW = "".join(chr(c) for c in (0x200B, 0x200C, 0x200D, 0xFEFF))
 TAG_RE = re.compile(r"[\U000E0000-\U000E007F]")

--- a/.claude/skills/triage-issue/scripts/set-triage-label.sh
+++ b/.claude/skills/triage-issue/scripts/set-triage-label.sh
@@ -54,8 +54,11 @@ for l in "${state_labels[@]}"; do
     gh api -X DELETE "repos/$repo/issues/$issue/labels/$encoded" >/dev/null
 done
 
-if ! grep -qxF "$target" <<<"$current"; then
+if grep -qxF "$target" <<<"$current"; then
+    echo "'$target' already set on issue #$issue"
+else
     gh api -X POST "repos/$repo/issues/$issue/labels" -f "labels[]=$target" >/dev/null
+    echo "added '$target' to issue #$issue"
 fi
 
 echo "issue #$issue labels:"

--- a/.claude/skills/triage-issue/scripts/snapshot-issue.sh
+++ b/.claude/skills/triage-issue/scripts/snapshot-issue.sh
@@ -12,6 +12,8 @@
 set -euo pipefail
 
 source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+# shellcheck source=_canonical-fields.sh
+source "$(dirname "$0")/_canonical-fields.sh"
 
 if [ $# -ne 1 ]; then
     echo "usage: $0 <issue-number>" >&2
@@ -26,22 +28,9 @@ mkdir -p "$(dirname "$out")"
 
 # Pull canonical fields. Comments are paginated, so use --paginate.
 issue_json=$(gh api "repos/$repo/issues/$issue")
-comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" \
-    | jq -s 'add // [] | map({id, user: .user.login, body, updated_at})')
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
 
-snapshot=$(jq -n \
-    --argjson issue "$issue_json" \
-    --argjson comments "$comments_json" \
-    '{
-        number:     $issue.number,
-        title:      $issue.title,
-        body:       $issue.body,
-        author:     $issue.user.login,
-        created_at: $issue.created_at,
-        updated_at: $issue.updated_at,
-        locked:     $issue.locked,
-        comments:   $comments
-    }')
+snapshot=$(build_canonical_snapshot "$issue_json" "$comments_json")
 
 printf '%s\n' "$snapshot" > "$out"
 

--- a/.claude/skills/triage-issue/scripts/verify-snapshot.sh
+++ b/.claude/skills/triage-issue/scripts/verify-snapshot.sh
@@ -7,6 +7,8 @@
 set -euo pipefail
 
 source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+# shellcheck source=_canonical-fields.sh
+source "$(dirname "$0")/_canonical-fields.sh"
 
 if [ $# -ne 2 ]; then
     echo "usage: $0 <issue-number> <expected-sha256>" >&2
@@ -18,22 +20,10 @@ expected="$2"
 repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
 issue_json=$(gh api "repos/$repo/issues/$issue")
-comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" \
-    | jq -s 'add // [] | map({id, user: .user.login, body, updated_at})')
+comments_json=$(gh api --paginate "repos/$repo/issues/$issue/comments" | jq -s 'add // []')
 
-actual=$(jq -nSc \
-    --argjson issue "$issue_json" \
-    --argjson comments "$comments_json" \
-    '{
-        number:     $issue.number,
-        title:      $issue.title,
-        body:       $issue.body,
-        author:     $issue.user.login,
-        created_at: $issue.created_at,
-        updated_at: $issue.updated_at,
-        locked:     $issue.locked,
-        comments:   $comments
-    }' | sha256sum | awk '{print $1}')
+actual=$(build_canonical_snapshot "$issue_json" "$comments_json" \
+    | jq -Sc . | sha256sum | awk '{print $1}')
 
 if [ "$actual" = "$expected" ]; then
     echo "snapshot verified for issue #$issue"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -20,7 +20,7 @@ jobs:
         run: gh issue edit "$ISSUE_URL" --add-label "needs triage"
 
   label-new-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref != 'main'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -23,11 +23,16 @@ wiki/
 .claude-jobs/triage-snapshots/
 .claude-jobs/triage-reports/
 
-# Review-body files staged for `gh pr review --body-file` — local-only
+# Body files staged for `--body-file` (PR/issue/release) — local-only
 .claude-jobs/review-bodies/
 .claude-jobs/release-bodies/
+.claude-jobs/pr-bodies/
+.claude-jobs/issue-bodies/
 
 # Operator-private threat-model docs (kept locally, never shipped)
 .claude-jobs/*.private.md
 .claude-jobs/triage-public.md
 .claude/scheduled_tasks.lock
+
+# Subagent worktrees (created by Agent isolation: worktree)
+.claude/worktrees/

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -138,10 +138,15 @@ const projectSettings = projectRoot
     : {};
 
 // 9. Create CLI
+//    `name` stays apijack so storage paths (~/.apijack/) and env-var prefix
+//    (APIJACK_*) are unaffected. `programName`, `description`, and `version`
+//    pull from .apijack.json when present so a delegating consumer brands its
+//    own --help / setup output.
 const cli = createCli({
     name: CLI_NAME,
-    description: 'Jack into any OpenAPI spec and rip a full-featured CLI',
-    version: VERSION,
+    programName: projectConfig?.name ?? CLI_NAME,
+    description: projectConfig?.description ?? 'Jack into any OpenAPI spec and rip a full-featured CLI',
+    version: projectConfig?.version ?? VERSION,
     specPath,
     auth: authStrategy,
     sessionAuth,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.11.1",
+  "version": "1.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -153,6 +153,11 @@ fi
 
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 
+# Apply `release` label idempotently. `gh pr edit --add-label` is currently
+# broken by the projects-classic deprecation (exits 1), so use the REST API.
+gh api -X POST "repos/normalled/apijack/issues/$PR_NUM/labels" \
+    -f 'labels[]=release' >/dev/null
+
 # ── Step 5: Wait for CI checks ─────────────────────────────────────
 
 info "Waiting for CI checks..."

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -76,7 +76,7 @@ const CORE_COMMANDS = new Set([
 
 function showCustomHelp(
     program: Command,
-    cliName: string,
+    displayName: string,
     showAll: boolean,
     customCommandNames: Set<string>,
 ): void {
@@ -123,11 +123,11 @@ function showCustomHelp(
         }
     } else if (api.length > 0) {
         console.log(
-            `\n  ${api.length} API command groups available — run '${cliName} --help' to list all`,
+            `\n  ${api.length} API command groups available — run '${displayName} --help' to list all`,
         );
     }
 
-    console.log(`\nRun '${cliName} <command> --help' for details on any command.`);
+    console.log(`\nRun '${displayName} <command> --help' for details on any command.`);
 }
 
 export function createCli(options: CliOptions): Cli {
@@ -136,6 +136,7 @@ export function createCli(options: CliOptions): Cli {
     const consumerResolvers = new Map<string, CustomResolver>();
     const pluginRegistry = new PluginRegistry();
     const cliName = options.name;
+    const displayName = options.programName ?? options.name;
     const configOpts = options.configPath ? { configPath: options.configPath } : undefined;
     const configDir = options.configPath
         ? resolve(options.configPath, '..')
@@ -188,7 +189,7 @@ export function createCli(options: CliOptions): Cli {
         const resolved = resolveAuth(cliName, configOpts);
 
         if (!resolved) {
-            throw new Error(`No active env config. Run '${cliName} setup' to configure credentials.`);
+            throw new Error(`No active env config. Run '${displayName} setup' to configure credentials.`);
         }
 
         // 3. Compute auth strategy + sessionMgr.
@@ -421,7 +422,7 @@ export function createCli(options: CliOptions): Cli {
 
             // 1. Build Commander program
             program
-                .name(cliName)
+                .name(displayName)
                 .description(options.description)
                 .version(options.version);
 
@@ -444,6 +445,7 @@ export function createCli(options: CliOptions): Cli {
             registerSetupCommand(program, cliName, {
                 allowedCidrs: options.allowedCidrs,
                 configPath: options.configPath,
+                displayName,
             });
             registerConfigCommand(program, cliName, {
                 configPath: options.configPath,
@@ -486,7 +488,7 @@ export function createCli(options: CliOptions): Cli {
                 && !skipAuthCommands.has(cmd)
                 && !isHelpOrVersion
             ) {
-                console.log(`${cliName} Setup\n`);
+                console.log(`${displayName} Setup\n`);
                 const envName = await prompt('Environment name [default]: ', 'default');
                 const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
                 const user = await prompt('Username/Email: ');
@@ -507,7 +509,7 @@ export function createCli(options: CliOptions): Cli {
                         console.log('Credentials verified.');
                     }
 
-                    console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+                    console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
                 } else {
                     console.error('Setup cancelled.');
@@ -574,7 +576,7 @@ export function createCli(options: CliOptions): Cli {
             // Shared session resolver — lazy, runs on first API request or explicit consumer call
             const resolveSession = async (): Promise<void> => {
                 if (!resolved || !sessionMgr) {
-                    throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                    throw new Error(`Not authenticated. Run '${displayName} setup' to configure credentials.`);
                 }
 
                 if (ctx && ctx.session) return;
@@ -600,7 +602,7 @@ export function createCli(options: CliOptions): Cli {
                     resolveSession,
                     saveSession: async () => {
                         if (!sessionMgr) {
-                            throw new Error(`Not authenticated. Run '${cliName} setup' to configure credentials.`);
+                            throw new Error(`Not authenticated. Run '${displayName} setup' to configure credentials.`);
                         }
 
                         if (ctx!.session) {
@@ -913,7 +915,7 @@ export function createCli(options: CliOptions): Cli {
                 const showAll
                     = userArgs[0] === '--help' || userArgs[0] === '-h';
                 const customCommandNames = new Set(consumerCommands.map(c => c.name));
-                showCustomHelp(program, cliName, showAll, customCommandNames);
+                showCustomHelp(program, displayName, showAll, customCommandNames);
                 process.exit(0);
             }
 

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -509,7 +509,7 @@ export function createCli(options: CliOptions): Cli {
                         console.log('Credentials verified.');
                     }
 
-                    console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
+                    console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
                     console.log(`Switched to '${envName}'\n`);
                 } else {
                     console.error('Setup cancelled.');

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -42,10 +42,13 @@ export function registerSetupCommand(
     opts?: {
         allowedCidrs?: string[];
         configPath?: string;
+        /** Display name for user-facing output. Defaults to cliName. */
+        displayName?: string;
     },
 ): void {
+    const displayName = opts?.displayName ?? cliName;
     const action = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
-        console.log(`${cliName} Setup\n`);
+        console.log(`${displayName} Setup\n`);
 
         const envName = await prompt('Environment name [default]: ', 'default');
         const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
@@ -81,7 +84,7 @@ export function registerSetupCommand(
             console.log('Credentials verified.');
         }
 
-        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
+        console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
         console.log(`Switched to '${envName}'\n`);
     };
 

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -84,7 +84,7 @@ export function registerSetupCommand(
             console.log('Credentials verified.');
         }
 
-        console.log(`Saved environment '${envName}' to ~/.${displayName}/config.json`);
+        console.log(`Saved environment '${envName}' to ~/.${cliName}/config.json`);
         console.log(`Switched to '${envName}'\n`);
     };
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -4,6 +4,8 @@ import { homedir } from 'os';
 
 export interface ProjectConfig {
     name?: string;
+    description?: string;
+    version?: string;
     specUrl?: string;
     generatedDir?: string;
     auth?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,14 @@ export interface AuthedCliContext extends CliContext {
 }
 
 export interface CliOptions {
+    /** Storage / session / env-var-prefix identity. Determines on-disk paths
+     *  (~/.<name>/), the env-var prefix (NAME_URL/NAME_USER/NAME_PASS), and
+     *  config namespacing. Should not change once a CLI ships. */
     name: string;
+    /** Display-only name used in --help, the setup banner, and "Run '<cli> setup'"
+     *  hints. Defaults to `name`. Lets a downstream CLI delegating to the shared
+     *  `apijack` binary brand its own user-facing output without altering storage. */
+    programName?: string;
     description: string;
     version: string;
     specPath: string;

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -334,6 +334,67 @@ describe('built-in commands', () => {
         expect(output).toContain('My custom CLI tool');
     });
 
+    test('without programName, help and hints show storage name (cliName)', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'apijack',
+                description: 'Default branding',
+            }),
+        );
+        cli.command('extra', (program) => {
+            program.command('extra').description('extra command');
+        });
+
+        // No --help flag triggers showCustomHelp's compact path that emits the
+        // "run '<cliName> --help'" hint.
+        process.argv = ['node', 'apijack'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('Usage: apijack');
+        expect(output).toContain("Run 'apijack <command> --help'");
+    });
+
+    test('programName overrides display name in help and hints, leaves cliName for storage', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'apijack',           // storage identity (unchanged)
+                programName: 'rrc',        // display-only branding
+                description: 'RRCloud CLI',
+            }),
+        );
+        cli.command('extra', (program) => {
+            program.command('extra').description('extra command');
+        });
+
+        process.argv = ['node', 'rrc'];
+
+        const output = await captureOutput(() => cli.run());
+
+        // Display strings show the override.
+        expect(output).toContain('Usage: rrc');
+        expect(output).toContain('RRCloud CLI');
+        expect(output).toContain("Run 'rrc <command> --help'");
+        // The bare "apijack" identity should NOT appear in user-facing branding.
+        expect(output).not.toMatch(/Usage: apijack/);
+        expect(output).not.toMatch(/Run 'apijack /);
+    });
+
+    test('programName defaults to name when omitted', async () => {
+        const cli = createCli(
+            makeOptions({
+                name: 'foo',
+                description: 'Foo CLI',
+            }),
+        );
+
+        process.argv = ['node', 'foo', '--help'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain('Usage: foo');
+    });
+
     test('--dry-run flag is registered', async () => {
         const cli = createCli(makeOptions());
 

--- a/tests/project.test.ts
+++ b/tests/project.test.ts
@@ -81,6 +81,20 @@ describe('loadProjectConfig()', () => {
         expect(result!.auth).toBe('basic');
         expect(result!.allowedCidrs).toEqual(['192.168.1.0/24']);
     });
+
+    test('loads display branding fields (description, version)', () => {
+        mkdirSync(testRoot, { recursive: true });
+        writeFileSync(join(testRoot, '.apijack.json'), JSON.stringify({
+            name: 'rrc',
+            description: 'RRCloud CLI',
+            version: '2.5.0',
+        }));
+
+        const result = loadProjectConfig(join(testRoot, '.apijack.json'));
+        expect(result!.name).toBe('rrc');
+        expect(result!.description).toBe('RRCloud CLI');
+        expect(result!.version).toBe('2.5.0');
+    });
 });
 
 describe('resolveConfigDir()', () => {


### PR DESCRIPTION
Closes #50
Closes #51
Closes #52
Closes #53
Closes #83

Consumer CLIs delegating to the shared `apijack` binary can now brand themselves in user-facing output via `projectConfig`, while identity-keyed paths (storage, env-var prefix, session keys) keep using the binary's name.

## ✨ Features

- **`projectConfig` display fields** (#89) — opt-in `name`, `description`, and `version` in `.apijack/config` flow through to `--help`, the setup banner, and `Run '<cli> setup'` hints. Storage paths and env-var prefix are unchanged. New `programName` field on `CliOptions` keeps display and identity cleanly separated.

## 🧹 Internal

- Release PRs now get a `release` label and skip the `needs review` auto-labeler (#88); triage automation hygiene fixes (#90).

---

Shipped via `scripts/ship.sh`.
