### PR TITLE
v1.14.1: README "What is apijack?" intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,33 @@ Jack into any OpenAPI spec and rip a full-featured CLI with AI-agentic workflow 
 [![e2e](https://github.com/normalled/apijack/actions/workflows/e2e.yml/badge.svg)](https://github.com/normalled/apijack/actions/workflows/e2e.yml)
 [![buy me a coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-orange?logo=buy-me-a-coffee)](https://www.buymeacoffee.com/garreta)
 
+## What is `apijack`?
+
+`apijack` turns any API into a CLI.
+
+```
+GET /api/pets
+GET /api/pets/{id}
+GET /api/owners
+GET /api/owners/{id}
+```
+
+becomes a command tree that mirrors your API:
+
+```
+apijack
+├── pets
+│   ├── list
+│   └── get <id>
+└── owners
+    ├── list
+    └── get <id>
+```
+
+```bash
+$ apijack pets get 25
+```
+
 ## Getting Started
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.14.0",
+  "version": "1.14.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adds a "What is `apijack`?" section at the top of the README with a worked example showing how an OpenAPI spec collapses into a CLI command tree — using the real `apijack-petstore-example` operationIds so anyone can verify against `apijack --help`.

---

Shipped via `scripts/ship.sh`.
