### PR TITLE
v1.14.2: codegen hardening — real-world spec emission, typed body props, collision-safe method names

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.14.1",
+  "version": "1.14.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -213,8 +213,14 @@ export function createCli(options: CliOptions): Cli {
                 const clientMod = await import(resolve(generatedDir, 'client'));
                 ApiClientClass = clientMod.ApiClient;
             }
-        } catch {
-            // Generated commands not available — routines that don't dispatch to API methods still work.
+        } catch (err) {
+            // A genuinely-absent module is expected before the first `generate`
+            // (routines that don't dispatch to API methods still work) — stay
+            // silent. A module that exists but fails to import (e.g. a codegen
+            // syntax error) is a real problem — surface it to stderr.
+            if ((err as { code?: string }).code !== 'ERR_MODULE_NOT_FOUND') {
+                console.warn(`[apijack] Generated module failed to import: ${(err as Error).message}`);
+            }
         }
 
         // 5. Build CliContext with lazy session.
@@ -573,8 +579,13 @@ export function createCli(options: CliOptions): Cli {
                     const clientMod = await import(resolve(generatedDir, 'client'));
                     ApiClientClass = clientMod.ApiClient;
                 }
-            } catch {
-                // Generated commands not available — consumer hasn't run `generate` yet
+            } catch (err) {
+                // A genuinely-absent module is expected before the consumer runs
+                // `generate` — stay silent. A module that exists but fails to
+                // import (e.g. a codegen syntax error) is a real problem — surface it.
+                if ((err as { code?: string }).code !== 'ERR_MODULE_NOT_FOUND') {
+                    console.warn(`[apijack] Generated module failed to import: ${(err as Error).message}`);
+                }
             }
 
             // 7. Detect request-preview output modes

--- a/src/codegen/client.ts
+++ b/src/codegen/client.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { schemaToTsType, refToName, resolveType, resolveResponseType, sanitizeIdentifier } from './util';
+import { schemaToTsType, refToName, resolveType, resolveResponseType, buildMethodNameMap } from './util';
 
 /**
  * Generate an ApiClient class from OpenAPI paths.
@@ -30,6 +30,7 @@ export function generateClient(
     }
 
     const methodLines: string[] = [];
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -164,7 +165,7 @@ export function generateClient(
                 }
             }
 
-            methodLines.push(`  async ${sanitizeIdentifier(op.operationId)}(${args.join(', ')}): Promise<${returnType}> {`);
+            methodLines.push(`  async ${methodNames.get(op.operationId)!}(${args.join(', ')}): Promise<${returnType}> {`);
             methodLines.push(`    return this.request("${method.toUpperCase()}", ${pathTemplate}${optsArg}) as Promise<${returnType}>;`);
             methodLines.push('  }');
             methodLines.push('');

--- a/src/codegen/client.ts
+++ b/src/codegen/client.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { schemaToTsType, refToName, resolveType, resolveResponseType } from './util';
+import { schemaToTsType, refToName, resolveType, resolveResponseType, sanitizeIdentifier } from './util';
 
 /**
  * Generate an ApiClient class from OpenAPI paths.
@@ -147,22 +147,24 @@ export function generateClient(
                 }
             }
 
-            // Emit JSDoc
-            if (docLines.length === 1) {
-                methodLines.push(`  /** ${docLines[0]} */`);
-            } else {
-                methodLines.push(`  /** ${docLines[0]}`);
+            // Emit JSDoc — escape `*/` so a description doesn't close the comment early
+            const safeDocLines = docLines.map(l => l.replace(/\*\//g, '*\\/'));
 
-                for (let i = 1; i < docLines.length; i++) {
-                    if (i === docLines.length - 1) {
-                        methodLines.push(`   * ${docLines[i]} */`);
+            if (safeDocLines.length === 1) {
+                methodLines.push(`  /** ${safeDocLines[0]} */`);
+            } else {
+                methodLines.push(`  /** ${safeDocLines[0]}`);
+
+                for (let i = 1; i < safeDocLines.length; i++) {
+                    if (i === safeDocLines.length - 1) {
+                        methodLines.push(`   * ${safeDocLines[i]} */`);
                     } else {
-                        methodLines.push(`   * ${docLines[i]}`);
+                        methodLines.push(`   * ${safeDocLines[i]}`);
                     }
                 }
             }
 
-            methodLines.push(`  async ${op.operationId}(${args.join(', ')}): Promise<${returnType}> {`);
+            methodLines.push(`  async ${sanitizeIdentifier(op.operationId)}(${args.join(', ')}): Promise<${returnType}> {`);
             methodLines.push(`    return this.request("${method.toUpperCase()}", ${pathTemplate}${optsArg}) as Promise<${returnType}>;`);
             methodLines.push('  }');
             methodLines.push('');

--- a/src/codegen/command-map.ts
+++ b/src/codegen/command-map.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { normalizeTag, resolveSchemaProps } from './util';
+import { normalizeTag, resolveSchemaProps, sanitizeIdentifier } from './util';
 
 /**
  * Generate a command map that maps CLI command paths to their
@@ -138,12 +138,15 @@ export function generateCommandMap(
                         ? `${groupName} ${cmdName}`
                         : `${groupName} ${resourceName} ${cmdName}`;
 
-                const descPart = cmd.summary ? `, description: "${cmd.summary.replace(/"/g, '\\"')}"` : '';
+                const descPart = cmd.summary ? `, description: ${JSON.stringify(cmd.summary)}` : '';
                 const bodyPart = cmd.bodyFields.length > 0
                     ? `, bodyFields: ${JSON.stringify(cmd.bodyFields)}`
                     : '';
