### PR TITLE
fix: thread programName through runRoutine for consistent branding (#99)

### DIFF
--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -21,6 +21,7 @@ import { getActiveEnvConfig } from './config';
 export interface StandaloneRunRoutineOptions extends RunRoutineOptions {
     cwd?: string;
     cliName?: string;
+    programName?: string;
 }
 
 export async function runRoutine(
@@ -146,6 +147,10 @@ export async function runRoutine(
 
     const cli = createCli({
         name: cliName,
+        // Mirror bin/apijack.ts: prefer explicit override, then project config, then cliName.
+        // Surfaces the project's brand in user-visible hints (e.g., the "No active env config.
+        // Run '<programName> setup' ..." error) emitted by createCli().
+        programName: opts.programName ?? projectConfig?.name ?? cliName,
         description: 'apijack',
         version: '0.0.0', // not relevant in programmatic mode
         specPath,

--- a/tests/run-routine.test.ts
+++ b/tests/run-routine.test.ts
@@ -78,6 +78,30 @@ export default async (args) => ({ echoed: args.msg });
         const result = await runRoutine('echo', { cwd: projectDir });
         expect(result.status).toBe('ok');
     });
+
+    test('uses projectConfig.name as programName in surfaced errors', async () => {
+        // Re-write project marker with a name; remove env config so the bootstrap surfaces
+        // the "No active env config. Run '<programName> setup' ..." error from createCli().
+        writeFileSync(join(projectDir, '.apijack.json'), JSON.stringify({ name: 'mybrand' }));
+        rmSync(join(projectDir, '.apijack', 'config.json'));
+
+        await expect(runRoutine('echo')).rejects.toThrow(/Run 'mybrand setup'/);
+    });
+
+    test('opts.programName overrides projectConfig.name in surfaced errors', async () => {
+        writeFileSync(join(projectDir, '.apijack.json'), JSON.stringify({ name: 'mybrand' }));
+        rmSync(join(projectDir, '.apijack', 'config.json'));
+
+        await expect(runRoutine('echo', { programName: 'override' }))
+            .rejects.toThrow(/Run 'override setup'/);
+    });
+
+    test('falls back to cliName when neither opts.programName nor projectConfig.name set', async () => {
+        // Project marker has no `name` field (default beforeEach state); remove env config.
+        rmSync(join(projectDir, '.apijack', 'config.json'));
+
+        await expect(runRoutine('echo')).rejects.toThrow(/Run 'apijack setup'/);
+    });
 });
 
 describe('runRoutine (standalone, no project marker — global config path)', () => {


### PR DESCRIPTION
Closes #99

## Summary

The standalone `runRoutine()` helper in `src/run-routine.ts` was constructing its internal `Cli` via `createCli({ name: cliName, ... })` without passing `programName`. As a result, any user-visible hint surfaced from a programmatic invocation (e.g., the "No active env config. Run 'apijack setup' ..." error) always read "apijack" — even when the project's `.apijack.json` defined a different brand name. This mirrors the fix already in place at `bin/apijack.ts:147`.

## What changes

- `src/run-routine.ts`: forward `programName: opts.programName ?? projectConfig?.name ?? cliName` into the `createCli` call. Same precedence as the bin entrypoint.
- `src/run-routine.ts`: extend `StandaloneRunRoutineOptions` with an optional `programName?: string` so callers can override the project name without touching `.apijack.json`.
- `tests/run-routine.test.ts`: add three tests that assert the resolved `programName` via the user-facing error string (`"Run '<name> setup'"`) emitted by `createCli()` when no active env config exists. This was the most direct user-facing assertion path — `cli` doesn't expose `programName` publicly, so reaching for the error hint matches the triage note's preferred approach.

```ts
const cli = createCli({
    name: cliName,
    programName: opts.programName ?? projectConfig?.name ?? cliName,
    // ...
});
```

## Acceptance criteria

- [x] `runRoutine()` honors `projectConfig?.name` for `programName` when project config is present
- [x] `runRoutine()` accepts an explicit `programName` override on `StandaloneRunRoutineOptions`
- [x] Unit test asserts an error surfaced from `runRoutine` uses the project-configured name
- [x] No behavior change when neither is set — falls back to `cliName`

## Test plan

- [x] `bun test` — 877 pass / 0 fail
- [x] `bun run lint` — 0 errors (108 pre-existing warnings)
- [x] New tests cover all 3 precedence branches (project name, explicit override, fallback to cliName)
