### PR TITLE
v1.12.2: displayName in subcommand error hints

### DIFF
--- a/.claude-jobs/review-issue.yaml
+++ b/.claude-jobs/review-issue.yaml
@@ -16,9 +16,13 @@ claude:
 
   append_system_prompt: |
     You are running non-interactively. Your scope for this run is strictly
-    review-and-comment: read the PR, post review feedback via `gh pr review`,
-    then stop. Do NOT merge, do NOT push, do NOT hand off to other skills.
-    If the skill suggests merging, skip that step and exit.
+    review-and-label: read the PR, post review feedback via `gh pr review`,
+    apply the appropriate review-state label via
+    `.claude/skills/review-issue/scripts/set-review-label.sh` (i.e.
+    `first pass reviewed` for a passing review or `changes requested` for a
+    blocking review), then stop. Do NOT merge, do NOT push, do NOT hand off
+    to other skills like next-deployer. If the skill suggests merging or
+    handing off, skip those steps and exit.
 
   allowed_tools:
     - "Bash(gh pr view*)"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -451,6 +451,7 @@ export function createCli(options: CliOptions): Cli {
                 configPath: options.configPath,
                 knownSites: options.knownSites,
                 allowedCidrs: options.allowedCidrs,
+                displayName,
             });
             registerUpgradeCommand(program, options.version);
             registerMcpCommand(
@@ -820,7 +821,7 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 12. Register routine commands
-            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers, pluginRegistry);
+            registerRoutineCommand(program, cliName, routinesDir, dispatch, options.builtinRoutinesDir, customResolvers, pluginRegistry, displayName);
 
             // 13. Handle -o routine-step
             if (isRoutineStep) {

--- a/src/commands/config/register.ts
+++ b/src/commands/config/register.ts
@@ -14,9 +14,12 @@ export function registerConfigCommand(
         configPath?: string;
         knownSites?: Record<string, { url: string; description: string; group?: string }>;
         allowedCidrs?: string[];
+        /** Display name for user-facing hints. Defaults to cliName. */
+        displayName?: string;
     },
 ): void {
     const configOpts = opts?.configPath ? { configPath: opts.configPath } : undefined;
+    const displayName = opts?.displayName ?? cliName;
     const config = program
         .command('config')
         .description('Manage environment configurations');
@@ -30,7 +33,7 @@ export function registerConfigCommand(
             });
 
             if (envs.length === 0) {
-                console.log(`No environments configured. Run '${cliName} setup' to add one.`);
+                console.log(`No environments configured. Run '${displayName} setup' to add one.`);
 
                 return;
             }
@@ -143,7 +146,7 @@ export function registerConfigCommand(
                 const cfg = await loadConfig(cliName, configOpts);
 
                 if (!cfg || Object.keys(cfg.environments).length === 0) {
-                    console.error(`No environments configured. Run '${cliName} config import' first.`);
+                    console.error(`No environments configured. Run '${displayName} config import' first.`);
                     process.exit(1);
                 }
 
@@ -170,6 +173,7 @@ export function registerConfigCommand(
                         loadConfig: async () => cfg,
                         save: saveEnvironment,
                         cliName,
+                        displayName,
                         saveOpts: configOpts ?? {},
                     });
                     console.log('Password updated.');

--- a/src/commands/config/update-password/update-password.ts
+++ b/src/commands/config/update-password/update-password.ts
@@ -6,6 +6,8 @@ export interface ConfigUpdatePasswordDeps {
     loadConfig: (cliName: string) => Promise<CliConfig | null>;
     save: (cliName: string, name: string, env: EnvironmentConfig, setActive?: boolean, opts?: Record<string, unknown>) => Promise<void>;
     cliName: string;
+    /** Display name for user-facing hints. Defaults to cliName. */
+    displayName?: string;
     saveOpts: Record<string, unknown>;
 }
 
@@ -18,7 +20,8 @@ export async function configUpdatePasswordAction(deps: ConfigUpdatePasswordDeps)
     const cfg = await deps.loadConfig(deps.cliName);
 
     if (!cfg || Object.keys(cfg.environments).length === 0) {
-        throw new Error(`No environments configured. Run '${deps.cliName} config import' first.`);
+        const displayName = deps.displayName ?? deps.cliName;
+        throw new Error(`No environments configured. Run '${displayName} config import' first.`);
     }
 
     const envName = deps.envName ?? cfg.active;

--- a/src/commands/routine/register.ts
+++ b/src/commands/routine/register.ts
@@ -46,10 +46,13 @@ export function registerRoutineCommand(
     builtinRoutinesDir?: string,
     customResolvers?: Map<string, CustomResolver>,
     pluginRegistry?: PluginRegistry,
+    /** Display name for user-facing hints. Defaults to cliName. */
+    displayName?: string,
 ): void {
     const builtinsMap = builtinRoutinesDir
         ? loadBuiltinRoutines(builtinRoutinesDir)
         : undefined;
+    const display = displayName ?? cliName;
 
     const routine = program
         .command('routine')
@@ -70,7 +73,7 @@ export function registerRoutineCommand(
                     console.log(`No routines found under '${path.replace(/\/+$/, '')}/'`);
                 } else {
                     console.log(`No routines found in ~/.${cliName}/routines/`);
-                    console.log(`Run '${cliName} routine init' to install built-in routines.`);
+                    console.log(`Run '${display} routine init' to install built-in routines.`);
                 }
 
                 return;
@@ -101,13 +104,13 @@ export function registerRoutineCommand(
                         stepsRun: 0,
                         stepsSkipped: 0,
                         stepsFailed: 0,
-                        error: `No active session. Run '${cliName} setup' first.`,
+                        error: `No active session. Run '${display} setup' first.`,
                     };
                     process.stdout.write(JSON.stringify(failure) + '\n');
                     process.exit(2);
                 }
 
