### PR TITLE
fix: emit steps[] entry for forEach non-array path and tag iterations with index (#100)

### DIFF
--- a/src/routine/executor.ts
+++ b/src/routine/executor.ts
@@ -21,6 +21,7 @@ export interface RoutineResultStep {
     status: 'ok' | 'failed' | 'skipped';
     output?: unknown;
     error?: string;
+    iteration?: { index: number; total: number };
 }
 
 export interface RoutineResult {
@@ -55,8 +56,17 @@ class RoutineExecutor {
     private stepsSkipped = 0;
     private stepsFailed = 0;
     private inIteration = false;
+    private currentIteration: { index: number; total: number } | null = null;
     private steps: RoutineResultStep[] = [];
     private namedOutput: Record<string, unknown> = {};
+
+    private pushStep(entry: RoutineResultStep): void {
+        if (this.currentIteration) {
+            entry.iteration = { ...this.currentIteration };
+        }
+
+        this.steps.push(entry);
+    }
 
     constructor(
         private dispatch: CommandDispatcher,
@@ -121,7 +131,7 @@ class RoutineExecutor {
 
             if (!evaluateCondition(step.condition, ctx)) {
                 this.stepsSkipped++;
-                this.steps.push({ name: step.name, status: 'skipped' });
+                this.pushStep({ name: step.name, status: 'skipped' });
 
                 if (this.options?.onStep && !this.inIteration)
                     this.options.onStep(step, i, steps.length);
@@ -183,6 +193,7 @@ class RoutineExecutor {
             }
 
             this.stepsSkipped++;
+            this.pushStep({ name: step.name, status: 'skipped' });
 
             return true;
         }
@@ -205,6 +216,7 @@ class RoutineExecutor {
 
         const asName = step.as || 'item';
         this.inIteration = true;
+        const previousIteration = this.currentIteration;
 
         for (let i = 0; i < items.length; i++) {
             if (this.options?.onIteration)
@@ -216,6 +228,8 @@ class RoutineExecutor {
                     totalSteps,
                 );
 
+            this.currentIteration = { index: i, total: items.length };
+
             const iterCtx: RoutineContext = {
                 ...ctx,
                 forEachItem: { name: asName, value: items[i] },
@@ -224,12 +238,14 @@ class RoutineExecutor {
 
             if (!ok && !step.continueOnError) {
                 this.inIteration = false;
+                this.currentIteration = previousIteration;
 
                 return false;
             }
         }
 
         this.inIteration = false;
+        this.currentIteration = previousIteration;
 
         if (this.options?.onIteration && !this.options.silent) process.stderr.write('\n');
 
@@ -284,7 +300,7 @@ class RoutineExecutor {
             if (step.output) ctx.stepOutputs.set(step.output, stepResult);
 
             this.stepsRun++;
-            this.steps.push({ name: step.name, status: 'ok', output: result });
+            this.pushStep({ name: step.name, status: 'ok', output: result });
 
             if (step.output) this.namedOutput[step.output] = result;
 
@@ -299,12 +315,19 @@ class RoutineExecutor {
                     stepResult.success = false;
                     stepResult.error = `Assertion failed: ${step.assert}`;
                     this.stepsFailed++;
-                    // overwrite the previously-pushed 'ok' with the failed entry
-                    this.steps[this.steps.length - 1] = {
+                    // overwrite the previously-pushed 'ok' with the failed entry,
+                    // preserving the iteration tag if any
+                    const overwrite: RoutineResultStep = {
                         name: step.name,
                         status: 'failed',
                         error: stepResult.error,
                     };
+
+                    if (this.currentIteration) {
+                        overwrite.iteration = { ...this.currentIteration };
+                    }
+
+                    this.steps[this.steps.length - 1] = overwrite;
 
                     if (step.output) delete this.namedOutput[step.output];
 
@@ -340,7 +363,7 @@ class RoutineExecutor {
                 console.error(`Step "${step.name}" failed: ${errMsg}`);
             }
 
-            this.steps.push({ name: step.name, status: 'failed', error: errMsg });
+            this.pushStep({ name: step.name, status: 'failed', error: errMsg });
 
             if (!step.continueOnError) return false;
         }

--- a/tests/routine/executor.test.ts
+++ b/tests/routine/executor.test.ts
@@ -603,6 +603,201 @@ describe('executeRoutine', () => {
         }
     });
 
+    test('forEach on non-array emits a skipped steps[] entry (invariant: stepsSkipped == steps.filter(skipped))', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$not-an-array',
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { value: '$item' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher, calls } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher, { silent: true });
+
+        expect(result.success).toBe(true);
+        expect(result.stepsSkipped).toBe(1);
+        expect(calls.length).toBe(0);
+        expect(result.steps.length).toBe(1);
+        expect(result.steps[0]!).toMatchObject({ name: 'loop', status: 'skipped' });
+        // Invariant from issue #100
+        expect(result.stepsSkipped).toBe(
+            result.steps.filter(s => s.status === 'skipped').length,
+        );
+    });
+
+    test('forEach iteration entries are tagged with iteration index and total', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b', 'c'] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { value: '$item' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.steps.length).toBe(3);
+        expect(result.steps[0]!).toMatchObject({
+            name: 'inner',
+            status: 'ok',
+            iteration: { index: 0, total: 3 },
+        });
+        expect(result.steps[1]!).toMatchObject({
+            name: 'inner',
+            status: 'ok',
+            iteration: { index: 1, total: 3 },
+        });
+        expect(result.steps[2]!).toMatchObject({
+            name: 'inner',
+            status: 'ok',
+            iteration: { index: 2, total: 3 },
+        });
+        // Iteration entries are distinguishable
+        const iterations = result.steps.map(s => s.iteration?.index);
+        expect(iterations).toEqual([0, 1, 2]);
+    });
+
+    test('range iteration entries are tagged with iteration index and total', async () => {
+        const routine = makeRoutine({
+            steps: [
+                {
+                    name: 'loop',
+                    range: [1, 3] as [number, number],
+                    as: 'n',
+                    steps: [
+                        { name: 'inner', command: 'process', args: { num: '$n' } },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.steps.length).toBe(3);
+        expect(result.steps[0]!.iteration).toEqual({ index: 0, total: 3 });
+        expect(result.steps[1]!.iteration).toEqual({ index: 1, total: 3 });
+        expect(result.steps[2]!.iteration).toEqual({ index: 2, total: 3 });
+    });
+
+    test('skipped step inside forEach iteration carries the iteration tag', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b'], gate: false },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    steps: [
+                        { name: 'inner', command: 'process', condition: '$gate' },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.stepsSkipped).toBe(2);
+        expect(result.steps.length).toBe(2);
+        expect(result.steps[0]!).toMatchObject({
+            name: 'inner',
+            status: 'skipped',
+            iteration: { index: 0, total: 2 },
+        });
+        expect(result.steps[1]!).toMatchObject({
+            name: 'inner',
+            status: 'skipped',
+            iteration: { index: 1, total: 2 },
+        });
+        // Invariant
+        expect(result.stepsSkipped).toBe(
+            result.steps.filter(s => s.status === 'skipped').length,
+        );
+    });
+
+    test('assertion failure inside forEach iteration preserves the iteration tag', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b'] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    continueOnError: true,
+                    steps: [
+                        {
+                            name: 'inner',
+                            command: 'cmd',
+                            output: 'r',
+                            assert: '$r.value == "never"',
+                        },
+                    ],
+                },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher({ cmd: { value: 'actual' } });
+        const result = await executeRoutine(routine, {}, dispatcher, { silent: true });
+
+        expect(result.steps.length).toBe(2);
+        expect(result.steps[0]!).toMatchObject({
+            name: 'inner',
+            status: 'failed',
+            iteration: { index: 0, total: 2 },
+        });
+        expect(result.steps[1]!).toMatchObject({
+            name: 'inner',
+            status: 'failed',
+            iteration: { index: 1, total: 2 },
+        });
+    });
+
+    test('non-iteration steps do not carry an iteration tag', async () => {
+        const routine = makeRoutine({
+            steps: [
+                { name: 'a', command: 'cmd-a' },
+                { name: 'b', command: 'cmd-b' },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.steps[0]!.iteration).toBeUndefined();
+        expect(result.steps[1]!.iteration).toBeUndefined();
+    });
+
+    test('steps after a forEach do not carry an iteration tag', async () => {
+        const routine = makeRoutine({
+            variables: { items: ['a', 'b'] },
+            steps: [
+                {
+                    name: 'loop',
+                    forEach: '$items',
+                    as: 'item',
+                    steps: [{ name: 'inner', command: 'cmd-inner' }],
+                },
+                { name: 'after', command: 'cmd-after' },
+            ],
+        });
+        const { dispatcher } = makeMockDispatcher();
+        const result = await executeRoutine(routine, {}, dispatcher);
+
+        expect(result.steps.length).toBe(3);
+        expect(result.steps[0]!.iteration).toEqual({ index: 0, total: 2 });
+        expect(result.steps[1]!.iteration).toEqual({ index: 1, total: 2 });
+        expect(result.steps[2]!).toMatchObject({ name: 'after', status: 'ok' });
+        expect(result.steps[2]!.iteration).toBeUndefined();
+    });
+
     test('result includes status, output, steps, and durationMs fields', async () => {
         const routine = makeRoutine({
             steps: [


### PR DESCRIPTION
Closes #100

## Summary

Fixes two related defects in `RoutineResult` reporting around `forEach` (and by extension `range:`) — both surfaced by the bot review on #85 but never tracked separately. Both made `result.steps[]` an unreliable mirror of what actually executed for any consumer of the programmatic `runRoutine()` API or the `--json` CLI mode introduced in v1.11.0.

1. **Non-array `forEach` skip emitted no `steps[]` entry** — `stepsSkipped` was incremented but the array was not, breaking the invariant that the condition-skip path maintains.
2. **`forEach` iteration entries were indistinguishable** — N inner-step entries shared the same `name` with no marker linking them to the iteration that produced them.

## What changes

### `src/routine/executor.ts`

- **New optional field on `RoutineResultStep`**: `iteration?: { index: number; total: number }`. Additive — backward compatible.
- **New private `pushStep()` helper**: stamps `iteration` automatically when called from inside an iteration. All four `this.steps.push(...)` sites now go through it.
- **Iteration tracking via `currentIteration`**: set per iteration in `runIteration` (which is the shared engine for both `forEach` and `range:`). Save/restore around the loop so nested iterations work too.
- **Non-array `forEach` path** now emits `{ name: step.name, status: 'skipped' }` — mirroring the condition-skip path two-line pattern.
- **Assert-fail overwrite path** (`executor.ts:303-307`) preserves the iteration tag when rewriting the last entry from `ok` to `failed`.

### `tests/routine/executor.test.ts`

Seven new tests:

- non-array `forEach` produces a skipped `steps[]` entry and the `stepsSkipped == steps.filter(skipped).length` invariant holds
- `forEach` iteration entries tagged with `{ index, total }`
- `range:` iteration entries tagged the same way (shared engine)
- skipped step inside a `forEach` iteration carries the iteration tag
- assertion failure inside a `forEach` iteration preserves the iteration tag
- non-iteration steps do not carry an iteration tag (no leakage)
- steps after a `forEach` block do not carry an iteration tag (save/restore works)

Iteration `index` is 0-based to match standard array indexing in structured data; `total` is the array length. The user-facing `onIteration` callback continues to pass `i + 1` (1-based) for terminal display — that surface is unchanged.

## Acceptance criteria

- [x] `result.stepsSkipped === result.steps.filter(s => s.status === 'skipped').length` always holds
- [x] For an N-iteration `forEach`, the consumer can identify which `steps[]` entry came from which iteration (via `step.iteration.index`)
- [x] Unit test: `forEach: '$not-an-array'` → `stepsSkipped === 1` AND a `steps[]` entry with `status: 'skipped'` exists
- [x] Unit test: `forEach: ['a','b','c']` with one inner step → produced entries are distinguishable by iteration

## Test plan

- [x] `bun test` — 881 pass / 0 fail
- [x] `bun run lint` — 0 errors (108 pre-existing warnings)
