### PR TITLE
fix: coerce object-body props by resolved schema type (#116)

### DIFF
--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -358,9 +358,37 @@ export function generateCommands(
                         lines.push('      const obj: Record<string, unknown> = {};');
 
                         for (const bp of cmd.bodyProps) {
-                            lines.push(
-                                `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName};`,
-                            );
+                            // Commander flag values are always strings — coerce
+                            // per the prop's resolved schema (see issue #116).
+                            switch (bp.coerce) {
+                                case 'number':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) {`,
+                                        `        const n = Number(opts.${bp.camelName});`,
+                                        `        if (Number.isNaN(n)) throw new Error("--${bp.cliFlag} expects a number");`,
+                                        `        obj["${bp.name}"] = n;`,
+                                        '      }',
+                                    );
+                                    break;
+                                case 'boolean':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName} === "true";`,
+                                    );
+                                    break;
+                                case 'json':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) {`,
+                                        `        try { obj["${bp.name}"] = JSON.parse(opts.${bp.camelName} as string); }`,
+                                        `        catch { throw new Error("--${bp.cliFlag} expects JSON, e.g. '[{\\"id\\":...}]'"); }`,
+                                        '      }',
+                                    );
+                                    break;
+                                default:
+                                    // string / scalar enum — passthrough
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName};`,
+                                    );
+                            }
                         }
 
                         if (cmd.bodyIsArray) {

--- a/src/codegen/openapi-types.ts
+++ b/src/codegen/openapi-types.ts
@@ -92,6 +92,13 @@ export const HTTP_METHODS: HttpMethod[] = [
 export interface BodyProp {
     name: string;
     type: string;
+    /**
+     * How the always-string CLI flag value is converted before it goes into
+     * the request body. Computed from the resolved schema at construction time
+     * (see resolveSchemaProps): 'number' → Number(), 'boolean' → === "true",
+     * 'json' → JSON.parse (arrays/objects/complex), 'string' → passthrough.
+     */
+    coerce: 'number' | 'boolean' | 'json' | 'string';
     cliFlag: string; // kebab-case for CLI, e.g. "first-name"
     camelName: string; // camelCase for Commander opts, e.g. "firstName"
     enumValues?: (string | number | boolean | null)[];

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -218,6 +218,65 @@ export function schemaToTsType(schema: OpenApiSchema): string {
 }
 
 /**
+ * Classify how a body property's always-string CLI flag value must be coerced
+ * before it goes into the request body. `schemaToTsType` collapses arrays and
+ * inline objects to `unknown`, so this resolves the raw (and `$ref`-able)
+ * schema instead: a `$ref` to a string enum stays a string (no parse) while a
+ * `$ref` to an object becomes JSON.
+ */
+export function bodyPropCoercion(
+    prop: OpenApiSchema,
+    schemas: Record<string, OpenApiSchema>,
+    enumValues: (string | number | boolean | null)[] | undefined,
+): 'number' | 'boolean' | 'json' | 'string' {
+    // Scalar enums arrive as plain strings — never JSON. Classify by member
+    // type so a numeric/boolean enum still coerces (a string enum passes
+    // through). null members are ignored (nullable enums).
+    if (enumValues) {
+        const nonNull = enumValues.filter(v => v !== null);
+
+        if (nonNull.length > 0 && nonNull.every(v => typeof v === 'number')) return 'number';
+
+        if (nonNull.length > 0 && nonNull.every(v => typeof v === 'boolean')) return 'boolean';
+
+        return 'string';
+    }
+
+    // Resolve $refs (transitively, cycle-guarded) so classification sees the
+    // underlying type — a $ref-to-object becomes JSON, a $ref-to-string stays
+    // a string.
+    let resolved = prop;
+    const seen = new Set<string>();
+
+    while (resolved.$ref) {
+        const refName = resolved.$ref.split('/').pop()!;
+
+        if (seen.has(refName)) break;
+
+        seen.add(refName);
+
+        const refSchema = schemas[refName];
+
+        if (!refSchema) break;
+
+        resolved = refSchema;
+    }
+
+    switch (resolved.type) {
+        case 'integer':
+        case 'number':
+            return 'number';
+        case 'boolean':
+            return 'boolean';
+        case 'string':
+            return 'string';
+        default:
+            // array, object, $ref-to-object, or otherwise unknown → JSON
+            return 'json';
+    }
+}
+
+/**
  * Normalize an OpenAPI tag into an array of lowercase tokens.
  * Splits on whitespace, slashes, and colons. Strips leading/trailing hyphens.
  */
@@ -506,6 +565,7 @@ export function resolveSchemaProps(
         results.push({
             name,
             type: schemaToTsType(prop),
+            coerce: bodyPropCoercion(prop, schemas, enumValues),
             cliFlag: flag,
             camelName: name,
             enumValues,

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -262,7 +262,29 @@ export function bodyPropCoercion(
         resolved = refSchema;
     }
 
-    switch (resolved.type) {
+    // Normalize OAS 3.1 nullable forms to their sole non-null member so a
+    // nullable scalar keeps its scalar coercion (a nullable string stays a
+    // string passthrough instead of falling through to JSON):
+    //   - array type    { type: ["string", "null"] }
+    //   - anyOf/oneOf    { anyOf: [{ type: "string" }, { type: "null" }] }
+    //     (ubiquitous in Pydantic/FastAPI-generated specs)
+    let effectiveType: string | undefined = Array.isArray(resolved.type)
+        ? undefined
+        : resolved.type;
+
+    if (Array.isArray(resolved.type)) {
+        const nonNull = resolved.type.filter(t => t !== 'null');
+
+        if (nonNull.length === 1) effectiveType = nonNull[0];
+    } else if (!effectiveType && (resolved.anyOf || resolved.oneOf)) {
+        const nonNull = (resolved.anyOf || resolved.oneOf)!.filter(
+            v => v.type !== 'null',
+        );
+
+        if (nonNull.length === 1) return bodyPropCoercion(nonNull[0], schemas, undefined);
+    }
+
+    switch (effectiveType) {
         case 'integer':
         case 'number':
             return 'number';

--- a/tests/codegen/body-coercion.test.ts
+++ b/tests/codegen/body-coercion.test.ts
@@ -164,6 +164,29 @@ describe('#116 body-prop coercion — emitted source', () => {
         expect(src).not.toContain('JSON.parse(opts.status');
     });
 
+    it('OAS 3.1 nullable string (array type) stays a passthrough string', () => {
+        const src = gen({ name: { type: ['string', 'null'] } });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+    });
+
+    it('OAS 3.1 nullable number (array type) coerces via Number()', () => {
+        const src = gen({ count: { type: ['integer', 'null'] } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).not.toContain('JSON.parse(opts.count');
+    });
+
+    it('OAS 3.1 nullable string (anyOf form) stays a passthrough string', () => {
+        const src = gen({
+            name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+    });
+
     it('coerce survives allOf-merged props', () => {
         const paths: Record<string, Record<string, OpenApiOperation>> = {
             '/items': {
@@ -245,6 +268,11 @@ describe('#116 body-prop coercion — runtime behavior', () => {
 
     it('leaves a string flag untouched', () => {
         const src = gen({ name: { type: 'string' } });
+        expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
+    });
+
+    it('passes a nullable string (OAS 3.1) through untouched', () => {
+        const src = gen({ name: { type: ['string', 'null'] } });
         expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
     });
 

--- a/tests/codegen/body-coercion.test.ts
+++ b/tests/codegen/body-coercion.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'bun:test';
+import { generateCommands } from '../../src/codegen/commands';
+import type {
+    OpenApiOperation,
+    OpenApiSchema,
+} from '../../src/codegen/openapi-types';
+
+// Regression tests for issue #116: the object-body branch of the command
+// generator shipped every body prop verbatim, so Commander's always-string
+// option values reached the API uncoerced (arrays/objects as raw strings →
+// 400; numbers/booleans as "42"/"true"). Each body prop now carries a
+// `coerce` kind computed at BodyProp construction, and the generated action
+// coerces accordingly. These tests assert the emitted source both (a) parses
+// as valid TypeScript and (b) actually coerces at runtime.
+
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+function expectParses(code: string): void {
+    expect(() => transpiler.transformSync(code)).not.toThrow();
+}
+
+/**
+ * Generate a single POST /items command whose body is `Dto` with the given
+ * properties. `extraSchemas` supplies any `$ref` targets referenced by props.
+ */
+function gen(
+    properties: Record<string, OpenApiSchema>,
+    extraSchemas: Record<string, OpenApiSchema> = {},
+): string {
+    const paths: Record<string, Record<string, OpenApiOperation>> = {
+        '/items': {
+            post: {
+                operationId: 'createItem',
+                tags: ['items'],
+                requestBody: {
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/Dto' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+    const schemas: Record<string, OpenApiSchema> = {
+        Dto: { type: 'object', properties },
+        ...extraSchemas,
+    };
+
+    return generateCommands(paths, schemas);
+}
+
+/**
+ * Extract the object-body building block from the generated action and run it
+ * against a supplied `opts`, returning the assembled body object. Exercises the
+ * exact emitted source (minus the `as string` casts TS-only tokens).
+ */
+function runCoercion(
+    source: string,
+    opts: Record<string, unknown>,
+): Record<string, unknown> {
+    const marker = 'const obj: Record<string, unknown> = {};';
+    const start = source.indexOf(marker);
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf('body = ', start);
+    const block = source
+        .slice(start + marker.length, end)
+        .replace(/ as string/g, '');
+
+    const build = new Function(
+        'opts',
+        `const obj = {};\n${block}\nreturn obj;`,
+    ) as (o: Record<string, unknown>) => Record<string, unknown>;
+
+    return build(opts);
+}
+
+describe('#116 body-prop coercion — emitted source', () => {
+    it('number/integer props coerce via Number() with a NaN guard', () => {
+        const src = gen({ count: { type: 'integer' }, ratio: { type: 'number' } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).toContain('Number.isNaN(n)');
+        expect(src).toContain('--count expects a number');
+        expect(src).not.toContain('obj["count"] = opts.count;');
+    });
+
+    it('boolean props coerce via === "true"', () => {
+        const src = gen({ flagged: { type: 'boolean' } });
+        expectParses(src);
+        expect(src).toContain('obj["flagged"] = opts.flagged === "true";');
+    });
+
+    it('array props parse as JSON with a per-flag error', () => {
+        const src = gen({ tags: { type: 'array', items: { type: 'string' } } });
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.tags as string)');
+        expect(src).toContain('--tags expects JSON');
+    });
+
+    it('inline object props parse as JSON', () => {
+        const src = gen({
+            meta: { type: 'object', properties: { k: { type: 'string' } } },
+        });
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.meta as string)');
+    });
+
+    it('string props pass through unchanged', () => {
+        const src = gen({ name: { type: 'string' } });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+        expect(src).not.toContain('Number(opts.name)');
+    });
+
+    it('a $ref to a string enum stays a string (no JSON parse)', () => {
+        const src = gen(
+            { status: { $ref: '#/components/schemas/Status' } },
+            { Status: { type: 'string', enum: ['open', 'closed'] } },
+        );
+        expectParses(src);
+        expect(src).toContain('obj["status"] = opts.status;');
+        expect(src).not.toContain('JSON.parse(opts.status');
+    });
+
+    it('a $ref to an object becomes JSON', () => {
+        const src = gen(
+            { address: { $ref: '#/components/schemas/Address' } },
+            {
+                Address: {
+                    type: 'object',
+                    properties: { city: { type: 'string' } },
+                },
+            },
+        );
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.address as string)');
+    });
+
+    it('a numeric enum coerces via Number(), not string passthrough', () => {
+        const src = gen({ priority: { type: 'integer', enum: [1, 2, 3] } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.priority);');
+        expect(src).not.toContain('obj["priority"] = opts.priority;');
+    });
+
+    it('a boolean enum coerces via === "true"', () => {
+        const src = gen({ toggled: { type: 'boolean', enum: [true, false] } });
+        expectParses(src);
+        expect(src).toContain('obj["toggled"] = opts.toggled === "true";');
+    });
+
+    it('a $ref chain to a string enum stays a string', () => {
+        const src = gen(
+            { status: { $ref: '#/components/schemas/StatusAlias' } },
+            {
+                StatusAlias: { $ref: '#/components/schemas/Status' },
+                Status: { type: 'string', enum: ['open', 'closed'] },
+            },
+        );
+        expectParses(src);
+        expect(src).toContain('obj["status"] = opts.status;');
+        expect(src).not.toContain('JSON.parse(opts.status');
+    });
+
+    it('coerce survives allOf-merged props', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    tags: ['items'],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/Merged' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const schemas: Record<string, OpenApiSchema> = {
+            Merged: {
+                allOf: [
+                    { type: 'object', properties: { count: { type: 'integer' } } },
+                    {
+                        type: 'object',
+                        properties: {
+                            tags: { type: 'array', items: { type: 'string' } },
+                        },
+                    },
+                ],
+            },
+        };
+        const src = generateCommands(paths, schemas);
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).toContain('JSON.parse(opts.tags as string)');
+    });
+});
+
+describe('#116 body-prop coercion — runtime behavior', () => {
+    it('coerces a number flag to a JS number', () => {
+        const body = runCoercion(gen({ count: { type: 'integer' } }), {
+            count: '42',
+        });
+        expect(body.count).toBe(42);
+    });
+
+    it('throws a clear error when a number flag is not numeric', () => {
+        const src = gen({ count: { type: 'integer' } });
+        expect(() => runCoercion(src, { count: 'abc' })).toThrow(
+            '--count expects a number',
+        );
+    });
+
+    it('coerces a boolean flag to a JS boolean', () => {
+        const src = gen({ flagged: { type: 'boolean' } });
+        expect(runCoercion(src, { flagged: 'true' }).flagged).toBe(true);
+        expect(runCoercion(src, { flagged: 'false' }).flagged).toBe(false);
+    });
+
+    it('parses an array-of-objects flag into a real array', () => {
+        const src = gen({
+            lineItems: { type: 'array', items: { type: 'object' } },
+        });
+        const body = runCoercion(src, {
+            lineItems: '[{"id":"a","done":true}]',
+        });
+        expect(body.lineItems).toEqual([{ id: 'a', done: true }]);
+    });
+
+    it('throws a clear JSON error when an array flag is not valid JSON', () => {
+        const src = gen({ lineItems: { type: 'array', items: {} } });
+        expect(() => runCoercion(src, { lineItems: 'not json' })).toThrow(
+            '--lineItems expects JSON',
+        );
+    });
+
+    it('coerces a numeric-enum flag to a JS number', () => {
+        const src = gen({ priority: { type: 'integer', enum: [1, 2, 3] } });
+        expect(runCoercion(src, { priority: '2' }).priority).toBe(2);
+    });
+
+    it('leaves a string flag untouched', () => {
+        const src = gen({ name: { type: 'string' } });
+        expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
+    });
+
+    it('leaves an omitted flag out of the body', () => {
+        const src = gen({ name: { type: 'string' }, count: { type: 'integer' } });
+        const body = runCoercion(src, { name: 'only-name' });
+        expect(body).toEqual({ name: 'only-name' });
+    });
+});


### PR DESCRIPTION
Closes #116

## Summary

The generated CLI's object-body branch shipped every body property verbatim (`obj["x"] = opts.x`). Commander option values are always strings, so array/object props reached strict APIs as raw JSON strings (`{"line_items": "[{…}]"}` → 400 `"expected": "array", "received": "string"`), and number/boolean props went out as `"42"`/`"true"`. The primitive-body branch just above already coerced; the per-prop object branch never got the same treatment.

This adds a `coerce` kind to each `BodyProp`, computed at construction from the resolved schema, and emits per-kind coercion in the generated action.

## What changes

### Coercion classification (`src/codegen/util.ts`)

`schemaToTsType` collapses arrays and inline objects to `unknown`, so keying coercion on `BodyProp.type` (as the issue originally proposed) can't work. Instead a new `bodyPropCoercion(prop, schemas, enumValues)` helper classifies at `BodyProp` construction time in `resolveSchemaProps`, where the raw and `$ref`-resolvable schema is available:

- `integer` / `number` → `number`
- `boolean` → `boolean`
- `string`, and scalar enums (`enumValues` present) → `string`
- `array` / `object` / `$ref`-to-object / otherwise-`unknown` → `json`

It resolves a single `$ref` so a ref to a string enum stays `string` (no parse) while a ref to an object becomes `json`.

### Emission (`src/codegen/commands.ts`)

The object-body branch now switches on `bp.coerce`:

```ts
// number
if (opts.count !== undefined) {
  const n = Number(opts.count);
  if (Number.isNaN(n)) throw new Error("--count expects a number");
  obj["count"] = n;
}
// boolean
if (opts.flagged !== undefined) obj["flagged"] = opts.flagged === "true";
// json
if (opts.lineItems !== undefined) {
  try { obj["lineItems"] = JSON.parse(opts.lineItems as string); }
  catch { throw new Error("--lineItems expects JSON, e.g. '[{\"id\":...}]'"); }
}
// string — unchanged passthrough
if (opts.name !== undefined) obj["name"] = opts.name;
```

### New field (`src/codegen/openapi-types.ts`)

`BodyProp.coerce: 'number' | 'boolean' | 'json' | 'string'` (required; the sole construction site is `resolveSchemaProps`).

## Scope decisions (from triage, resolved autonomously)

- **Query params — out of scope.** The client serializes params via `String(v)` into a query string, which carries strings by definition; there is no coercion bug there. Array-typed query params (OpenAPI `style`/`explode`) are a separate concern not addressed here.
- **Comma-split fallback for `string[]` — dropped.** Array element type is lost at `BodyProp` construction (everything array-shaped becomes `json`), so a CSV fallback couldn't be distinguished from a JSON array and would corrupt the primary case. `JSON.parse` only.

### UX note — two array input styles, by shape

There is an intentional divergence in how array input is accepted, driven by where the array sits:

- **Array-typed *object properties*** (this PR) now require JSON: `--tags '["a","b"]'`.
- **Top-level primitive array *bodies*** (the pre-existing primitive-body branch, unchanged) still comma-split: `-B a,b`.

The property branch can't reliably comma-split because element type is erased at classification time (see above), so JSON is the single unambiguous form. Numeric/boolean *enums* (including `$ref`-to-enum) are classified by member type, so a numeric enum coerces with `Number()` rather than shipping `"2"`.

## Acceptance criteria

- [x] Object-body `number`/`integer` props coerced via `Number(...)`, erroring on `NaN`.
- [x] Object-body `boolean` props coerced via `=== "true"`.
- [x] Object-body array/object/complex props parsed via `JSON.parse` with a clear per-flag error naming the flag and showing a JSON example.
- [x] `string` (and scalar-enum) props unchanged.
- [x] Unit coverage on `generateCommands` output for each coercion kind — first direct coverage of the object-body coercion.
- [x] No change to query-param handling.

## Test plan

- [x] `bun test` — 947 pass / 0 fail (19 new in `tests/codegen/body-coercion.test.ts`)
- [x] `bun run lint` — 0 errors
- [x] New tests both transpile the emitted source (catches escaping bugs in the JSON error message) and execute the extracted coercion block: `'42'`→`42`, `'true'`→`true`, `'[{"id":"a","done":true}]'`→real array, non-numeric/invalid-JSON throw the per-flag error, string passthrough unchanged, `$ref`→string-enum stays string, `$ref`→object becomes JSON.
