### PR TITLE
feat: make the setup URL default configurable per project (#122)

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -152,6 +152,7 @@ const cli = createCli({
     sessionAuth,
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,
+    defaultUrl: projectConfig?.defaultUrl,
     configPath: join(configDir, 'config.json'),
     customCommandDefaults: projectSettings.customCommands?.defaults,
 });

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -21,7 +21,7 @@ import { registerPluginsCommand } from './commands/plugins/register';
 import { PluginRegistry } from './plugin/registry';
 import { loadPluginPeerInfo, checkPeerRange } from './plugin/peer-version';
 import { PluginPeerMismatchError } from './plugin/errors';
-import { registerSetupCommand, setupAction } from './commands/setup/setup';
+import { registerSetupCommand, setupAction, setupUrlDefault } from './commands/setup/setup';
 import { registerConfigCommand } from './commands/config/register';
 import { registerGenerateCommand } from './commands/generate/generate';
 import { registerUpgradeCommand } from './commands/upgrade/upgrade';
@@ -466,6 +466,7 @@ export function createCli(options: CliOptions): Cli {
                 allowedCidrs: options.allowedCidrs,
                 configPath: options.configPath,
                 displayName,
+                defaultUrl: options.defaultUrl,
             });
             registerConfigCommand(program, cliName, {
                 configPath: options.configPath,
@@ -511,7 +512,8 @@ export function createCli(options: CliOptions): Cli {
             ) {
                 console.log(`${displayName} Setup\n`);
                 const envName = await prompt('Environment name [default]: ', 'default');
-                const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+                const urlDefault = setupUrlDefault(options.defaultUrl);
+                const url = await prompt(`URL [${urlDefault}]: `, urlDefault);
                 const user = await prompt('Username/Email: ');
                 const password = await hiddenPrompt('Password: ');
 

--- a/src/commands/setup/setup.test.ts
+++ b/src/commands/setup/setup.test.ts
@@ -1,5 +1,20 @@
 import { describe, test, expect, mock } from 'bun:test';
-import { setupAction } from './setup';
+import { setupAction, setupUrlDefault, DEFAULT_SETUP_URL } from './setup';
+
+describe('setupUrlDefault', () => {
+    test('falls back to localhost:8080 when no defaultUrl is configured', () => {
+        expect(setupUrlDefault(undefined)).toBe('http://localhost:8080');
+        expect(DEFAULT_SETUP_URL).toBe('http://localhost:8080');
+    });
+
+    test('uses the consumer-configured defaultUrl', () => {
+        expect(setupUrlDefault('http://localhost:7080')).toBe('http://localhost:7080');
+    });
+
+    test('ignores an empty defaultUrl', () => {
+        expect(setupUrlDefault('')).toBe('http://localhost:8080');
+    });
+});
 
 describe('setupAction', () => {
     test('calls saveEnvironment with provided credentials', async () => {

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -3,6 +3,14 @@ import { saveEnvironment, verifyCredentials } from '../../config';
 import type { EnvironmentConfig } from '../../config';
 import { prompt, hiddenPrompt } from '../../prompt';
 
+/** URL offered by the interactive setup prompts when a consumer configures none. */
+export const DEFAULT_SETUP_URL = 'http://localhost:8080';
+
+/** Resolve the URL pre-fill for the setup prompts — the consumer's `defaultUrl`, else the built-in default. */
+export function setupUrlDefault(defaultUrl?: string): string {
+    return defaultUrl || DEFAULT_SETUP_URL;
+}
+
 export interface SetupInput {
     cliName: string;
     envName: string;
@@ -44,14 +52,17 @@ export function registerSetupCommand(
         configPath?: string;
         /** Display name for user-facing output. Defaults to cliName. */
         displayName?: string;
+        /** URL pre-filled in the setup prompt. Defaults to `DEFAULT_SETUP_URL`. */
+        defaultUrl?: string;
     },
 ): void {
     const displayName = opts?.displayName ?? cliName;
+    const urlDefault = setupUrlDefault(opts?.defaultUrl);
     const action = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
         console.log(`${displayName} Setup\n`);
 
         const envName = await prompt('Environment name [default]: ', 'default');
-        const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+        const url = await prompt(`URL [${urlDefault}]: `, urlDefault);
         const user = await prompt('Username/Email: ');
         const password = await hiddenPrompt('Password: ');
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -10,6 +10,8 @@ export interface ProjectConfig {
     generatedDir?: string;
     auth?: string;
     allowedCidrs?: string[];
+    /** URL pre-filled in the interactive setup prompts. Defaults to `http://localhost:8080`. */
+    defaultUrl?: string;
 }
 
 export function findProjectConfig(startDir: string): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,10 @@ export interface CliOptions {
     allowedCidrs?: string[];
     configPath?: string;
     customCommandDefaults?: { requiresAuth?: boolean };
+    /** URL pre-filled in the interactive setup prompts. Defaults to `http://localhost:8080`.
+     *  Prompt default only — it does not participate in the NAME_URL / saved-config
+     *  resolution chain used for non-interactive runs. */
+    defaultUrl?: string;
 }
 
 export type CommandRegistrar<R extends boolean = false> = R extends true


### PR DESCRIPTION
Closes #122

## Summary

The interactive setup URL prompt hardcoded `http://localhost:8080` at two sites, with no way for a consumer project to change it. apijack is a generic framework, but every wrapper it generated assumed the wrapped API runs locally on 8080 — so a CLI for an API on any other port handed new users a wrong default on the very first command they ran, and the only workarounds were documenting "ignore the default" or bypassing config with the `<NAME>_URL` env var.

This adds a `defaultUrl` option, settable in `.apijack.json` or passed to `createCli`.

**Scope note:** this is a *prompt default only*. Issue #122's Notes section raised whether `defaultUrl` should also seed the non-interactive resolution chain; the narrower option was chosen deliberately during triage. `src/config.ts` is untouched — `<NAME>_URL` env var → saved config → error behaves exactly as before, including when it errors. Broadening it would change a CLI that fails loudly with "Run `<cli> setup`" into one that silently attempts a request against `defaultUrl` with no credentials.

## What changes

### New option

`defaultUrl?: string` added to two public interfaces, both optional and additive:

- `ProjectConfig` (`src/project.ts`) — settable in `.apijack.json`
- `CliOptions` (`src/types.ts`) — for consumers with a custom `bin/<cli>.ts` calling `createCli` directly, who may have no `.apijack.json` at all

```json
{
  "specUrl": "/v3/api-docs",
  "generatedDir": ".apijack/generated",
  "defaultUrl": "http://localhost:7080"
}
```

### Plumbing

`.apijack.json` → `loadProjectConfig` → `bin/apijack.ts` → `CliOptions.defaultUrl` → two sinks:

- `cli-builder.ts` → `registerSetupCommand` opts → the `setup` / `login` command
- `cli-builder.ts` → the implicit first-run prompt inside `run()`

This mirrors how the sibling `allowedCidrs` option is threaded through the same call paths. Issue #122's proposed step 4 said "have `cli-builder` read `projectConfig.defaultUrl`" — `cli-builder` never reads project config; `bin/apijack.ts` loads it and passes values into `createCli`, hence the `CliOptions` field.

### Prompt sites

Both sites now derive the prompt label and the prompt's default value from a single variable, so they cannot drift apart:

```ts
const urlDefault = setupUrlDefault(opts?.defaultUrl);
const url = await prompt(`URL [${urlDefault}]: `, urlDefault);
```

`setupUrlDefault` is a small pure helper next to the new exported `DEFAULT_SETUP_URL` constant. It centralises "empty string means unset" and gives a mock-free unit to test, matching this repo's dependency-injection test style. Neither is exported from `src/index.ts` — that file exports nothing from `src/commands/*`, and consumers configure through `CliOptions` / `.apijack.json`.

## Acceptance criteria

- [ ] `defaultUrl` in `.apijack.json` changes the pre-filled URL in both `<cli> setup` and the auto-setup prompt in `cli-builder.ts`
- [ ] `defaultUrl` passed to `createCli` works for consumers with a custom `bin/<cli>.ts` and no `.apijack.json`
- [ ] With `defaultUrl` unset, both prompts still show and accept `http://localhost:8080`
- [ ] `getActiveEnvConfig` / `resolveAuth` behavior is unchanged — no new fallback, no change to when the CLI errors
- [ ] Tests cover set / unset / empty for the resolution helper
- [ ] Public API addition is additive and non-breaking

## Test plan

- [x] `bun test` — 958 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `bunx tsc --noEmit` — only pre-existing TS2578 errors in untouched `src/mcp/**/*.spec.ts`; none in changed files
- [x] Manual smoke, `defaultUrl: "http://localhost:7080"` → `URL [http://localhost:7080]:`
- [x] Manual smoke, unset → `URL [http://localhost:8080]:`
- [x] `grep` confirms `http://localhost:8080` no longer appears in non-test source except `DEFAULT_SETUP_URL` and prose/comments

## Reviewer notes

Two deliberate non-changes, both flagged and accepted during self-review:

- **`src/run-routine.ts:160` threads `allowedCidrs` but not `defaultUrl`.** Cosmetic asymmetry, not a bug — the programmatic path builds its runtime via `_buildRoutineRuntime`, which throws `No active env config` rather than prompting, so the setup prompt is unreachable from `runRoutine`.
- **`src/mcp/tools/config/setup/setup.ts:18`** keeps `http://localhost:8080` in a zod `.describe()` example on a *required* `url` param. The MCP agent always supplies the URL, so there is no default to configure.

**Docs:** there is no in-repo doc file for `.apijack.json` keys (they live on the wiki; `allowedCidrs` is likewise undocumented in-repo). The wiki's *Building a CLI* and *Project Mode* pages need a follow-up edit for `defaultUrl`.
