### PR TITLE
docs: link Building-a-CLI, Session-Auth, and Project-Mode in README (#111)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ apijack supports pre-built plugins as standalone npm packages for common utiliti
 Full documentation is available on the [wiki](https://github.com/normalled/apijack/wiki):
 
 - [Quickstart](https://github.com/normalled/apijack/wiki/Quickstart)
+- [Building a CLI](https://github.com/normalled/apijack/wiki/Building-a-CLI)
 - [Writing Routines](https://github.com/normalled/apijack/wiki/Writing-Routines)
 - [Authentication Strategies](https://github.com/normalled/apijack/wiki/Authentication-Strategies)
+- [Session Auth](https://github.com/normalled/apijack/wiki/Session-Auth)
+- [Project Mode](https://github.com/normalled/apijack/wiki/Project-Mode)
 - [CLI Command Reference](https://github.com/normalled/apijack/wiki/CLI-Command-Reference)
 - [Routine YAML Schema](https://github.com/normalled/apijack/wiki/Routine-YAML-Schema)
 


### PR DESCRIPTION
Follow-up to #111.

## Summary

The wiki refresh in #111 (already shipped on `apijack.wiki`) brought `Building-a-CLI`, `Project-Mode`, and `Session-Auth` up to v1.13.0. This adds those three pages to the README's Documentation section so readers landing on the README can find them — most importantly `Session-Auth`, which is now where `dropBaseHeaders` is documented.

## What changes

`README.md` — Documentation list goes from 5 entries to 8:

```diff
 - [Quickstart](https://github.com/normalled/apijack/wiki/Quickstart)
+- [Building a CLI](https://github.com/normalled/apijack/wiki/Building-a-CLI)
 - [Writing Routines](https://github.com/normalled/apijack/wiki/Writing-Routines)
 - [Authentication Strategies](https://github.com/normalled/apijack/wiki/Authentication-Strategies)
+- [Session Auth](https://github.com/normalled/apijack/wiki/Session-Auth)
+- [Project Mode](https://github.com/normalled/apijack/wiki/Project-Mode)
 - [CLI Command Reference](https://github.com/normalled/apijack/wiki/CLI-Command-Reference)
 - [Routine YAML Schema](https://github.com/normalled/apijack/wiki/Routine-YAML-Schema)
```

No code changes. No new content in the README body — the existing inline references to "Building a CLI" (under "As a Framework") and the auth/project-mode features list already exist; this just makes the Documentation section parallel.

## Acceptance criteria

- [x] `Building-a-CLI`, `Session-Auth`, and `Project-Mode` appear in README Documentation list
- [x] No regressions to existing links
- [x] Order keeps related entries grouped (auth pages adjacent; project mode near the bottom)

## Test plan

- [x] `bun run lint` — 0 errors (110 pre-existing warnings unchanged)
- [x] Visual scan of rendered README — all wiki links point to live pages

No spec doc; this is a small follow-up to a closed issue.
