### PR TITLE
fix: escape strings and sanitize identifiers in codegen (#115)

### DIFF
--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -213,8 +213,14 @@ export function createCli(options: CliOptions): Cli {
                 const clientMod = await import(resolve(generatedDir, 'client'));
                 ApiClientClass = clientMod.ApiClient;
             }
-        } catch {
-            // Generated commands not available — routines that don't dispatch to API methods still work.
+        } catch (err) {
+            // A genuinely-absent module is expected before the first `generate`
+            // (routines that don't dispatch to API methods still work) — stay
+            // silent. A module that exists but fails to import (e.g. a codegen
+            // syntax error) is a real problem — surface it to stderr.
+            if ((err as { code?: string }).code !== 'ERR_MODULE_NOT_FOUND') {
+                console.warn(`[apijack] Generated module failed to import: ${(err as Error).message}`);
+            }
         }
 
         // 5. Build CliContext with lazy session.
@@ -573,8 +579,13 @@ export function createCli(options: CliOptions): Cli {
                     const clientMod = await import(resolve(generatedDir, 'client'));
                     ApiClientClass = clientMod.ApiClient;
                 }
-            } catch {
-                // Generated commands not available — consumer hasn't run `generate` yet
+            } catch (err) {
+                // A genuinely-absent module is expected before the consumer runs
+                // `generate` — stay silent. A module that exists but fails to
+                // import (e.g. a codegen syntax error) is a real problem — surface it.
+                if ((err as { code?: string }).code !== 'ERR_MODULE_NOT_FOUND') {
+                    console.warn(`[apijack] Generated module failed to import: ${(err as Error).message}`);
+                }
             }
 
             // 7. Detect request-preview output modes

--- a/src/codegen/client.ts
+++ b/src/codegen/client.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { schemaToTsType, refToName, resolveType, resolveResponseType } from './util';
+import { schemaToTsType, refToName, resolveType, resolveResponseType, sanitizeIdentifier } from './util';
 
 /**
  * Generate an ApiClient class from OpenAPI paths.
@@ -147,22 +147,24 @@ export function generateClient(
                 }
             }
 
-            // Emit JSDoc
-            if (docLines.length === 1) {
-                methodLines.push(`  /** ${docLines[0]} */`);
-            } else {
-                methodLines.push(`  /** ${docLines[0]}`);
+            // Emit JSDoc — escape `*/` so a description doesn't close the comment early
+            const safeDocLines = docLines.map(l => l.replace(/\*\//g, '*\\/'));
 
-                for (let i = 1; i < docLines.length; i++) {
-                    if (i === docLines.length - 1) {
-                        methodLines.push(`   * ${docLines[i]} */`);
+            if (safeDocLines.length === 1) {
+                methodLines.push(`  /** ${safeDocLines[0]} */`);
+            } else {
+                methodLines.push(`  /** ${safeDocLines[0]}`);
+
+                for (let i = 1; i < safeDocLines.length; i++) {
+                    if (i === safeDocLines.length - 1) {
+                        methodLines.push(`   * ${safeDocLines[i]} */`);
                     } else {
-                        methodLines.push(`   * ${docLines[i]}`);
+                        methodLines.push(`   * ${safeDocLines[i]}`);
                     }
                 }
             }
 
-            methodLines.push(`  async ${op.operationId}(${args.join(', ')}): Promise<${returnType}> {`);
+            methodLines.push(`  async ${sanitizeIdentifier(op.operationId)}(${args.join(', ')}): Promise<${returnType}> {`);
             methodLines.push(`    return this.request("${method.toUpperCase()}", ${pathTemplate}${optsArg}) as Promise<${returnType}>;`);
             methodLines.push('  }');
             methodLines.push('');

--- a/src/codegen/command-map.ts
+++ b/src/codegen/command-map.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { normalizeTag, resolveSchemaProps } from './util';
+import { normalizeTag, resolveSchemaProps, sanitizeIdentifier } from './util';
 
 /**
  * Generate a command map that maps CLI command paths to their
@@ -138,12 +138,15 @@ export function generateCommandMap(
                         ? `${groupName} ${cmdName}`
                         : `${groupName} ${resourceName} ${cmdName}`;
 
-                const descPart = cmd.summary ? `, description: "${cmd.summary.replace(/"/g, '\\"')}"` : '';
+                const descPart = cmd.summary ? `, description: ${JSON.stringify(cmd.summary)}` : '';
                 const bodyPart = cmd.bodyFields.length > 0
                     ? `, bodyFields: ${JSON.stringify(cmd.bodyFields)}`
                     : '';