+                // Sanitize identically to the client method name so the
+                // dispatcher's client[operationId] lookup resolves at runtime.
+                const methodName = sanitizeIdentifier(cmd.operationId);
                 entries.push(
-                    `  "${cmdPath}": { operationId: "${cmd.operationId}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
+                    `  "${cmdPath}": { operationId: "${methodName}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
                 );
             }
         }

--- a/src/codegen/command-map.ts
+++ b/src/codegen/command-map.ts
@@ -1,6 +1,6 @@
 import type { OpenApiOperation, OpenApiSchema } from './openapi-types';
 import { HTTP_METHODS } from './openapi-types';
-import { normalizeTag, resolveSchemaProps, sanitizeIdentifier } from './util';
+import { normalizeTag, resolveSchemaProps, buildMethodNameMap } from './util';
 
 /**
  * Generate a command map that maps CLI command paths to their
@@ -27,6 +27,7 @@ export function generateCommandMap(
             }>
         >
     >();
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [_path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -144,7 +145,7 @@ export function generateCommandMap(
                     : '';
                 // Sanitize identically to the client method name so the
                 // dispatcher's client[operationId] lookup resolves at runtime.
-                const methodName = sanitizeIdentifier(cmd.operationId);
+                const methodName = methodNames.get(cmd.operationId)!;
                 entries.push(
                     `  "${cmdPath}": { operationId: "${methodName}", pathParams: [${cmd.pathParams.map(p => `"${p}"`).join(', ')}], queryParams: [${cmd.queryParams.map(p => `"${p}"`).join(', ')}], hasBody: ${cmd.hasBody}${bodyPart}${descPart} },`,
                 );

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -358,9 +358,37 @@ export function generateCommands(
                         lines.push('      const obj: Record<string, unknown> = {};');
 
                         for (const bp of cmd.bodyProps) {
-                            lines.push(
-                                `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName};`,
-                            );
+                            // Commander flag values are always strings — coerce
+                            // per the prop's resolved schema (see issue #116).
+                            switch (bp.coerce) {
+                                case 'number':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) {`,
+                                        `        const n = Number(opts.${bp.camelName});`,
+                                        `        if (Number.isNaN(n)) throw new Error("--${bp.cliFlag} expects a number");`,
+                                        `        obj["${bp.name}"] = n;`,
+                                        '      }',
+                                    );
+                                    break;
+                                case 'boolean':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName} === "true";`,
+                                    );
+                                    break;
+                                case 'json':
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) {`,
+                                        `        try { obj["${bp.name}"] = JSON.parse(opts.${bp.camelName} as string); }`,
+                                        `        catch { throw new Error("--${bp.cliFlag} expects JSON, e.g. '[{\\"id\\":...}]'"); }`,
+                                        '      }',
+                                    );
+                                    break;
+                                default:
+                                    // string / scalar enum — passthrough
+                                    lines.push(
+                                        `      if (opts.${bp.camelName} !== undefined) obj["${bp.name}"] = opts.${bp.camelName};`,
+                                    );
+                            }
                         }
 
                         if (cmd.bodyIsArray) {

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -9,7 +9,7 @@ import {
     normalizeTag,
     resolveSchemaProps,
     sanitizeVar,
-    sanitizeIdentifier,
+    buildMethodNameMap,
     capitalize,
 } from './util';
 
@@ -22,6 +22,7 @@ export function generateCommands(
     schemas: Record<string, OpenApiSchema> = {},
 ): string {
     const groups = new Map<string, Map<string, CommandDef[]>>();
+    const methodNames = buildMethodNameMap(paths);
 
     for (const [path, methods] of Object.entries(paths)) {
         const pathLevelParams: NonNullable<OpenApiOperation['parameters']> = (methods as Record<string, unknown>).parameters as NonNullable<OpenApiOperation['parameters']> || [];
@@ -190,7 +191,7 @@ export function generateCommands(
             for (const cmd of cmds) {
                 // Sanitized operationId — used as the client method name and as a
                 // local variable name; must match the client emitter and command-map.
-                const methodName = sanitizeIdentifier(cmd.operationId);
+                const methodName = methodNames.get(cmd.operationId)!;
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
 

--- a/src/codegen/commands.ts
+++ b/src/codegen/commands.ts
@@ -9,6 +9,7 @@ import {
     normalizeTag,
     resolveSchemaProps,
     sanitizeVar,
+    sanitizeIdentifier,
     capitalize,
 } from './util';
 
@@ -187,6 +188,9 @@ export function generateCommands(
             const verbSeen = new Map<string, number>();
 
             for (const cmd of cmds) {
+                // Sanitized operationId — used as the client method name and as a
+                // local variable name; must match the client emitter and command-map.
+                const methodName = sanitizeIdentifier(cmd.operationId);
                 const count = verbCounts.get(cmd.verb) || 1;
                 let cmdName = cmd.verb;
 
@@ -215,7 +219,7 @@ export function generateCommands(
                 // Commands with variant props need a variable reference for configureHelp
                 if (hasVariantProps) {
                     lines.push(
-                        `  const _${cmd.operationId} = ${parent}`,
+                        `  const _${methodName} = ${parent}`,
                     );
                 } else {
                     lines.push(`  ${parent}`);
@@ -234,7 +238,7 @@ export function generateCommands(
                 }
 
                 lines.push(
-                    `    .description("${cmdDesc.replace(/"/g, '\\"')}${arrayNote} (use -o routine-step to export as YAML)")`,
+                    `    .description(${JSON.stringify(`${cmdDesc}${arrayNote} (use -o routine-step to export as YAML)`)})`,
                 );
 
                 for (const qp of cmd.queryParams) {
@@ -248,7 +252,7 @@ export function generateCommands(
                         ? `${qp.description}${qpEnum}${qpFormat}${qpDefault}${qpStyle}`
                         : `${qp.name}${qpEnum}${qpFormat}${qpDefault}${qpStyle}`;
                     lines.push(
-                        `    .option("--${qp.name} <${qp.name}>", "${qpDesc.replace(/"/g, '\\"')}")`,
+                        `    .option("--${qp.name} <${qp.name}>", ${JSON.stringify(qpDesc)})`,
                     );
                 }
 
@@ -278,20 +282,19 @@ export function generateCommands(
                             const variantTag = bp.variant
                                 ? ` (${bp.variant})`
                                 : '';
-                            const escapedDesc = desc.replace(/"/g, '\\"');
 
                             if (bp.variant) {
                                 // Variant-specific: hidden by default, shown with -V
                                 lines.push(
-                                    `    .addOption(new Option("--${bp.cliFlag} <value>", "${escapedDesc}${variantTag}").hideHelp())`,
+                                    `    .addOption(new Option("--${bp.cliFlag} <value>", ${JSON.stringify(`${desc}${variantTag}`)}).hideHelp())`,
                                 );
                             } else if (bp.required) {
                                 lines.push(
-                                    `    .requiredOption("--${bp.cliFlag} <value>", "${escapedDesc} (required)")`,
+                                    `    .requiredOption("--${bp.cliFlag} <value>", ${JSON.stringify(`${desc} (required)`)})`,
                                 );
                             } else {
                                 lines.push(
-                                    `    .option("--${bp.cliFlag} <value>", "${escapedDesc}")`,
+                                    `    .option("--${bp.cliFlag} <value>", ${JSON.stringify(desc)})`,
                                 );
                             }
                         }
@@ -380,14 +383,14 @@ export function generateCommands(
                 }
 
                 lines.push(
-                    `      const result = await client.${cmd.operationId}(${callArgs.join(', ')});`,
+                    `      const result = await client.${methodName}(${callArgs.join(', ')});`,
                 );
                 lines.push('      onResult(result);');
                 lines.push('    });');
 
                 // For commands with variant props, configure help to show hidden options with --verbose
                 if (hasVariantProps) {
-                    lines.push(`  _${cmd.operationId}.configureHelp({`);
+                    lines.push(`  _${methodName}.configureHelp({`);
                     lines.push('    visibleOptions: (cmd) => {');
                     lines.push(
                         '      if (process.argv.includes("-V")) {',

--- a/src/codegen/openapi-types.ts
+++ b/src/codegen/openapi-types.ts
@@ -92,6 +92,13 @@ export const HTTP_METHODS: HttpMethod[] = [
 export interface BodyProp {
     name: string;
     type: string;
+    /**
+     * How the always-string CLI flag value is converted before it goes into
+     * the request body. Computed from the resolved schema at construction time
+     * (see resolveSchemaProps): 'number' → Number(), 'boolean' → === "true",
+     * 'json' → JSON.parse (arrays/objects/complex), 'string' → passthrough.
+     */
+    coerce: 'number' | 'boolean' | 'json' | 'string';
     cliFlag: string; // kebab-case for CLI, e.g. "first-name"
     camelName: string; // camelCase for Commander opts, e.g. "firstName"
     enumValues?: (string | number | boolean | null)[];

