### PR TITLE
fix: thread displayName through subcommand registrar hints (#91)

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -451,6 +451,7 @@ export function createCli(options: CliOptions): Cli {
                 configPath: options.configPath,
                 knownSites: options.knownSites,
                 allowedCidrs: options.allowedCidrs,
+                displayName,
             });
             registerUpgradeCommand(program, options.version);
             registerMcpCommand(
@@ -820,7 +821,7 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 12. Register routine commands
-            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers, pluginRegistry);
+            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers, pluginRegistry, displayName);
 
             // 13. Handle -o routine-step
             if (isRoutineStep) {

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -14,9 +14,12 @@ export function registerConfigCommand(
         configPath?: string;
         knownSites?: Record<string, { url: string; description: string; group?: string }>;
         allowedCidrs?: string[];
+        /** Display name for user-facing hints. Defaults to cliName. */
+        displayName?: string;
     },
 ): void {
     const configOpts = opts?.configPath ? { configPath: opts.configPath } : undefined;
+    const displayName = opts?.displayName ?? cliName;
     const config = program
         .command('config')
         .description('Manage environment configurations');
@@ -30,7 +33,7 @@ export function registerConfigCommand(
             });
 
             if (envs.length === 0) {
-                console.log(`No environments configured. Run '${cliName} setup' to add one.`);
+                console.log(`No environments configured. Run '${displayName} setup' to add one.`);
 
                 return;
             }
@@ -143,7 +146,7 @@ export function registerConfigCommand(
                 const cfg = await loadConfig(cliName, configOpts);
 
                 if (!cfg || Object.keys(cfg.environments).length === 0) {
-                    console.error(`No environments configured. Run '${cliName} config import' first.`);
+                    console.error(`No environments configured. Run '${displayName} config import' first.`);
                     process.exit(1);
                 }
 
@@ -170,6 +173,7 @@ export function registerConfigCommand(
                         loadConfig: async () => cfg,
                         save: saveEnvironment,
                         cliName,
+                        displayName,
                         saveOpts: configOpts ?? {},
                     });
                     console.log('Password updated.');

--- a/src/commands/config/update-password/update-password.ts
+++ b/src/commands/config/update-password/update-password.ts
@@ -6,6 +6,8 @@ export interface ConfigUpdatePasswordDeps {
     loadConfig: (cliName: string) => Promise<CliConfig | null>;
     save: (cliName: string, name: string, env: EnvironmentConfig, setActive?: boolean, opts?: Record<string, unknown>) => Promise<void>;
     cliName: string;
+    /** Display name for user-facing hints. Defaults to cliName. */
+    displayName?: string;
     saveOpts: Record<string, unknown>;
 }
 
@@ -18,7 +20,8 @@ export async function configUpdatePasswordAction(deps: ConfigUpdatePasswordDeps)
     const cfg = await deps.loadConfig(deps.cliName);
 
     if (!cfg || Object.keys(cfg.environments).length === 0) {
-        throw new Error(`No environments configured. Run '${deps.cliName} config import' first.`);
+        const displayName = deps.displayName ?? deps.cliName;
+        throw new Error(`No environments configured. Run '${displayName} config import' first.`);
     }
 
     const envName = deps.envName ?? cfg.active;

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -46,10 +46,13 @@ export function registerRoutineCommand(
     builtinRoutinesDir?: string,
     customResolvers?: Map<string, CustomResolver>,
     pluginRegistry?: PluginRegistry,
+    /** Display name for user-facing hints. Defaults to cliName. */
+    displayName?: string,
 ): void {
     const builtinsMap = builtinRoutinesDir
         ? loadBuiltinRoutines(builtinRoutinesDir)
         : undefined;
+    const display = displayName ?? cliName;
 
     const routine = program
         .command('routine')
@@ -70,7 +73,7 @@ export function registerRoutineCommand(
                     console.log(`No routines found under '${path.replace(/\/+$/, '')}/'`);
                 } else {
                     console.log(`No routines found in ~/.${cliName}/routines/`);
-                    console.log(`Run '${cliName} routine init' to install built-in routines.`);
+                    console.log(`Run '${display} routine init' to install built-in routines.`);
                 }
 
                 return;
@@ -101,13 +104,13 @@ export function registerRoutineCommand(
                         stepsRun: 0,
                         stepsSkipped: 0,
                         stepsFailed: 0,
-                        error: `No active session. Run '${cliName} setup' first.`,
+                        error: `No active session. Run '${display} setup' first.`,
                     };
                     process.stdout.write(JSON.stringify(failure) + '\n');
                     process.exit(2);
                 }
 
-                console.error(`No active session. Run '${cliName} setup' first.`);
+                console.error(`No active session. Run '${display} setup' first.`);
                 process.exit(2);
             }
 
