### PR TITLE
test: integration coverage for SessionAuthStrategy stale-session refresh + retry (#77)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,20 @@ apijack supports pluggable authentication:
 
 Generated OpenAPI commands resolve the session automatically. Consumer-registered custom commands and dispatchers opt in — see Project Extensions below.
 
+### Stale-session refresh and retry (opt-in)
+
+`SessionAuthStrategy`'s cached cookies can go stale on the server side (idle timeout) without the client knowing — the next call ships the dead cookie and the server returns 401 (or 403 in some Spring configs). To recover transparently, opt in by setting `refreshOn` on the session config:
+
+```ts
+new SessionAuthStrategy(new BasicAuthStrategy(), {
+  session: { endpoint: '/session' },
+  cookies: { extract: ['SESSION'], applyTo: ['POST', 'PUT', 'DELETE'] },
+  refreshOn: [401],   // or [401, 403]
+});
+```
+
+When the generated client receives a status in `refreshOn`, it calls the wired refresh callback — which invalidates the cached session and re-bootstraps `/session` — then retries the original request once. Capped at one retry. Strategies that don't use `/session` are unaffected (the field is ignored).
+
 ## Project Extensions
 
 The `.apijack/` directory at a project root is auto-loaded when the CLI runs inside that project:

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -31,6 +31,12 @@ export interface SessionAuthConfig {
         toHeader: string;
         applyTo?: string[];
     }>;
+    /**
+     * HTTP statuses that trigger a one-shot session refresh + retry on the original request.
+     * Opt-in. Common value for stale-session recovery: `[401]` (or `[401, 403]` for servers
+     * that map an expired session to 403). The generated client invokes the refresh callback,
+     * which re-bootstraps `/session`, then retries the original request once.
+     */
     refreshOn?: number[];
     /** Called when the session endpoint returns a non-OK response. Return query params to retry, or null to give up. */
     onChallenge?: (status: number, body: string) => Promise<Record<string, string> | null>;

--- a/tests/auth/session-auth-stale-retry.integration.test.ts
+++ b/tests/auth/session-auth-stale-retry.integration.test.ts
@@ -1,0 +1,225 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { generateClient } from '../../src/codegen/client';
+import { SessionManager } from '../../src/session';
+import { SessionAuthStrategy } from '../../src/auth/session-auth';
+import { BasicAuthStrategy } from '../../src/auth/basic';
+import { resolveRequestHeaders } from '../../src/auth/resolve-headers';
+import type { OpenApiOperation } from '../../src/codegen/openapi-types';
+import type { SessionAuthConfig, AuthSession, ResolvedAuth } from '../../src/auth/types';
+
+/**
+ * Integration test for stale-session refresh + retry (#77).
+ *
+ * Exercises the full pipeline that recovers from a server-side session timeout:
+ *   cached session loaded → API call → 401 → /session re-bootstrap → retry → 200
+ *
+ * This is the contract documented in CLAUDE.md under "Stale-session refresh and
+ * retry": a consumer opts in by setting `refreshOn` on `SessionAuthConfig`, and
+ * the generated client + cli-builder wiring transparently refresh and retry
+ * once on the configured statuses.
+ */
+describe('SessionAuthStrategy stale-session refresh + retry (integration)', () => {
+    let tmpDir: string;
+    let sessionPath: string;
+    let originalFetch: typeof globalThis.fetch;
+
+    const baseUrl = 'https://api.example.com';
+    const resolved: ResolvedAuth = { baseUrl, username: 'user', password: 'pass' };
+    const sessionConfig: SessionAuthConfig = {
+        session: { endpoint: '/session' },
+        cookies: { extract: ['SESSION'], applyTo: ['DELETE'] },
+        refreshOn: [401],
+    };
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'apijack-stale-retry-'));
+        sessionPath = join(tmpDir, 'session.json');
+        originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test('on 401, refreshes /session exactly once and retries the original request successfully', async () => {
+        // 1. Pre-populate session.json with a cached (server-side stale) session.
+        writeFileSync(sessionPath, JSON.stringify({
+            headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+            cookies: { SESSION: 'stale-sess' },
+        }));
+
+        // 2. Generate a real ApiClient with one DELETE method, write to tmp, dynamic-import.
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/admin/matters/{id}': {
+                delete: {
+                    operationId: 'deleteMatter',
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const clientPath = join(tmpDir, 'client.ts');
+        writeFileSync(clientPath, generateClient(paths));
+        const { ApiClient } = await import(clientPath) as { ApiClient: new (
+            baseUrl: string,
+            getHeaders: (method: string) => Record<string, string>,
+            onRefreshNeeded?: () => Promise<void>,
+            refreshOn?: number[],
+        ) => { deleteMatter(id: number): Promise<unknown> }; };
+
+        // 3. Mock fetch:
+        //    - DELETE #1 (with stale cookie) -> 401
+        //    - GET /session (refresh)        -> 200 with fresh SESSION cookie
+        //    - DELETE #2 (with fresh cookie) -> 200
+        const calls: { url: string; method: string; cookieHeader: string | undefined }[] = [];
+        let deleteCount = 0;
+        let sessionCount = 0;
+
+        globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+            const urlStr = typeof url === 'string'
+                ? url
+                : url instanceof URL ? url.toString() : url.url;
+            const method = (init?.method ?? 'GET').toUpperCase();
+            const headers = init?.headers as Record<string, string> | undefined;
+            calls.push({ url: urlStr, method, cookieHeader: headers?.Cookie });
+
+            if (urlStr.endsWith('/session')) {
+                sessionCount++;
+
+                return new Response('{}', {
+                    status: 200,
+                    headers: [['Set-Cookie', `SESSION=fresh-sess-${sessionCount}; Path=/; HttpOnly`]],
+                });
+            }
+
+            if (urlStr.includes('/admin/matters/5') && method === 'DELETE') {
+                deleteCount++;
+
+                if (deleteCount === 1) {
+                    return new Response(
+                        JSON.stringify({ status: 403, error: 'Forbidden', path: '/admin/matters/5' }),
+                        { status: 401 },
+                    );
+                }
+
+                return new Response(JSON.stringify({ ok: true, id: 5 }), { status: 200 });
+            }
+
+            return new Response('not found', { status: 404 });
+        }) as typeof fetch;
+
+        // 4. Wire SessionManager + SessionAuthStrategy exactly as cli-builder does.
+        const sessionMgr = new SessionManager('test', sessionPath);
+        const strategy = new SessionAuthStrategy(new BasicAuthStrategy(), sessionConfig);
+
+        let session: AuthSession | null = null;
+        const getHeaders = (method: string) =>
+            resolveRequestHeaders(session ?? { headers: {} }, sessionConfig, method);
+        const refreshSession = async () => {
+            // Refresh-callback failure path (refresh itself throws) is intentionally
+            // not covered here — the original-error-with-cause behavior is a deferred
+            // follow-up to #77.
+            sessionMgr.invalidate();
+            session = await sessionMgr.resolve(strategy, resolved);
+        };
+
+        // 5. Initial resolve loads the cached session — does NOT hit /session yet.
+        session = await sessionMgr.resolve(strategy, resolved);
+        expect(session.cookies?.SESSION).toBe('stale-sess');
+        expect(sessionCount).toBe(0);
+
+        const client = new ApiClient(baseUrl, getHeaders, refreshSession, sessionConfig.refreshOn);
+
+        // 6. Make the request — 401 triggers refresh, retry succeeds.
+        const result = await client.deleteMatter(5);
+        expect(result).toEqual({ ok: true, id: 5 });
+
+        // 7. /session called exactly once (during refresh).
+        expect(sessionCount).toBe(1);
+
+        // 8. The DELETE was made twice; the retry shipped the refreshed cookie.
+        const deletes = calls.filter(c => c.method === 'DELETE');
+        expect(deletes).toHaveLength(2);
+        expect(deletes[0].cookieHeader).toContain('SESSION=stale-sess');
+        expect(deletes[1].cookieHeader).toContain('SESSION=fresh-sess-1');
+    });
+
+    test('when refreshOn is unset, a 401 propagates without refresh or retry (opt-in)', async () => {
+        // Same setup as the happy-path test, but no refreshOn on the config — the
+        // contract is opt-in, so the 401 should surface untouched.
+        writeFileSync(sessionPath, JSON.stringify({
+            headers: { Authorization: 'Basic dXNlcjpwYXNz' },
+            cookies: { SESSION: 'stale-sess' },
+        }));
+
+        const optInConfig: SessionAuthConfig = {
+            session: { endpoint: '/session' },
+            cookies: { extract: ['SESSION'], applyTo: ['DELETE'] },
+            // refreshOn intentionally omitted
+        };
+
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/admin/matters/{id}': {
+                delete: {
+                    operationId: 'deleteMatter',
+                    parameters: [
+                        { name: 'id', in: 'path', required: true, schema: { type: 'integer' } },
+                    ],
+                },
+            },
+        };
+        const clientPath = join(tmpDir, 'client.ts');
+        writeFileSync(clientPath, generateClient(paths));
+        const { ApiClient } = await import(clientPath) as { ApiClient: new (
+            baseUrl: string,
+            getHeaders: (method: string) => Record<string, string>,
+            onRefreshNeeded?: () => Promise<void>,
+            refreshOn?: number[],
+        ) => { deleteMatter(id: number): Promise<unknown> }; };
+
+        let deleteCount = 0;
+        let sessionCount = 0;
+        globalThis.fetch = (async (url: string | URL | Request) => {
+            const urlStr = typeof url === 'string'
+                ? url
+                : url instanceof URL ? url.toString() : url.url;
+
+            if (urlStr.endsWith('/session')) {
+                sessionCount++;
+
+                return new Response('{}', { status: 200, headers: [['Set-Cookie', 'SESSION=fresh; Path=/']] });
+            }
+
+            if (urlStr.includes('/admin/matters/5')) {
+                deleteCount++;
+
+                return new Response('Forbidden', { status: 401 });
+            }
+
+            return new Response('not found', { status: 404 });
+        }) as typeof fetch;
+
+        const sessionMgr = new SessionManager('test', sessionPath);
+        const strategy = new SessionAuthStrategy(new BasicAuthStrategy(), optInConfig);
+        let session: AuthSession | null = await sessionMgr.resolve(strategy, resolved);
+        const getHeaders = (method: string) =>
+            resolveRequestHeaders(session ?? { headers: {} }, optInConfig, method);
+        const refreshSession = async () => {
+            sessionMgr.invalidate();
+            session = await sessionMgr.resolve(strategy, resolved);
+        };
+
+        const client = new ApiClient(baseUrl, getHeaders, refreshSession, optInConfig.refreshOn);
+
+        await expect(client.deleteMatter(5)).rejects.toMatchObject({ status: 401 });
+
+        // No refresh attempted, no retry made.
+        expect(sessionCount).toBe(0);
+        expect(deleteCount).toBe(1);
+    });
+});


