### PR TITLE
fix: de-duplicate colliding operationIds in codegen (#118)

### DIFF
--- a/src/codegen/client.ts
+++ b/src/codegen/client.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { schemaToTsType, refToName, resolveType, resolveResponseType, sanitizeIdentifier } from './util';
+import { schemaToTsType, refToName, resolveType, resolveResponseType, buildMethodNameMap } from './util';
 
 /**
  * Generate an ApiClient class from OpenAPI paths.
@@ -30,6 +30,7 @@ export function generateClient(
     }
 
     const methodLines: string[] = [];
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -164,7 +165,7 @@ export function generateClient(
                 }
             }
 
-            methodLines.push(`  async ${sanitizeIdentifier(op.operationId)}(${args.join(', ')}): Promise<${returnType}> {`);
+            methodLines.push(`  async ${methodNames.get(op.operationId)!}(${args.join(', ')}): Promise<${returnType}> {`);
             methodLines.push(`    return this.request("${method.toUpperCase()}", ${pathTemplate}${optsArg}) as Promise<${returnType}>;`);
             methodLines.push('  }');
             methodLines.push('');

--- a/src/codegen/command-map.ts
+++ b/src/codegen/command-map.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { normalizeTag, resolveSchemaProps, sanitizeIdentifier } from './util';
+import { normalizeTag, resolveSchemaProps, buildMethodNameMap } from './util';
 
 /**
  * Generate a command map that maps CLI command paths to their
@@ -27,6 +27,7 @@ export function generateCommandMap(
             }>
         >
     >();
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [_path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -144,7 +145,7 @@ export function generateCommandMap(
                     : '';
                 // Sanitize identically to the client method name so the
                 // dispatcher's client[operationId] lookup resolves at runtime.
-                const methodName = sanitizeIdentifier(cmd.operationId);
+                const methodName = methodNames.get(cmd.operationId)!;
                 entries.push(
                     `  "${cmdPath}": { operationId: "${methodName}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
                 );

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -9,7 +9,7 @@ import {
     normalizeTag,
     resolveSchemaProps,
     sanitizeVar,
-    sanitizeIdentifier,
+    buildMethodNameMap,
     capitalize,
 } from './util';
 
@@ -22,6 +22,7 @@ export function generateCommands(
     schemas: Record<string, OpenApiSchema> = {},
 ): string {
     const groups = new Map<string, Map<string, CommandDef[]>>();
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -190,7 +191,7 @@ export function generateCommands(
             for (const cmd of cmds) {
                 // Sanitized operationId — used as the client method name and as a
                 // local variable name; must match the client emitter and command-map.
-                const methodName = sanitizeIdentifier(cmd.operationId);
+                const methodName = methodNames.get(cmd.operationId)!;
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
 

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -1,4 +1,5 @@
-import type { OpenApiSchema, BodyProp } from './openapi-types';
+import type { OpenApiSchema, BodyProp, OpenApiOperation } from './openapi-types';
+import { HTTP_METHODS } from './openapi-types';
 
 /**
  * Resolve an OpenAPI schema to a TypeScript type string.
@@ -631,6 +632,52 @@ export function sanitizeIdentifier(name: string): string {
     }
 
     return id;
+}
+
+/**
+ * Build a deterministic map from each raw operationId in `paths` to a unique,
+ * sanitized method name.
+ *
+ * {@link sanitizeIdentifier} is not injective — distinct operationIds that
+ * differ only by a non-identifier character vs. an underscore collapse to the
+ * same name (e.g. both `Foo.bar` and `Foo_bar` → `Foo_bar`). Left unhandled,
+ * `generateClient` would emit two identical methods (the second shadowing the
+ * first) and both command-map entries would dispatch to the survivor — a
+ * wrong-op dispatch at runtime. On collision this appends a numeric suffix
+ * (`_2`, `_3`, …) so every operationId gets a distinct name.
+ *
+ * Iterates in the same `Object.entries(paths)` × {@link HTTP_METHODS} order
+ * that `generateClient`, `generateCommands`, and `generateCommandMap` all use,
+ * so a single shared map keeps the three emission sites in sync by
+ * construction. Look names up by raw operationId.
+ */
+export function buildMethodNameMap(
+    paths: Record<string, Record<string, OpenApiOperation>>,
+): Map<string, string> {
+    const map = new Map<string, string>();
+    const used = new Set<string>();
+
+    for (const [, methods] of Object.entries(paths)) {
+        for (const method of HTTP_METHODS) {
+            const op = methods[method] as OpenApiOperation | undefined;
+
+            if (!op || !op.operationId || map.has(op.operationId)) continue;
+
+            const base = sanitizeIdentifier(op.operationId);
+            let name = base;
+            let suffix = 2;
+
+            while (used.has(name)) {
+                name = `${base}_${suffix}`;
+                suffix++;
+            }
+
+            used.add(name);
+            map.set(op.operationId, name);
+        }
+    }
+
+    return map;
 }
 
 /**

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -115,6 +115,97 @@ describe('#115 bug 2: dotted operationIds', () => {
     });
 });
 
+// -- #118: colliding operationIds after sanitization --
+
+describe('#118: sanitizeIdentifier collision (Foo.bar vs Foo_bar)', () => {
+    // `Foo.bar` and `Foo_bar` both sanitize to `Foo_bar`. Without de-duplication
+    // generateClient emits two identical `async Foo_bar(` methods (the second
+    // shadows the first) and both command-map entries point at the survivor —
+    // wrong-op dispatch at runtime.
+    const paths = {
+        '/foo-dot': {
+            get: {
+                operationId: 'Foo.bar',
+                tags: ['foo'],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+        '/foo-underscore': {
+            get: {
+                operationId: 'Foo_bar',
+                tags: ['foo'],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    /** All generated op method names (excludes the built-in `request`). */
+    function clientMethodNames(client: string): string[] {
+        return [...client.matchAll(/\n {2}async ([^\s(]+)\(/g)].map(m => m[1]);
+    }
+
+    it('generateClient emits two distinct method names', () => {
+        const client = generateClient(paths, {});
+        const names = clientMethodNames(client);
+        expect(names).toHaveLength(2);
+        expect(new Set(names).size).toBe(2);
+        expectParses(client);
+    });
+
+    it('each command-map operationId matches a distinct client method name', () => {
+        const client = generateClient(paths, {});
+        const map = generateCommandMap(paths, {});
+
+        const methodNames = new Set(clientMethodNames(client));
+        const mapOpIds = [...map.matchAll(/operationId: "([^"]+)"/g)].map(m => m[1]);
+
+        expect(mapOpIds).toHaveLength(2);
+        // Cross-site sync: every command-map operationId resolves to a real,
+        // distinct client method.
+        expect(new Set(mapOpIds).size).toBe(2);
+
+        for (const opId of mapOpIds) {
+            expect(methodNames.has(opId)).toBe(true);
+        }
+    });
+
+    it('resolves a 3-way collision to _2/_3 suffixes', () => {
+        // Foo.bar, Foo_bar, and Foo-bar all sanitize to Foo_bar.
+        const threeWay = {
+            '/a': { get: { operationId: 'Foo.bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/b': { get: { operationId: 'Foo_bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/c': { get: { operationId: 'Foo-bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+        } as any;
+        const names = clientMethodNames(generateClient(threeWay, {}));
+        expect(new Set(names)).toEqual(new Set(['Foo_bar', 'Foo_bar_2', 'Foo_bar_3']));
+    });
+
+    it('bumps a suffixed candidate past a real operationId that already owns it', () => {
+        // Foo_bar_2 is a real operation and claims that name first; the
+        // Foo.bar/Foo_bar collision pair must skip it (used-set check) rather
+        // than reuse Foo_bar_2 and collide again.
+        const withReal = {
+            '/a': { get: { operationId: 'Foo_bar_2', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/b': { get: { operationId: 'Foo.bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/c': { get: { operationId: 'Foo_bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+        } as any;
+        const client = generateClient(withReal, {});
+        const map = generateCommandMap(withReal, {});
+
+        const names = clientMethodNames(client);
+        expect(new Set(names)).toEqual(new Set(['Foo_bar_2', 'Foo_bar', 'Foo_bar_3']));
+
+        // Cross-site sync holds across all three distinct names.
+        const methodNames = new Set(names);
+        const mapOpIds = [...map.matchAll(/operationId: "([^"]+)"/g)].map(m => m[1]);
+        expect(new Set(mapOpIds).size).toBe(3);
+
+        for (const opId of mapOpIds) {
+            expect(methodNames.has(opId)).toBe(true);
+        }
+    });
+});
+
 // -- Bug 3: reserved-word group variable for untagged operations --
 
 describe('#115 bug 3: untagged operations (reserved-word group)', () => {


### PR DESCRIPTION
Closes #118

## Summary

`sanitizeIdentifier` (src/codegen/util.ts) maps any `[^A-Za-z0-9_$]` character to `_`, so it is not injective: two distinct operationIds that differ only by a non-identifier character vs. an underscore collapse to the same method name (e.g. both `Foo.bar` and `Foo_bar` → `Foo_bar`). When a single spec contains both, `generateClient` emits two identical `async Foo_bar(` methods (the second shadows the first) and both `generateCommandMap` entries carry `operationId: "Foo_bar"` — so one CLI command dispatches to the wrong operation at runtime (`client[methodName]`).

This replaces the three independent `sanitizeIdentifier(op.operationId)` call sites with a single shared, deterministic name map that de-duplicates on collision, keeping the three emission sites in sync by construction.

## What changes

### New `buildMethodNameMap(paths)` (src/codegen/util.ts)

Builds a `Map<rawOperationId, uniqueMethodName>` by iterating in the same `Object.entries(paths)` × `HTTP_METHODS` order all three generators already use. For each operation it sanitizes the operationId and, if that name is already taken, appends a numeric suffix (`_2`, `_3`, …) — checking a `used` set each time so a suffixed candidate that happens to equal a real operationId's name (e.g. a genuine `Foo_bar_2` op) is skipped rather than reused. Look-ups are keyed by the raw operationId, so iteration order only affects suffix assignment, not correctness.

### Shared lookup at all three emission sites

`generateClient`, `generateCommands`, and `generateCommandMap` each build the map once and replace their `sanitizeIdentifier(op.operationId)` / `sanitizeIdentifier(cmd.operationId)` call with `methodNames.get(...)!`. Because the map is keyed by raw operationId and built with identical iteration order in each generator, the client method name, the command-map `operationId` string, and the command's local method reference all resolve to the same unique name.

`sanitizeIdentifier` itself is unchanged (still exported, now also consumed internally by `buildMethodNameMap`).

## Acceptance criteria

- [x] A spec containing both `Foo.bar` and `Foo_bar` operationIds generates two distinct client method names.
- [x] The command-map `operationId` string for each still matches its emitted client method name (cross-site sync preserved).
- [x] Regression test covering the collision case.

## Test plan

- [x] `bun test` — 955 pass / 0 fail
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] New regression tests in `tests/codegen/invalid-typescript.test.ts` (`#118` block):
  - two-way collision (`Foo.bar` vs `Foo_bar`) → two distinct client methods, both command-map operationIds distinct and matching a real method
  - three-way collision (`Foo.bar` / `Foo_bar` / `Foo-bar`) → `_2` / `_3` suffixes
  - suffix-vs-real-name collision (`Foo_bar_2` real op present) → `used`-set bumps the collision pair past the real name; all three distinct and command-map sync holds