@@ -230,7 +233,7 @@ export function registerRoutineCommand(
         .option('--set <pairs...>', 'Override variables (key=value)')
         .action(async (name: string, opts: { set?: string[] }) => {
             if (!dispatch) {
-                console.error(`No active session. Run '${cliName} setup' first.`);
+                console.error(`No active session. Run '${display} setup' first.`);
                 process.exit(2);
             }
 

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { createCli, type Cli } from '../src/cli-builder';
 import type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, ApijackPlugin } from '../src/types';
 import { BasicAuthStrategy } from '../src/auth/basic';
+import { configUpdatePasswordAction } from '../src/commands/config/update-password/update-password';
 
 const coreManifest = JSON.parse(
     readFileSync(join(import.meta.dir, '..', 'package.json'), 'utf-8'),
@@ -436,6 +437,97 @@ describe('built-in commands', () => {
 
         expect(output).toContain('curl');
         expect(output).toContain('curl-with-creds');
+    });
+});
+
+describe('displayName threaded through subcommand registrar hints (#91)', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-displayname-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+        // Empty-environments config — triggers the "no envs configured" hint paths.
+        writeFileSync(configPath, JSON.stringify({ active: '', environments: {} }));
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('config list: hint uses programName when set', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', programName: 'mycli', configPath }));
+
+        process.argv = ['node', 'mycli', 'config', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'mycli setup'");
+        expect(output).not.toContain("Run 'apijack setup'");
+    });
+
+    test('config list: hint falls back to cliName when programName omitted', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', configPath }));
+
+        process.argv = ['node', 'apijack', 'config', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'apijack setup'");
+    });
+
+    test('routine list: hint uses programName when set', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', programName: 'mycli', configPath }));
+
+        process.argv = ['node', 'mycli', 'routine', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'mycli routine init'");
+        expect(output).not.toContain("Run 'apijack routine init'");
+    });
+
+    test('routine list: hint falls back to cliName when programName omitted', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', configPath }));
+
+        process.argv = ['node', 'apijack', 'routine', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'apijack routine init'");
+    });
+
+    test('configUpdatePasswordAction: throws with displayName when set', async () => {
+        await expect(configUpdatePasswordAction({
+            password: 'new',
+            loadConfig: async () => ({ active: '', environments: {} }),
+            save: async () => {},
+            cliName: 'apijack',
+            displayName: 'mycli',
+            saveOpts: {},
+        })).rejects.toThrow("Run 'mycli config import' first");
+    });
+
+    test('configUpdatePasswordAction: throws with cliName when displayName omitted', async () => {
+        await expect(configUpdatePasswordAction({
+            password: 'new',
+            loadConfig: async () => ({ active: '', environments: {} }),
+            save: async () => {},
+            cliName: 'apijack',
+            saveOpts: {},
+        })).rejects.toThrow("Run 'apijack config import' first");
     });
 });
 


### PR DESCRIPTION
Closes #91

## Summary

Follow-up to #83/#89. Seven user-facing `Run '<cli> ...'` hints across the config and routine subcommand registrars still interpolated the identity `cliName` instead of the new `displayName`. A consumer that sets `programName: "mycli"` would see `Run 'apijack setup'` (or similar) when hitting any of these error paths, breaking the branding contract that #83 established.

This PR plumbs `displayName` through both registrars (opts struct on `registerConfigCommand`, optional 8th positional on `registerRoutineCommand`) and the `configUpdatePasswordAction` deps, defaulting to `cliName` when omitted so existing consumers see no behavior change. Identity-keyed uses (`~/.${cliName}/` path log, MCP routines dir, `run-routine.ts`, storage/env-var/session keys) intentionally keep `cliName` per the issue's explicit out-of-scope list.

## What changes

### Plumbing

- `src/commands/config/update-password/update-password.ts` — `ConfigUpdatePasswordDeps` gains `displayName?: string`; the `No environments configured` throw uses `deps.displayName ?? deps.cliName`.
- `src/commands/config/register.ts` — `registerConfigCommand` opts gain `displayName?`. Computed once at the top: `const displayName = opts?.displayName ?? cliName`. Used at the two hint sites (`config list` empty + `update-password` empty-envs guard) and forwarded into `configUpdatePasswordAction` deps.
- `src/commands/routine/register.ts` — `registerRoutineCommand` gains an optional 8th positional param `displayName?`. Local `const display = displayName ?? cliName` (named `display` to avoid shadowing the parameter). Used at the four hint sites: `routine list` empty branch, `routine run` no-dispatch JSON failure, `routine run` no-dispatch stderr, `routine test` no-dispatch.
- `src/cli-builder.ts` — passes `displayName` (already computed at line 139) to both registrars.

### Tests

`tests/cli-builder.test.ts` gains a new `describe('displayName threaded through subcommand registrar hints (#91)')` block with 6 tests:

- `config list`: hint shows `programName` when set; falls back to `cliName` when omitted.
- `routine list`: hint shows `programName` when set; falls back to `cliName` when omitted.
- `configUpdatePasswordAction` (direct): throw includes `displayName` when set; falls back to `cliName` when omitted.

## Acceptance criteria

- [x] All seven listed sites use `displayName` (with `cliName` fallback) instead of `cliName`
- [x] A consumer that sets `programName: "mycli"` sees `Run 'mycli setup'`, `Run 'mycli config import'`, etc., on these error paths
- [x] Storage paths, env-var prefix, and session keys still use the identity `cliName` (no path-log lies)
- [x] Unit tests cover at least one site per file showing the displayName flow with and without `programName` set

## Test plan

- [x] `bun test` — 874 pass / 0 fail (was 868; +6 new tests)
- [x] `bun run lint` — 0 errors (108 pre-existing warnings unchanged)
- [x] `grep -rn "Run '\${cliName}\|Run '\${deps\.cliName}" src/` — zero remaining hint sites
- [x] Self-review via `superpowers:code-reviewer` — verdict: ready to merge