+                // Sanitize identically to the client method name so the
+                // dispatcher's client[operationId] lookup resolves at runtime.
+                const methodName = sanitizeIdentifier(cmd.operationId);
                 entries.push(
-                    `  "${cmdPath}": { operationId: "${cmd.operationId}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
+                    `  "${cmdPath}": { operationId: "${methodName}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
                 );
             }
         }

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -9,6 +9,7 @@ import {
     normalizeTag,
     resolveSchemaProps,
     sanitizeVar,
+    sanitizeIdentifier,
     capitalize,
 } from './util';
 
@@ -187,6 +188,9 @@ export function generateCommands(
             const verbSeen = new Map<string, number>();
 
             for (const cmd of cmds) {
+                // Sanitized operationId — used as the client method name and as a
+                // local variable name; must match the client emitter and command-map.
+                const methodName = sanitizeIdentifier(cmd.operationId);
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
 
@@ -215,7 +219,7 @@ export function generateCommands(
                 // Commands with variant props need a variable reference for configureHelp
                 if (hasVariantProps) {
                     lines.push(
-                        `  const _${cmd.operationId} = ${parent}`,
+                        `  const _${methodName} = ${parent}`,
                     );
                 } else {
                     lines.push(`  ${parent}`);
@@ -234,7 +238,7 @@ export function generateCommands(
                 }
 
                 lines.push(
-                    `    .description("${cmdDesc.replace(/"/g, '\\"')}${arrayNote} (use -o routine-step to export as YAML)")`,
+                    `    .description(${JSON.stringify(`${cmdDesc}${arrayNote} (use -o routine-step to export as YAML)`)})`,
                 );
 
                 for (const qp of cmd.queryParams) {
@@ -248,7 +252,7 @@ export function generateCommands(
                         ? `${qp.description}${qpEnum}${qpFormat}${qpDefault}${qpStyle}`
                         : `${qp.name}${qpEnum}${qpFormat}${qpDefault}${qpStyle}`;
                     lines.push(
-                        `    .option("--${qp.name} <${qp.name}>", "${qpDesc.replace(/"/g, '\\"')}")`,
+                        `    .option("--${qp.name} <${qp.name}>", ${JSON.stringify(qpDesc)})`,
                     );
                 }
 
@@ -278,20 +282,19 @@ export function generateCommands(
                             const variantTag = bp.variant
                                 ? ` (${bp.variant})`
                                 : '';
-                            const escapedDesc = desc.replace(/"/g, '\\"');
 
                             if (bp.variant) {
                                 // Variant-specific: hidden by default, shown with -V
                                 lines.push(
-                                    `    .addOption(new Option("--${bp.cliFlag} <value>", "${escapedDesc}${variantTag}").hideHelp())`,
+                                    `    .addOption(new Option("--${bp.cliFlag} <value>", ${JSON.stringify(`${desc}${variantTag}`)}).hideHelp())`,
                                 );
                             } else if (bp.required) {
                                 lines.push(
-                                    `    .requiredOption("--${bp.cliFlag} <value>", "${escapedDesc} (required)")`,
+                                    `    .requiredOption("--${bp.cliFlag} <value>", ${JSON.stringify(`${desc} (required)`)})`,
                                 );
                             } else {
                                 lines.push(
-                                    `    .option("--${bp.cliFlag} <value>", "${escapedDesc}")`,
+                                    `    .option("--${bp.cliFlag} <value>", ${JSON.stringify(desc)})`,
                                 );
                             }
                         }
@@ -380,14 +383,14 @@ export function generateCommands(
                 }
 
                 lines.push(
-                    `      const result = await client.${cmd.operationId}(${callArgs.join(', ')});`,
+                    `      const result = await client.${methodName}(${callArgs.join(', ')});`,
                 );
                 lines.push('      onResult(result);');
                 lines.push('    });');
 
                 // For commands with variant props, configure help to show hidden options with --verbose
                 if (hasVariantProps) {
-                    lines.push(`  _${cmd.operationId}.configureHelp({`);
+                    lines.push(`  _${methodName}.configureHelp({`);
                     lines.push('    visibleOptions: (cmd) => {');
                     lines.push(
                         '      if (process.argv.includes("-V")) {',

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -1,5 +1,5 @@
 import type { OpenApiSchema } from './openapi-types';
-import { resolveType, refToName, buildJsDoc, sanitizeTypeName } from './util';
+import { resolveType, refToName, buildJsDoc, sanitizeTypeName, emitKey } from './util';
 
 /**
  * Generate TypeScript type definitions from OpenAPI component schemas.
@@ -77,7 +77,7 @@ export function generateTypes(
                     const propDoc = buildJsDoc(propSchema, '  ');
                     lines.push(...propDoc);
                     const optional = requiredSet.has(propName) ? '' : '?';
-                    lines.push(`  ${propName}${optional}: ${tsType};`);
+                    lines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
                 }
             }
 
@@ -134,7 +134,7 @@ export function generateTypes(
                         innerLines.push(...propDoc);
                         const tsType = resolveType(propSchema, allSchemas, 0);
                         const optional = partRequired.has(propName) ? '' : '?';
-                        innerLines.push(`  ${propName}${optional}: ${tsType};`);
+                        innerLines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
                     }
 
                     innerLines.push('}');

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -563,6 +563,10 @@ export function emitKey(name: string): string {
  * Replace non-alphanumeric characters with underscores for safe variable names.
  * Also guards against a leading digit or reserved word producing an invalid
  * identifier (e.g. an untagged operation grouped under `default`).
+ *
+ * Intentionally stricter than {@link sanitizeIdentifier}: this collapses `$`
+ * to `_` as well, since it names group/resource locals derived from CLI tags
+ * rather than spec operationIds.
  */
 export function sanitizeVar(name: string): string {
     const base = name.replace(/[^a-zA-Z0-9]/g, '_');

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -137,7 +137,7 @@ export function resolveType(
                 innerLines.push(...propDoc);
                 const tsType = resolveType(propSchema, schemas, depth + 1, visited);
                 const optional = requiredSet.has(propName) ? '' : '?';
-                innerLines.push(`  ${propName}${optional}: ${tsType};`);
+                innerLines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
             }
 
             // patternProperties inside inline objects
@@ -522,10 +522,56 @@ export function resolveSchemaProps(
 }
 
 /**
+ * Reserved words that cannot be used as bare JavaScript identifiers.
+ * Includes keywords, future reserved words, and literals.
+ */
+const RESERVED_WORDS = new Set([
+    'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
+    'default', 'delete', 'do', 'else', 'enum', 'export', 'extends', 'false',
+    'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'new',
+    'null', 'return', 'super', 'switch', 'this', 'throw', 'true', 'try',
+    'typeof', 'var', 'void', 'while', 'with', 'yield', 'let', 'static',
+    'implements', 'interface', 'package', 'private', 'protected', 'public',
+    'await',
+]);
+
+/**
+ * Sanitize an arbitrary name (operationId, tag, etc.) into a valid JS
+ * identifier: non-identifier characters become underscores, and a leading
+ * digit or a reserved word is prefixed with `_`. Deterministic so the same
+ * input always yields the same identifier across emission sites.
+ */
+export function sanitizeIdentifier(name: string): string {
+    let id = name.replace(/[^A-Za-z0-9_$]/g, '_');
+
+    if (/^[0-9]/.test(id) || RESERVED_WORDS.has(id)) {
+        id = `_${id}`;
+    }
+
+    return id;
+}
+
+/**
+ * Emit an object property key: return it as-is when it is a valid JS
+ * identifier, otherwise quote it via JSON.stringify (e.g. "16x16").
+ */
+export function emitKey(name: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+/**
  * Replace non-alphanumeric characters with underscores for safe variable names.
+ * Also guards against a leading digit or reserved word producing an invalid
+ * identifier (e.g. an untagged operation grouped under `default`).
  */
 export function sanitizeVar(name: string): string {
-    return name.replace(/[^a-zA-Z0-9]/g, '_');
+    const base = name.replace(/[^a-zA-Z0-9]/g, '_');
+
+    if (/^[0-9]/.test(base) || RESERVED_WORDS.has(base)) {
+        return `_${base}`;
+    }
+
+    return base;
 }
 
 /**

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -66,6 +66,11 @@ describe('#115 bug 1: description strings with newlines/quotes/backslashes', () 
     it('generateCommandMap emits parseable source for descriptions with quotes/newlines', () => {
         expectParses(generateCommandMap(paths, schemas));
     });
+
+    it('generateTypes emits parseable source for a property description containing */', () => {
+        // Pins the existing */-escaping in buildJsDoc (util.ts) against regression.
+        expectParses(generateTypes(schemas));
+    });
 });
 
 // -- Bug 2: dotted operationIds emitted as identifiers --

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'bun:test';
+import { generateTypes } from '../../src/codegen/types';
+import { generateClient } from '../../src/codegen/client';
+import { generateCommands } from '../../src/codegen/commands';
+import { generateCommandMap } from '../../src/codegen/command-map';
+
+// Regression tests for issue #115: codegen emitted invalid TypeScript for
+// real-world specs (Jira Cloud platform v3). Each `expectParses` feeds the
+// generated source through Bun's transpiler, which throws on a syntax error —
+// so a broken emission fails the test instead of merely differing in text.
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+function expectParses(code: string): void {
+    // transformSync throws on any syntax error in the emitted source.
+    expect(() => transpiler.transformSync(code)).not.toThrow();
+}
+
+// -- Bug 1: unescaped description string literals --
+
+describe('#115 bug 1: description strings with newlines/quotes/backslashes', () => {
+    const paths = {
+        '/things': {
+            post: {
+                operationId: 'createThing',
+                summary: 'Create a thing',
+                description: 'Sends a bulk change notification when\nthe issue is updated. Contains a "quote", a \\ backslash, and a */ terminator.',
+                tags: ['things'],
+                parameters: [
+                    {
+                        name: 'filter',
+                        in: 'query',
+                        description: 'Filter text\nwith a newline and a "quote"',
+                        schema: { type: 'string' },
+                    },
+                ],
+                requestBody: {
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/Thing' },
+                        },
+                    },
+                },
+            },
+        },
+    } as any;
+    const schemas = {
+        Thing: {
+            type: 'object',
+            properties: {
+                note: {
+                    type: 'string',
+                    description: 'A note field\nspanning lines with a "quote" and */ inside',
+                },
+            },
+        },
+    } as any;
+
+    it('generateCommands emits parseable source for multi-line descriptions', () => {
+        expectParses(generateCommands(paths, schemas));
+    });
+
+    it('generateClient emits parseable JSDoc for descriptions containing */', () => {
+        expectParses(generateClient(paths, schemas));
+    });
+
+    it('generateCommandMap emits parseable source for descriptions with quotes/newlines', () => {
+        expectParses(generateCommandMap(paths, schemas));
+    });
+});
+
+// -- Bug 2: dotted operationIds emitted as identifiers --
+
+describe('#115 bug 2: dotted operationIds', () => {
+    const paths = {
+        '/addons/{addonKey}/properties': {
+            get: {
+                operationId: 'AddonPropertiesResource.getAddonProperties_get',
+                tags: ['addons'],
+                parameters: [
+                    { name: 'addonKey', in: 'path', schema: { type: 'string' } },
+                ],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    it('generateClient emits a valid method identifier', () => {
+        expectParses(generateClient(paths, {}));
+    });
+
+    it('generateCommands emits a valid call site and variable name', () => {
+        expectParses(generateCommands(paths, {}));
+    });
+
+    it('command-map operationId string matches the emitted client method name', () => {
+        const client = generateClient(paths, {});
+        const map = generateCommandMap(paths, {});
+
+        // The generated op method is defined as `  async <sanitized>(` (the
+        // built-in `request` method is `  private async request(`).
+        const methodMatch = client.match(/\n {2}async ([^\s(]+)\(/);
+        expect(methodMatch).not.toBeNull();
+        const methodName = methodMatch![1];
+
+        // No dot survived into the emitted identifier.
+        expect(methodName).not.toContain('.');
+
+        // The command-map string the dispatcher looks up must match exactly.
+        expect(map).toContain(`operationId: "${methodName}"`);
+    });
+});
+
+// -- Bug 3: reserved-word group variable for untagged operations --
+
+describe('#115 bug 3: untagged operations (reserved-word group)', () => {
+    const paths = {
+        '/health': {
+            get: {
+                operationId: 'getHealth',
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    it('generateCommands does not emit `const default =`', () => {
+        const out = generateCommands(paths, {});
+        expect(out).not.toMatch(/const default\b/);
+        expectParses(out);
+    });
+});
+
+// -- Bug 4: non-identifier schema property keys emitted unquoted --
+
+describe('#115 bug 4: non-identifier property keys', () => {
+    const schemas = {
+        AvatarUrls: {
+            type: 'object',
+            properties: {
+                '16x16': { type: 'string' },
+                '24x24': { type: 'string' },
+                'normalKey': { type: 'string' },
+            },
+        },
+        WithInlineObject: {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        '48x48': { type: 'string' },
+                    },
+                },
+            ],
+        },
+        Nested: {
+            type: 'object',
+            properties: {
+                avatars: {
+                    type: 'object',
+                    properties: {
+                        '32x32': { type: 'string' },
+                    },
+                },
+            },
+        },
+    } as any;
+
+    it('generateTypes quotes non-identifier property keys', () => {
+        const out = generateTypes(schemas);
+        expect(out).toContain('"16x16"?: string;');
+        expect(out).not.toMatch(/^\s*16x16\??:/m);
+        expectParses(out);
+    });
+
+    it('generateTypes leaves valid identifier keys unquoted', () => {
+        const out = generateTypes(schemas);
+        expect(out).toMatch(/^\s*normalKey\??: string;/m);
+    });
+});


### PR DESCRIPTION
Closes #115

## Summary

apijack's OpenAPI codegen emitted TypeScript that fails to compile for verbose real-world specs (reproduced against the Jira Cloud platform REST API v3, 619 operations). Because `cli-builder` imported the generated modules inside a bare `try/catch`, the failure was silent: `generate` reported success but no API commands registered.

This fixes four independent emission defects — all cases where spec-sourced text or an `operationId`/tag was written into generated source without being escaped or sanitized into a valid JS identifier — and makes the previously-silent import failure visible.

## What changes

### New shared helpers (`src/codegen/util.ts`)

- `sanitizeIdentifier(name)` — `[^A-Za-z0-9_$]` → `_`, and prefixes `_` when the result starts with a digit or is a reserved word. Deterministic, so every emission site derives the same identifier.
- `emitKey(name)` — returns the name as-is when it is a valid JS identifier, else `JSON.stringify(name)`.
- `sanitizeVar` — hardened to guard reserved words and a leading digit (shared `RESERVED_WORDS` set).

### Bug 1 — unescaped description string literals

The emitters escaped `"` only, never `\n` / `\r` / `\` / `\t`, so any description with a newline split the JS string literal. Replaced the `"${x.replace(/"/g,'\\"')}"` patterns with `${JSON.stringify(x)}` at the three `commands.ts` description sites and the `command-map.ts` description. Also escaped `*/` in the `client.ts` JSDoc builder so a description containing `*/` no longer closes the comment early.

### Bug 2 — dotted operationIds emitted as identifiers

`operationId` values like `AddonPropertiesResource.getAddonProperties_get` were emitted verbatim as method names, call sites, and variable names. Ran them through `sanitizeIdentifier` at every site that must stay in sync:

- `client.ts` — `async <name>(...)` method definition
- `commands.ts` — `client.<name>(...)` call site, the `_<name>` variable and its `configureHelp` use
- `command-map.ts` — the emitted `operationId: "<name>"` **string**, consumed at runtime by `src/routine/dispatcher.ts` as `client[methodName]`. Sanitizing identically here keeps routine dispatch working.

### Bug 3 — reserved-word group variable for untagged operations

An untagged operation is grouped under tag `default` and was emitted as `const default = ...` (a reserved word). `sanitizeVar` now guards reserved words and leading digits, so it emits `const _default = ...`.

### Bug 4 — non-identifier schema property keys emitted unquoted

Keys like Jira's `16x16`/`24x24` were interpolated raw (`16x16?: string;` — a syntax error). Property keys are now emitted via `emitKey(...)` at `types.ts` (interface members and `allOf` inline members) and `util.ts` (`resolveType` inline object literals), producing `"16x16"?: string;`.

### Scoped extra — surface silent import failures (`cli-builder.ts`)

The two bare `catch {}` swallows around generated-module imports now distinguish a genuinely-absent module (`err.code === 'ERR_MODULE_NOT_FOUND'` — expected before the first `generate`, stays silent) from a module that exists but fails to import (a codegen syntax error — now warns to stderr). Routine-only consumers who never generate see no new noise.

## Acceptance criteria

- [x] Generated `commands.ts`, `client.ts`, `types.ts`, and `command-map.ts` are valid TypeScript for descriptions containing newlines/quotes/backslashes/`*/`, dotted operationIds, untagged operations, and non-identifier property keys (e.g. `16x16`).
- [x] Routine dispatch still resolves a sanitized-name client method — the command-map `operationId` string matches the emitted client method name exactly.
- [x] No behavior change for specs that already generate cleanly (existing codegen tests unchanged and passing; committed `.apijack/generated` untouched).
- [x] New codegen unit tests cover each of the four cases.

## Known limitations / out of scope

- **`sanitizeIdentifier` is not injective** — two operationIds differing only by a non-identifier char vs `_` (e.g. `Foo.bar` and `Foo_bar`) collapse to the same method name. No such collision exists in the Jira v3 spec (the dotted ops have distinct prefixes), and the sanitizer stays a deterministic per-site pure function so all three emission sites agree. A de-dup guard is tracked as a follow-up in #118.
- **Dotted operationIds can leak a `.` into a CLI command *name*** on verb collision (the kebab-cased fallback command token at `commands.ts`/`command-map.ts` keeps the `.`). This is pre-existing, cosmetic (the token is a quoted string, not an identifier — no compile error), and out of scope for this fix.

## Test plan

- [x] `bun test` — 928 pass / 0 fail (10 new regression tests in `tests/codegen/invalid-typescript.test.ts`).
- [x] `bun run lint` — 0 errors (pre-existing warnings only).
- [x] New tests feed the generated source through `Bun.Transpiler`, which throws on any syntax error — so a regression fails the test rather than merely differing in text. One test asserts the command-map `operationId` string equals the emitted client method name (the cross-site sync guarantee).