--- a/src/codegen/types.ts
+++ b/src/codegen/types.ts
@@ -1,5 +1,5 @@
 import type { OpenApiSchema } from './openapi-types';
-import { resolveType, refToName, buildJsDoc, sanitizeTypeName } from './util';
+import { resolveType, refToName, buildJsDoc, sanitizeTypeName, emitKey } from './util';
 
 /**
  * Generate TypeScript type definitions from OpenAPI component schemas.
@@ -77,7 +77,7 @@ export function generateTypes(
                     const propDoc = buildJsDoc(propSchema, '  ');
                     lines.push(...propDoc);
                     const optional = requiredSet.has(propName) ? '' : '?';
-                    lines.push(`  ${propName}${optional}: ${tsType};`);
+                    lines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
                 }
             }
 
@@ -134,7 +134,7 @@ export function generateTypes(
                         innerLines.push(...propDoc);
                         const tsType = resolveType(propSchema, allSchemas, 0);
                         const optional = partRequired.has(propName) ? '' : '?';
-                        innerLines.push(`  ${propName}${optional}: ${tsType};`);
+                        innerLines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
                     }
 
                     innerLines.push('}');

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -563,6 +563,10 @@ export function emitKey(name: string): string {
  * Replace non-alphanumeric characters with underscores for safe variable names.
  * Also guards against a leading digit or reserved word producing an invalid
  * identifier (e.g. an untagged operation grouped under `default`).
+ *
+ * Intentionally stricter than {@link sanitizeIdentifier}: this collapses `$`
+ * to `_` as well, since it names group/resource locals derived from CLI tags
+ * rather than spec operationIds.
  */
 export function sanitizeVar(name: string): string {
     const base = name.replace(/[^a-zA-Z0-9]/g, '_');

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -1,4 +1,5 @@
-import type { OpenApiSchema, BodyProp } from './openapi-types';
+import type { OpenApiSchema, BodyProp, OpenApiOperation } from './openapi-types';
+import { HTTP_METHODS } from './openapi-types';
 
 /**
  * Resolve an OpenAPI schema to a TypeScript type string.
@@ -631,6 +632,52 @@ export function sanitizeIdentifier(name: string): string {
     }
 
     return id;
+}
+
+/**
+ * Build a deterministic map from each raw operationId in `paths` to a unique,
+ * sanitized method name.
+ *
+ * {@link sanitizeIdentifier} is not injective — distinct operationIds that
+ * differ only by a non-identifier character vs. an underscore collapse to the
+ * same name (e.g. both `Foo.bar` and `Foo_bar` → `Foo_bar`). Left unhandled,
+ * `generateClient` would emit two identical methods (the second shadowing the
+ * first) and both command-map entries would dispatch to the survivor — a
+ * wrong-op dispatch at runtime. On collision this appends a numeric suffix
+ * (`_2`, `_3`, …) so every operationId gets a distinct name.
+ *
+ * Iterates in the same `Object.entries(paths)` × {@link HTTP_METHODS} order
+ * that `generateClient`, `generateCommands`, and `generateCommandMap` all use,
+ * so a single shared map keeps the three emission sites in sync by
+ * construction. Look names up by raw operationId.
+ */
+export function buildMethodNameMap(
+    paths: Record<string, Record<string, OpenApiOperation>>,
+): Map<string, string> {
+    const map = new Map<string, string>();
+    const used = new Set<string>();
+
+    for (const [, methods] of Object.entries(paths)) {
+        for (const method of HTTP_METHODS) {
+            const op = methods[method] as OpenApiOperation | undefined;
+
+            if (!op || !op.operationId || map.has(op.operationId)) continue;
+
+            const base = sanitizeIdentifier(op.operationId);
+            let name = base;
+            let suffix = 2;
+
+            while (used.has(name)) {
+                name = `${base}_${suffix}`;
+                suffix++;
+            }
+
+            used.add(name);
+            map.set(op.operationId, name);
+        }
+    }
+
+    return map;
 }
 
 /**

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -137,7 +137,7 @@ export function resolveType(
                 innerLines.push(...propDoc);
                 const tsType = resolveType(propSchema, schemas, depth + 1, visited);
                 const optional = requiredSet.has(propName) ? '' : '?';
-                innerLines.push(`  ${propName}${optional}: ${tsType};`);
+                innerLines.push(`  ${emitKey(propName)}${optional}: ${tsType};`);
             }
 
             // patternProperties inside inline objects
@@ -522,10 +522,56 @@ export function resolveSchemaProps(
 }
 
 /**
+ * Reserved words that cannot be used as bare JavaScript identifiers.
+ * Includes keywords, future reserved words, and literals.
+ */
+const RESERVED_WORDS = new Set([
+    'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
+    'default', 'delete', 'do', 'else', 'enum', 'export', 'extends', 'false',
+    'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'new',
+    'null', 'return', 'super', 'switch', 'this', 'throw', 'true', 'try',
+    'typeof', 'var', 'void', 'while', 'with', 'yield', 'let', 'static',
+    'implements', 'interface', 'package', 'private', 'protected', 'public',
+    'await',
+]);
+
+/**
+ * Sanitize an arbitrary name (operationId, tag, etc.) into a valid JS
+ * identifier: non-identifier characters become underscores, and a leading
+ * digit or a reserved word is prefixed with `_`. Deterministic so the same
+ * input always yields the same identifier across emission sites.
+ */
+export function sanitizeIdentifier(name: string): string {
+    let id = name.replace(/[^A-Za-z0-9_$]/g, '_');
+
+    if (/^[0-9]/.test(id) || RESERVED_WORDS.has(id)) {
+        id = `_${id}`;
+    }
+
+    return id;
+}
+
+/**
+ * Emit an object property key: return it as-is when it is a valid JS
+ * identifier, otherwise quote it via JSON.stringify (e.g. "16x16").
+ */
+export function emitKey(name: string): string {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+}
+
+/**
  * Replace non-alphanumeric characters with underscores for safe variable names.
+ * Also guards against a leading digit or reserved word producing an invalid
+ * identifier (e.g. an untagged operation grouped under `default`).
  */
 export function sanitizeVar(name: string): string {
-    return name.replace(/[^a-zA-Z0-9]/g, '_');
+    const base = name.replace(/[^a-zA-Z0-9]/g, '_');
+
+    if (/^[0-9]/.test(base) || RESERVED_WORDS.has(base)) {
+        return `_${base}`;
+    }
+
+    return base;
 }
 
 /**

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -218,6 +218,65 @@ export function schemaToTsType(schema: OpenApiSchema): string {
 }
 
 /**
+ * Classify how a body property's always-string CLI flag value must be coerced
+ * before it goes into the request body. `schemaToTsType` collapses arrays and
+ * inline objects to `unknown`, so this resolves the raw (and `$ref`-able)
+ * schema instead: a `$ref` to a string enum stays a string (no parse) while a
+ * `$ref` to an object becomes JSON.
+ */
+export function bodyPropCoercion(
+    prop: OpenApiSchema,
+    schemas: Record<string, OpenApiSchema>,
+    enumValues: (string | number | boolean | null)[] | undefined,
+): 'number' | 'boolean' | 'json' | 'string' {
+    // Scalar enums arrive as plain strings — never JSON. Classify by member
+    // type so a numeric/boolean enum still coerces (a string enum passes
+    // through). null members are ignored (nullable enums).
+    if (enumValues) {
+        const nonNull = enumValues.filter(v => v !== null);
+
+        if (nonNull.length > 0 && nonNull.every(v => typeof v === 'number')) return 'number';
+
+        if (nonNull.length > 0 && nonNull.every(v => typeof v === 'boolean')) return 'boolean';
+
+        return 'string';
+    }
+
+    // Resolve $refs (transitively, cycle-guarded) so classification sees the
+    // underlying type — a $ref-to-object becomes JSON, a $ref-to-string stays
+    // a string.
+    let resolved = prop;
+    const seen = new Set<string>();
+
+    while (resolved.$ref) {
+        const refName = resolved.$ref.split('/').pop()!;
+
+        if (seen.has(refName)) break;
+
+        seen.add(refName);
+
+        const refSchema = schemas[refName];
+
+        if (!refSchema) break;
+
+        resolved = refSchema;
+    }
+
+    switch (resolved.type) {
+        case 'integer':
+        case 'number':
+            return 'number';
+        case 'boolean':
+            return 'boolean';
+        case 'string':
+            return 'string';
+        default:
+            // array, object, $ref-to-object, or otherwise unknown → JSON
+            return 'json';
+    }
+}
+
+/**
  * Normalize an OpenAPI tag into an array of lowercase tokens.
  * Splits on whitespace, slashes, and colons. Strips leading/trailing hyphens.
  */
@@ -506,6 +565,7 @@ export function resolveSchemaProps(
         results.push({
             name,
             type: schemaToTsType(prop),
+            coerce: bodyPropCoercion(prop, schemas, enumValues),
             cliFlag: flag,
             camelName: name,
             enumValues,

--- a/src/codegen/util.ts
+++ b/src/codegen/util.ts
@@ -262,7 +262,29 @@ export function bodyPropCoercion(
         resolved = refSchema;
     }
 
-    switch (resolved.type) {
+    // Normalize OAS 3.1 nullable forms to their sole non-null member so a
+    // nullable scalar keeps its scalar coercion (a nullable string stays a
+    // string passthrough instead of falling through to JSON):
+    //   - array type    { type: ["string", "null"] }
+    //   - anyOf/oneOf    { anyOf: [{ type: "string" }, { type: "null" }] }
+    //     (ubiquitous in Pydantic/FastAPI-generated specs)
+    let effectiveType: string | undefined = Array.isArray(resolved.type)
+        ? undefined
+        : resolved.type;
+
+    if (Array.isArray(resolved.type)) {
+        const nonNull = resolved.type.filter(t => t !== 'null');
+
+        if (nonNull.length === 1) effectiveType = nonNull[0];
+    } else if (!effectiveType && (resolved.anyOf || resolved.oneOf)) {
+        const nonNull = (resolved.anyOf || resolved.oneOf)!.filter(
+            v => v.type !== 'null',
+        );
+
+        if (nonNull.length === 1) return bodyPropCoercion(nonNull[0], schemas, undefined);
+    }
+
+    switch (effectiveType) {
         case 'integer':
         case 'number':
             return 'number';

--- a/tests/codegen/body-coercion.test.ts
+++ b/tests/codegen/body-coercion.test.ts
@@ -164,6 +164,29 @@ describe('#116 body-prop coercion — emitted source', () => {
         expect(src).not.toContain('JSON.parse(opts.status');
     });
 
+    it('OAS 3.1 nullable string (array type) stays a passthrough string', () => {
+        const src = gen({ name: { type: ['string', 'null'] } });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+    });
+
+    it('OAS 3.1 nullable number (array type) coerces via Number()', () => {
+        const src = gen({ count: { type: ['integer', 'null'] } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).not.toContain('JSON.parse(opts.count');
+    });
+
+    it('OAS 3.1 nullable string (anyOf form) stays a passthrough string', () => {
+        const src = gen({
+            name: { anyOf: [{ type: 'string' }, { type: 'null' }] },
+        });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+    });
+
     it('coerce survives allOf-merged props', () => {
         const paths: Record<string, Record<string, OpenApiOperation>> = {
             '/items': {
@@ -245,6 +268,11 @@ describe('#116 body-prop coercion — runtime behavior', () => {
 
     it('leaves a string flag untouched', () => {
         const src = gen({ name: { type: 'string' } });
+        expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
+    });
+
+    it('passes a nullable string (OAS 3.1) through untouched', () => {
+        const src = gen({ name: { type: ['string', 'null'] } });
         expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
     });
 

--- a/tests/codegen/body-coercion.test.ts
+++ b/tests/codegen/body-coercion.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect } from 'bun:test';
+import { generateCommands } from '../../src/codegen/commands';
+import type {
+    OpenApiOperation,
+    OpenApiSchema,
+} from '../../src/codegen/openapi-types';
+
+// Regression tests for issue #116: the object-body branch of the command
+// generator shipped every body prop verbatim, so Commander's always-string
+// option values reached the API uncoerced (arrays/objects as raw strings →
+// 400; numbers/booleans as "42"/"true"). Each body prop now carries a
+// `coerce` kind computed at BodyProp construction, and the generated action
+// coerces accordingly. These tests assert the emitted source both (a) parses
+// as valid TypeScript and (b) actually coerces at runtime.
+
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+function expectParses(code: string): void {
+    expect(() => transpiler.transformSync(code)).not.toThrow();
+}
+
+/**
+ * Generate a single POST /items command whose body is `Dto` with the given
+ * properties. `extraSchemas` supplies any `$ref` targets referenced by props.
+ */
+function gen(
+    properties: Record<string, OpenApiSchema>,
+    extraSchemas: Record<string, OpenApiSchema> = {},
+): string {
+    const paths: Record<string, Record<string, OpenApiOperation>> = {
+        '/items': {
+            post: {
+                operationId: 'createItem',
+                tags: ['items'],
+                requestBody: {
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/Dto' },
+                        },
+                    },
+                },
+            },
+        },
+    };
+    const schemas: Record<string, OpenApiSchema> = {
+        Dto: { type: 'object', properties },
+        ...extraSchemas,
+    };
+
+    return generateCommands(paths, schemas);
+}
+
+/**
+ * Extract the object-body building block from the generated action and run it
+ * against a supplied `opts`, returning the assembled body object. Exercises the
+ * exact emitted source (minus the `as string` casts TS-only tokens).
+ */
+function runCoercion(
+    source: string,
+    opts: Record<string, unknown>,
+): Record<string, unknown> {
+    const marker = 'const obj: Record<string, unknown> = {};';
+    const start = source.indexOf(marker);
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf('body = ', start);
+    const block = source
+        .slice(start + marker.length, end)
+        .replace(/ as string/g, '');
+
+    const build = new Function(
+        'opts',
+        `const obj = {};\n${block}\nreturn obj;`,
+    ) as (o: Record<string, unknown>) => Record<string, unknown>;
+
+    return build(opts);
+}
+
+describe('#116 body-prop coercion — emitted source', () => {
+    it('number/integer props coerce via Number() with a NaN guard', () => {
+        const src = gen({ count: { type: 'integer' }, ratio: { type: 'number' } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).toContain('Number.isNaN(n)');
+        expect(src).toContain('--count expects a number');
+        expect(src).not.toContain('obj["count"] = opts.count;');
+    });
+
+    it('boolean props coerce via === "true"', () => {
+        const src = gen({ flagged: { type: 'boolean' } });
+        expectParses(src);
+        expect(src).toContain('obj["flagged"] = opts.flagged === "true";');
+    });
+
+    it('array props parse as JSON with a per-flag error', () => {
+        const src = gen({ tags: { type: 'array', items: { type: 'string' } } });
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.tags as string)');
+        expect(src).toContain('--tags expects JSON');
+    });
+
+    it('inline object props parse as JSON', () => {
+        const src = gen({
+            meta: { type: 'object', properties: { k: { type: 'string' } } },
+        });
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.meta as string)');
+    });
+
+    it('string props pass through unchanged', () => {
+        const src = gen({ name: { type: 'string' } });
+        expectParses(src);
+        expect(src).toContain('obj["name"] = opts.name;');
+        expect(src).not.toContain('JSON.parse(opts.name');
+        expect(src).not.toContain('Number(opts.name)');
+    });
+
+    it('a $ref to a string enum stays a string (no JSON parse)', () => {
+        const src = gen(
+            { status: { $ref: '#/components/schemas/Status' } },
+            { Status: { type: 'string', enum: ['open', 'closed'] } },
+        );
+        expectParses(src);
+        expect(src).toContain('obj["status"] = opts.status;');
+        expect(src).not.toContain('JSON.parse(opts.status');
+    });
+
+    it('a $ref to an object becomes JSON', () => {
+        const src = gen(
+            { address: { $ref: '#/components/schemas/Address' } },
+            {
+                Address: {
+                    type: 'object',
+                    properties: { city: { type: 'string' } },
+                },
+            },
+        );
+        expectParses(src);
+        expect(src).toContain('JSON.parse(opts.address as string)');
+    });
+
+    it('a numeric enum coerces via Number(), not string passthrough', () => {
+        const src = gen({ priority: { type: 'integer', enum: [1, 2, 3] } });
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.priority);');
+        expect(src).not.toContain('obj["priority"] = opts.priority;');
+    });
+
+    it('a boolean enum coerces via === "true"', () => {
+        const src = gen({ toggled: { type: 'boolean', enum: [true, false] } });
+        expectParses(src);
+        expect(src).toContain('obj["toggled"] = opts.toggled === "true";');
+    });
+
+    it('a $ref chain to a string enum stays a string', () => {
+        const src = gen(
+            { status: { $ref: '#/components/schemas/StatusAlias' } },
+            {
+                StatusAlias: { $ref: '#/components/schemas/Status' },
+                Status: { type: 'string', enum: ['open', 'closed'] },
+            },
+        );
+        expectParses(src);
+        expect(src).toContain('obj["status"] = opts.status;');
+        expect(src).not.toContain('JSON.parse(opts.status');
+    });
+
+    it('coerce survives allOf-merged props', () => {
+        const paths: Record<string, Record<string, OpenApiOperation>> = {
+            '/items': {
+                post: {
+                    operationId: 'createItem',
+                    tags: ['items'],
+                    requestBody: {
+                        content: {
+                            'application/json': {
+                                schema: { $ref: '#/components/schemas/Merged' },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+        const schemas: Record<string, OpenApiSchema> = {
+            Merged: {
+                allOf: [
+                    { type: 'object', properties: { count: { type: 'integer' } } },
+                    {
+                        type: 'object',
+                        properties: {
+                            tags: { type: 'array', items: { type: 'string' } },
+                        },
+                    },
+                ],
+            },
+        };
+        const src = generateCommands(paths, schemas);
+        expectParses(src);
+        expect(src).toContain('const n = Number(opts.count);');
+        expect(src).toContain('JSON.parse(opts.tags as string)');
+    });
+});
+
+describe('#116 body-prop coercion — runtime behavior', () => {
+    it('coerces a number flag to a JS number', () => {
+        const body = runCoercion(gen({ count: { type: 'integer' } }), {
+            count: '42',
+        });
+        expect(body.count).toBe(42);
+    });
+
+    it('throws a clear error when a number flag is not numeric', () => {
+        const src = gen({ count: { type: 'integer' } });
+        expect(() => runCoercion(src, { count: 'abc' })).toThrow(
+            '--count expects a number',
+        );
+    });
+
+    it('coerces a boolean flag to a JS boolean', () => {
+        const src = gen({ flagged: { type: 'boolean' } });
+        expect(runCoercion(src, { flagged: 'true' }).flagged).toBe(true);
+        expect(runCoercion(src, { flagged: 'false' }).flagged).toBe(false);
+    });
+
+    it('parses an array-of-objects flag into a real array', () => {
+        const src = gen({
+            lineItems: { type: 'array', items: { type: 'object' } },
+        });
+        const body = runCoercion(src, {
+            lineItems: '[{"id":"a","done":true}]',
+        });
+        expect(body.lineItems).toEqual([{ id: 'a', done: true }]);
+    });
+
+    it('throws a clear JSON error when an array flag is not valid JSON', () => {
+        const src = gen({ lineItems: { type: 'array', items: {} } });
+        expect(() => runCoercion(src, { lineItems: 'not json' })).toThrow(
+            '--lineItems expects JSON',
+        );
+    });
+
+    it('coerces a numeric-enum flag to a JS number', () => {
+        const src = gen({ priority: { type: 'integer', enum: [1, 2, 3] } });
+        expect(runCoercion(src, { priority: '2' }).priority).toBe(2);
+    });
+
+    it('leaves a string flag untouched', () => {
+        const src = gen({ name: { type: 'string' } });
+        expect(runCoercion(src, { name: 'hello' }).name).toBe('hello');
+    });
+
+    it('leaves an omitted flag out of the body', () => {
+        const src = gen({ name: { type: 'string' }, count: { type: 'integer' } });
+        const body = runCoercion(src, { name: 'only-name' });
+        expect(body).toEqual({ name: 'only-name' });
+    });
+});

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -115,6 +115,97 @@ describe('#115 bug 2: dotted operationIds', () => {
     });
 });
 
+// -- #118: colliding operationIds after sanitization --
+
+describe('#118: sanitizeIdentifier collision (Foo.bar vs Foo_bar)', () => {
+    // `Foo.bar` and `Foo_bar` both sanitize to `Foo_bar`. Without de-duplication
+    // generateClient emits two identical `async Foo_bar(` methods (the second
+    // shadows the first) and both command-map entries point at the survivor —
+    // wrong-op dispatch at runtime.
+    const paths = {
+        '/foo-dot': {
+            get: {
+                operationId: 'Foo.bar',
+                tags: ['foo'],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+        '/foo-underscore': {
+            get: {
+                operationId: 'Foo_bar',
+                tags: ['foo'],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    /** All generated op method names (excludes the built-in `request`). */
+    function clientMethodNames(client: string): string[] {
+        return [...client.matchAll(/\n {2}async ([^\s(]+)\(/g)].map(m => m[1]);
+    }
+
+    it('generateClient emits two distinct method names', () => {
+        const client = generateClient(paths, {});
+        const names = clientMethodNames(client);
+        expect(names).toHaveLength(2);
+        expect(new Set(names).size).toBe(2);
+        expectParses(client);
+    });
+
+    it('each command-map operationId matches a distinct client method name', () => {
+        const client = generateClient(paths, {});
+        const map = generateCommandMap(paths, {});
+
+        const methodNames = new Set(clientMethodNames(client));
+        const mapOpIds = [...map.matchAll(/operationId: "([^"]+)"/g)].map(m => m[1]);
+
+        expect(mapOpIds).toHaveLength(2);
+        // Cross-site sync: every command-map operationId resolves to a real,
+        // distinct client method.
+        expect(new Set(mapOpIds).size).toBe(2);
+
+        for (const opId of mapOpIds) {
+            expect(methodNames.has(opId)).toBe(true);
+        }
+    });
+
+    it('resolves a 3-way collision to _2/_3 suffixes', () => {
+        // Foo.bar, Foo_bar, and Foo-bar all sanitize to Foo_bar.
+        const threeWay = {
+            '/a': { get: { operationId: 'Foo.bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/b': { get: { operationId: 'Foo_bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/c': { get: { operationId: 'Foo-bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+        } as any;
+        const names = clientMethodNames(generateClient(threeWay, {}));
+        expect(new Set(names)).toEqual(new Set(['Foo_bar', 'Foo_bar_2', 'Foo_bar_3']));
+    });
+
+    it('bumps a suffixed candidate past a real operationId that already owns it', () => {
+        // Foo_bar_2 is a real operation and claims that name first; the
+        // Foo.bar/Foo_bar collision pair must skip it (used-set check) rather
+        // than reuse Foo_bar_2 and collide again.
+        const withReal = {
+            '/a': { get: { operationId: 'Foo_bar_2', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/b': { get: { operationId: 'Foo.bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+            '/c': { get: { operationId: 'Foo_bar', tags: ['foo'], responses: { 200: { description: 'ok' } } } },
+        } as any;
+        const client = generateClient(withReal, {});
+        const map = generateCommandMap(withReal, {});
+
+        const names = clientMethodNames(client);
+        expect(new Set(names)).toEqual(new Set(['Foo_bar_2', 'Foo_bar', 'Foo_bar_3']));
+
+        // Cross-site sync holds across all three distinct names.
+        const methodNames = new Set(names);
+        const mapOpIds = [...map.matchAll(/operationId: "([^"]+)"/g)].map(m => m[1]);
+        expect(new Set(mapOpIds).size).toBe(3);
+
+        for (const opId of mapOpIds) {
+            expect(methodNames.has(opId)).toBe(true);
+        }
+    });
+});
+
 // -- Bug 3: reserved-word group variable for untagged operations --
 
 describe('#115 bug 3: untagged operations (reserved-word group)', () => {

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -66,6 +66,11 @@ describe('#115 bug 1: description strings with newlines/quotes/backslashes', () 
     it('generateCommandMap emits parseable source for descriptions with quotes/newlines', () => {
         expectParses(generateCommandMap(paths, schemas));
     });
+
+    it('generateTypes emits parseable source for a property description containing */', () => {
+        // Pins the existing */-escaping in buildJsDoc (util.ts) against regression.
+        expectParses(generateTypes(schemas));
+    });
 });
 
 // -- Bug 2: dotted operationIds emitted as identifiers --

--- a/tests/codegen/invalid-typescript.test.ts
+++ b/tests/codegen/invalid-typescript.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'bun:test';
+import { generateTypes } from '../../src/codegen/types';
+import { generateClient } from '../../src/codegen/client';
+import { generateCommands } from '../../src/codegen/commands';
+import { generateCommandMap } from '../../src/codegen/command-map';
+
+// Regression tests for issue #115: codegen emitted invalid TypeScript for
+// real-world specs (Jira Cloud platform v3). Each `expectParses` feeds the
+// generated source through Bun's transpiler, which throws on a syntax error —
+// so a broken emission fails the test instead of merely differing in text.
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+function expectParses(code: string): void {
+    // transformSync throws on any syntax error in the emitted source.
+    expect(() => transpiler.transformSync(code)).not.toThrow();
+}
+
+// -- Bug 1: unescaped description string literals --
+
+describe('#115 bug 1: description strings with newlines/quotes/backslashes', () => {
+    const paths = {
+        '/things': {
+            post: {
+                operationId: 'createThing',
+                summary: 'Create a thing',
+                description: 'Sends a bulk change notification when\nthe issue is updated. Contains a "quote", a \\ backslash, and a */ terminator.',
+                tags: ['things'],
+                parameters: [
+                    {
+                        name: 'filter',
+                        in: 'query',
+                        description: 'Filter text\nwith a newline and a "quote"',
+                        schema: { type: 'string' },
+                    },
+                ],
+                requestBody: {
+                    content: {
+                        'application/json': {
+                            schema: { $ref: '#/components/schemas/Thing' },
+                        },
+                    },
+                },
+            },
+        },
+    } as any;
+    const schemas = {
+        Thing: {
+            type: 'object',
+            properties: {
+                note: {
+                    type: 'string',
+                    description: 'A note field\nspanning lines with a "quote" and */ inside',
+                },
+            },
+        },
+    } as any;
+
+    it('generateCommands emits parseable source for multi-line descriptions', () => {
+        expectParses(generateCommands(paths, schemas));
+    });
+
+    it('generateClient emits parseable JSDoc for descriptions containing */', () => {
+        expectParses(generateClient(paths, schemas));
+    });
+
+    it('generateCommandMap emits parseable source for descriptions with quotes/newlines', () => {
+        expectParses(generateCommandMap(paths, schemas));
+    });
+});
+
+// -- Bug 2: dotted operationIds emitted as identifiers --
+
+describe('#115 bug 2: dotted operationIds', () => {
+    const paths = {
+        '/addons/{addonKey}/properties': {
+            get: {
+                operationId: 'AddonPropertiesResource.getAddonProperties_get',
+                tags: ['addons'],
+                parameters: [
+                    { name: 'addonKey', in: 'path', schema: { type: 'string' } },
+                ],
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    it('generateClient emits a valid method identifier', () => {
+        expectParses(generateClient(paths, {}));
+    });
+
+    it('generateCommands emits a valid call site and variable name', () => {
+        expectParses(generateCommands(paths, {}));
+    });
+
+    it('command-map operationId string matches the emitted client method name', () => {
+        const client = generateClient(paths, {});
+        const map = generateCommandMap(paths, {});
+
+        // The generated op method is defined as `  async <sanitized>(` (the
+        // built-in `request` method is `  private async request(`).
+        const methodMatch = client.match(/\n {2}async ([^\s(]+)\(/);
+        expect(methodMatch).not.toBeNull();
+        const methodName = methodMatch![1];
+
+        // No dot survived into the emitted identifier.
+        expect(methodName).not.toContain('.');
+
+        // The command-map string the dispatcher looks up must match exactly.
+        expect(map).toContain(`operationId: "${methodName}"`);
+    });
+});
+
+// -- Bug 3: reserved-word group variable for untagged operations --
+
+describe('#115 bug 3: untagged operations (reserved-word group)', () => {
+    const paths = {
+        '/health': {
+            get: {
+                operationId: 'getHealth',
+                responses: { 200: { description: 'ok' } },
+            },
+        },
+    } as any;
+
+    it('generateCommands does not emit `const default =`', () => {
+        const out = generateCommands(paths, {});
+        expect(out).not.toMatch(/const default\b/);
+        expectParses(out);
+    });
+});
+
+// -- Bug 4: non-identifier schema property keys emitted unquoted --
+
+describe('#115 bug 4: non-identifier property keys', () => {
+    const schemas = {
+        AvatarUrls: {
+            type: 'object',
+            properties: {
+                '16x16': { type: 'string' },
+                '24x24': { type: 'string' },
+                'normalKey': { type: 'string' },
+            },
+        },
+        WithInlineObject: {
+            allOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        '48x48': { type: 'string' },
+                    },
+                },
+            ],
+        },
+        Nested: {
+            type: 'object',
+            properties: {
+                avatars: {
+                    type: 'object',
+                    properties: {
+                        '32x32': { type: 'string' },
+                    },
+                },
+            },
+        },
+    } as any;
+
+    it('generateTypes quotes non-identifier property keys', () => {
+        const out = generateTypes(schemas);
+        expect(out).toContain('"16x16"?: string;');
+        expect(out).not.toMatch(/^\s*16x16\??:/m);
+        expectParses(out);
+    });
+
+    it('generateTypes leaves valid identifier keys unquoted', () => {
+        const out = generateTypes(schemas);
+        expect(out).toMatch(/^\s*normalKey\??: string;/m);
+    });
+});


### PR DESCRIPTION
Closes #115
Closes #116
Closes #118

Hardens codegen against real-world OpenAPI specs: generated CLIs now compile against verbose specs like Jira Cloud v3, send correctly typed request bodies, and never silently dispatch to the wrong operation.

## 🐛 Fixes

- **Codegen emits valid TypeScript for real-world specs** (#117) — spec descriptions with newlines/quotes, dotted operationIds, untagged operations, and non-identifier property keys (`16x16`) no longer produce broken generated modules; a generated module that fails to import now warns instead of silently registering no commands.
- **Object-body props are coerced to their schema types** (#119) — array/object flags are JSON-parsed and number/boolean flags converted (previously everything shipped as raw strings, causing 400s on strict APIs). Array-of-scalar *properties* now expect JSON (`--tags '["a","b"]'`).
- **Colliding operationIds get distinct method names** (#120) — operationIds differing only by `.`/`-` vs `_` no longer collapse into one client method with wrong-op dispatch.

---

Shipped via `scripts/ship.sh`.