### PR DESCRIPTION
Closes #77

## Summary

Closes a test + docs gap, not a code gap. The stale-session refresh + retry mechanism described by #77 already exists end-to-end: `SessionAuthConfig.refreshOn` → wired into the generated `ApiClient` via `cli-builder.ts:248-253` → on a status in `refreshOn`, the client invokes the refresh callback (which calls `sessionMgr.invalidate()` then `sessionMgr.resolve()`, ending in `SessionAuthStrategy.authenticate()` re-bootstrapping `/session`) and retries the original request once. The mechanism was undocumented and untested, so consumers (notably the RRC CLI that triggered the report) didn't know to opt in.

This PR adds the missing integration coverage and the missing docs. Per triage, behavior stays opt-in — no default-on change. Refresh-callback-throws semantics (the issue's "propagate the original error untouched") is intentionally deferred; the breadcrumb is in the test.

## What changes

### New integration test — `tests/auth/session-auth-stale-retry.integration.test.ts`

Two tests that wire the real components (`SessionManager`, `SessionAuthStrategy`, `BasicAuthStrategy`, `resolveRequestHeaders`) and a runtime-generated `ApiClient` produced by `generateClient()` and dynamic-imported from a tmp `.ts` file. The only seam mocked is `globalThis.fetch`.

1. **Happy path**: pre-populates a stale `session.json` on disk, stages fetch to return 401 on the first `DELETE /admin/matters/5`, 200 on `/session`, then 200 on the retried `DELETE`. Asserts:
   - `/session` was called exactly once (`expect(sessionCount).toBe(1)`)
   - The original `DELETE` was made twice
   - The retry shipped the **refreshed** cookie, not the stale one (proves `getHeaders()` is re-resolved post-refresh)
2. **Opt-in proof**: same setup, `refreshOn` omitted from the config, single 401 propagates with no refresh and no retry. Pins the contract that strategies without `refreshOn` are unaffected.

### Docs

- New "Stale-session refresh and retry (opt-in)" subsection in `CLAUDE.md` under "Authentication Strategies", with a copy-pasteable `SessionAuthStrategy` config snippet.
- JSDoc on `SessionAuthConfig.refreshOn` (`src/auth/types.ts`) so it's discoverable in IDE intellisense.

### No production code changed

`src/auth/session-auth.ts`, `src/codegen/client.ts`, `src/cli-builder.ts`, `src/session.ts` are all untouched.

## Acceptance criteria

- [x] Integration test simulates a stale-session 401, asserts `/session` is called exactly once, and asserts the original request is retried successfully
- [x] Behavior is opt-in (and now documented). Strategies that don't use `/session` are unaffected
- [x] Brief note in the auth strategy docs

## Test plan

- [x] `bun test` — 868 pass / 0 fail
- [x] `bun run lint` — 0 errors (108 pre-existing warnings unchanged)
- [x] `bun test tests/auth/session-auth-stale-retry.integration.test.ts` — 2 pass / 0 fail
- [x] Self-review via `superpowers:code-reviewer` — verdict: ready to merge
