### PR TITLE
feat: add dropBaseHeaders flag to SessionAuthConfig (#106)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,20 @@ new SessionAuthStrategy(new BasicAuthStrategy(), {
 
 When the generated client receives a status in `refreshOn`, it calls the wired refresh callback — which invalidates the cached session and re-bootstraps `/session` — then retries the original request once. Capped at one retry. Strategies that don't use `/session` are unaffected (the field is ignored).
 
+### Dropping base-strategy headers post-handshake (opt-in)
+
+By default, `SessionAuthStrategy` mirrors the wrapped base strategy's headers (e.g. `Authorization: Basic …` from `BasicAuthStrategy`) onto every post-handshake API request. For stateful backends — Spring Security with 2FA, for instance — re-presenting the base credentials on every call re-triggers the auth filter and either re-prompts, 401s, or invalidates the active session. Opt in to `dropBaseHeaders` to strip them:
+
+```ts
+new SessionAuthStrategy(new BasicAuthStrategy(), {
+  session: { endpoint: '/session' },
+  cookies: { extract: ['SESSION'], applyTo: ['POST', 'PUT', 'DELETE'] },
+  dropBaseHeaders: true,
+});
+```
+
+Base headers are still sent to the `/session` endpoint itself (handshake works as before); only post-handshake API calls carry just cookies + any `headerMirror` headers. Default is `false` for backwards compatibility.
+
 ## Project Extensions
 
 The `.apijack/` directory at a project root is auto-loaded when the CLI runs inside that project:

--- a/src/auth/session-auth.ts
+++ b/src/auth/session-auth.ts
@@ -69,7 +69,7 @@ export class SessionAuthStrategy implements AuthStrategy {
         const cookies = { ...challengeCookies, ...this.extractCookies(res) };
 
         return {
-            headers: baseSession.headers,
+            headers: this.config.dropBaseHeaders ? {} : baseSession.headers,
             cookies,
             expiresAt: baseSession.expiresAt,
             data: baseSession.data,
@@ -86,7 +86,7 @@ export class SessionAuthStrategy implements AuthStrategy {
         if (!baseRestored) return null;
 
         return {
-            headers: baseRestored.headers,
+            headers: this.config.dropBaseHeaders ? {} : baseRestored.headers,
             cookies: cached.cookies,
             expiresAt: baseRestored.expiresAt,
             data: baseRestored.data,

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -38,6 +38,19 @@ export interface SessionAuthConfig {
      * which re-bootstraps `/session`, then retries the original request once.
      */
     refreshOn?: number[];
+    /**
+     * When true, drops the base strategy's headers (e.g. `Authorization: Basic …`) from the
+     * returned `AuthSession` after the `/session` handshake completes. The base headers are
+     * still sent to the session endpoint itself; only post-handshake API calls carry just
+     * cookies + `headerMirror` headers. Required for stateful backends (e.g. Spring Security
+     * with 2FA) where re-presenting the base credentials on every call re-triggers auth filters
+     * and invalidates the active session.
+     *
+     * Drops *all* headers contributed by the base strategy, not just `Authorization`. If a
+     * custom base strategy contributes non-auth headers you need to keep, write a custom
+     * `AuthStrategy` instead of using this flag.
+     */
+    dropBaseHeaders?: boolean;
     /** Called when the session endpoint returns a non-OK response. Return query params to retry, or null to give up. */
     onChallenge?: (status: number, body: string) => Promise<Record<string, string> | null>;
 }

--- a/tests/auth/session-auth.test.ts
+++ b/tests/auth/session-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { SessionAuthStrategy } from '../../src/auth/session-auth';
+import { resolveRequestHeaders } from '../../src/auth/resolve-headers';
 import type { AuthStrategy, AuthSession, ResolvedAuth, SessionAuthConfig } from '../../src/auth/types';
 
 const resolvedAuth: ResolvedAuth = {
@@ -196,5 +197,101 @@ describe('SessionAuthStrategy', () => {
         const refreshed = await strategy.refresh!(oldSession, resolvedAuth);
         expect(refreshed.cookies!.SESSION).toBe('sess123');
         expect(fetchMock.mockFn).toHaveBeenCalledTimes(1);
+    });
+
+    describe('dropBaseHeaders', () => {
+        const dropConfig: SessionAuthConfig = { ...sessionConfig, dropBaseHeaders: true };
+
+        test('authenticate() omits base headers from returned session when enabled', async () => {
+            const base = makeBaseStrategy();
+            const session = await new SessionAuthStrategy(base, dropConfig).authenticate(resolvedAuth);
+            expect(session.headers).toEqual({});
+            expect(session.headers.Authorization).toBeUndefined();
+        });
+
+        test('authenticate() still sends base headers to the session endpoint when enabled', async () => {
+            const base = makeBaseStrategy();
+            await new SessionAuthStrategy(base, dropConfig).authenticate(resolvedAuth);
+            const fetchInit = (fetchMock.mockFn as any).mock.calls[0][1] as RequestInit;
+            expect(fetchInit.headers).toEqual({ Authorization: 'Basic YWRtaW46c2VjcmV0' });
+        });
+
+        test('authenticate() preserves cookies when base headers are dropped', async () => {
+            const base = makeBaseStrategy();
+            const session = await new SessionAuthStrategy(base, dropConfig).authenticate(resolvedAuth);
+            expect(session.cookies!.SESSION).toBe('sess123');
+            expect(session.cookies!['XSRF-TOKEN']).toBe('xsrf456');
+        });
+
+        test('restore() omits base headers from returned session when enabled', async () => {
+            const base = makeBaseStrategy();
+            const cached: AuthSession = {
+                headers: { Authorization: 'Basic cached' },
+                cookies: { 'SESSION': 'cached_sess', 'XSRF-TOKEN': 'cached_xsrf' },
+            };
+            const result = await new SessionAuthStrategy(base, dropConfig).restore(cached, resolvedAuth);
+            expect(result).not.toBeNull();
+            expect(result!.headers).toEqual({});
+            expect(result!.cookies!.SESSION).toBe('cached_sess');
+        });
+
+        test('flag is opt-in: default config keeps base headers', async () => {
+            const base = makeBaseStrategy();
+            const session = await new SessionAuthStrategy(base, sessionConfig).authenticate(resolvedAuth);
+            expect(session.headers.Authorization).toBe('Basic YWRtaW46c2VjcmV0');
+        });
+
+        test('onChallenge retry sends base headers but returned session drops them', async () => {
+            // First /session returns 401; onChallenge supplies a 2FA token; retry succeeds.
+            // With dropBaseHeaders: true, the retry must still send Authorization (handshake auth),
+            // but the AuthSession returned to the caller must not contain it.
+            const originalFetch = globalThis.fetch;
+            let callCount = 0;
+            const fetchMock = mock(async (_url: string | URL | Request, _init?: RequestInit) => {
+                callCount++;
+
+                if (callCount === 1) {
+                    return new Response('2FA required', { status: 401 });
+                }
+
+                return new Response('{}', {
+                    status: 200,
+                    headers: [
+                        ['Set-Cookie', 'SESSION=sess123; Path=/'],
+                        ['Set-Cookie', 'XSRF-TOKEN=xsrf456; Path=/'],
+                    ],
+                });
+            });
+            globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+            try {
+                const base = makeBaseStrategy();
+                const cfg: SessionAuthConfig = {
+                    ...dropConfig,
+                    onChallenge: async () => ({ otp: '123456' }),
+                };
+                const session = await new SessionAuthStrategy(base, cfg).authenticate(resolvedAuth);
+
+                expect(callCount).toBe(2);
+                const retryInit = (fetchMock as any).mock.calls[1][1] as RequestInit;
+                expect((retryInit.headers as Record<string, string>).Authorization).toBe('Basic YWRtaW46c2VjcmV0');
+                expect(session.headers).toEqual({});
+                expect(session.cookies!.SESSION).toBe('sess123');
+            } finally {
+                globalThis.fetch = originalFetch;
+            }
+        });
+
+        test('downstream resolveRequestHeaders produces clean request headers', async () => {
+            // End-to-end: from /session handshake through resolveRequestHeaders, the actual
+            // headers shipped on a POST request should be Cookie + headerMirror only.
+            const base = makeBaseStrategy();
+            const session = await new SessionAuthStrategy(base, dropConfig).authenticate(resolvedAuth);
+            const requestHeaders = resolveRequestHeaders(session, dropConfig, 'POST');
+
+            expect(requestHeaders.Authorization).toBeUndefined();
+            expect(requestHeaders.Cookie).toBe('SESSION=sess123; XSRF-TOKEN=xsrf456');
+            expect(requestHeaders['X-XSRF-TOKEN']).toBe('xsrf456');
+        });
     });
 });


### PR DESCRIPTION
Closes #106

## Summary

Adds an opt-in `dropBaseHeaders` flag to `SessionAuthConfig`. When enabled, `SessionAuthStrategy` strips the wrapped base strategy's headers (e.g. `Authorization: Basic …`) from the returned `AuthSession` after the `/session` handshake completes. Base headers are still sent to the session endpoint itself; only post-handshake API calls carry just cookies + `headerMirror` headers.

The motivating case is stateful backends like Spring Security with 2FA: re-presenting the base credentials on every API call re-triggers the auth filter and either re-prompts for 2FA, 401s, or invalidates the active session. Today the only workaround is to write a custom `AuthStrategy` from scratch — which sacrifices `refreshOn`, `headerMirror`, and `onChallenge` support.

Default behavior is unchanged.

## What changes

### Public API

- `SessionAuthConfig.dropBaseHeaders?: boolean` — new optional flag (`src/auth/types.ts`).

### Behavior

`SessionAuthStrategy` (`src/auth/session-auth.ts`):

- `authenticate()` returns `headers: this.config.dropBaseHeaders ? {} : baseSession.headers` after a successful handshake. The `fetch(/session)` call itself still uses `baseSession.headers`, so handshake auth (Basic, etc.) works unchanged.
- `restore()` mirrors the same logic — otherwise a process restart with a cached session on disk would re-introduce `Authorization` and undo the fix.
- `onChallenge` retry path is unaffected: retries inside `authenticate()` still build `retryHeaders` from `baseSession.headers`, so 2FA flows continue to work; only the final returned session is filtered.

```yaml
# example consumer config
new SessionAuthStrategy(new BasicAuthStrategy(), {
  session: { endpoint: '/session' },
  cookies: { extract: ['SESSION'], applyTo: ['POST', 'PUT', 'DELETE'] },
  dropBaseHeaders: true,
});
```

### Docs

`CLAUDE.md` — new "Dropping base-strategy headers post-handshake (opt-in)" subsection under Authentication Strategies, with a copy-pasteable example and an explicit note that the handshake itself still sends base headers.

### Tests

`tests/auth/session-auth.test.ts` — new `describe('dropBaseHeaders', …)` block with 7 tests covering:

- Returned session omits base headers when enabled
- `/session` handshake request still sends base headers when enabled
- Cookies preserved when base headers are dropped
- `restore()` omits base headers from returned session when enabled
- Default config (flag absent) keeps base headers — backwards-compat pin
- `onChallenge` retry sends base headers but returned session drops them — pins the 2FA path
- Downstream `resolveRequestHeaders` produces `Cookie` + `headerMirror` only — end-to-end pin

## Acceptance criteria

- [x] `SessionAuthConfig` exposes a documented mechanism for dropping base-strategy headers after handshake (`dropBaseHeaders: true`).
- [x] Integration test: with `BasicAuthStrategy` base + the new flag, post-handshake `AuthSession.headers` does NOT include `Authorization`.
- [x] Default behavior unchanged for backwards compatibility.
- [x] Brief note in auth strategy docs covering when to enable.

## Test plan

- [x] `bun test` — 892 pass / 0 fail
- [x] `bun run lint` — 0 errors (109 pre-existing warnings)
- [x] Self-review by code-reviewer subagent — Important issue raised (untested `onChallenge` retry path under flag) addressed; Minor TSDoc clarification applied.