-                console.error(`No active session. Run '${cliName} setup' first.`);
+                console.error(`No active session. Run '${display} setup' first.`);
                 process.exit(2);
             }
 
@@ -230,7 +233,7 @@ export function registerRoutineCommand(
         .option('--set <pairs...>', 'Override variables (key=value)')
         .action(async (name: string, opts: { set?: string[] }) => {
             if (!dispatch) {
-                console.error(`No active session. Run '${cliName} setup' first.`);
+                console.error(`No active session. Run '${display} setup' first.`);
                 process.exit(2);
             }
 

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -6,6 +6,7 @@ import { Command } from 'commander';
 import { createCli, type Cli } from '../src/cli-builder';
 import type { CliOptions, CliContext, CommandRegistrar, DispatcherHandler, ApijackPlugin } from '../src/types';
 import { BasicAuthStrategy } from '../src/auth/basic';
+import { configUpdatePasswordAction } from '../src/commands/config/update-password/update-password';
 
 const coreManifest = JSON.parse(
     readFileSync(join(import.meta.dir, '..', 'package.json'), 'utf-8'),
@@ -436,6 +437,97 @@ describe('built-in commands', () => {
 
         expect(output).toContain('curl');
         expect(output).toContain('curl-with-creds');
+    });
+});
+
+describe('displayName threaded through subcommand registrar hints (#91)', () => {
+    let originalArgv: string[];
+    let originalExit: typeof process.exit;
+    let testConfigDir: string;
+    let configPath: string;
+
+    beforeEach(() => {
+        originalArgv = process.argv;
+        originalExit = process.exit;
+
+        (process as unknown as { exit: (code?: number) => void }).exit = (code?: number) => {
+            throw new Error(`process.exit(${code ?? 0})`);
+        };
+
+        testConfigDir = join(tmpdir(), 'apijack-displayname-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        mkdirSync(testConfigDir, { recursive: true });
+        configPath = join(testConfigDir, 'config.json');
+        // Empty-environments config — triggers the "no envs configured" hint paths.
+        writeFileSync(configPath, JSON.stringify({ active: '', environments: {} }));
+    });
+
+    afterEach(() => {
+        process.argv = originalArgv;
+        (process as unknown as { exit: typeof process.exit }).exit = originalExit;
+        rmSync(testConfigDir, { recursive: true, force: true });
+    });
+
+    test('config list: hint uses programName when set', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', programName: 'mycli', configPath }));
+
+        process.argv = ['node', 'mycli', 'config', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'mycli setup'");
+        expect(output).not.toContain("Run 'apijack setup'");
+    });
+
+    test('config list: hint falls back to cliName when programName omitted', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', configPath }));
+
+        process.argv = ['node', 'apijack', 'config', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'apijack setup'");
+    });
+
+    test('routine list: hint uses programName when set', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', programName: 'mycli', configPath }));
+
+        process.argv = ['node', 'mycli', 'routine', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'mycli routine init'");
+        expect(output).not.toContain("Run 'apijack routine init'");
+    });
+
+    test('routine list: hint falls back to cliName when programName omitted', async () => {
+        const cli = createCli(makeOptions({ name: 'apijack', configPath }));
+
+        process.argv = ['node', 'apijack', 'routine', 'list'];
+
+        const output = await captureOutput(() => cli.run());
+
+        expect(output).toContain("Run 'apijack routine init'");
+    });
+
+    test('configUpdatePasswordAction: throws with displayName when set', async () => {
+        await expect(configUpdatePasswordAction({
+            password: 'new',
+            loadConfig: async () => ({ active: '', environments: {} }),
+            save: async () => {},
+            cliName: 'apijack',
+            displayName: 'mycli',
+            saveOpts: {},
+        })).rejects.toThrow("Run 'mycli config import' first");
+    });
+
+    test('configUpdatePasswordAction: throws with cliName when displayName omitted', async () => {
+        await expect(configUpdatePasswordAction({
+            password: 'new',
+            loadConfig: async () => ({ active: '', environments: {} }),
+            save: async () => {},
+            cliName: 'apijack',
+            saveOpts: {},
+        })).rejects.toThrow("Run 'apijack config import' first");
     });
 });
 


### PR DESCRIPTION
Closes #91

Bug fix and minor automation cleanup since v1.12.1.

## 🐛 Fixes

- **displayName threaded through subcommand registrar hints** (#91) — `Run '<cli> ...'` strings in seven config / routine / update-password error paths now honor `programName` instead of always interpolating the identity `cliName`. Strategies that don't use `programName` see no behavior change.

## 🧹 Internal

- review-issue cron prompt now explicitly permits `set-review-label.sh` after a passing review — the previous "no handoffs" wording was over-broad and left passing PRs stuck on `review in progress` instead of moving to `first pass reviewed`.

---

Shipped via `scripts/ship.sh`.
