### PR TITLE
v1.15.0: configurable setup URL default

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -152,6 +152,7 @@ const cli = createCli({
     sessionAuth,
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,
+    defaultUrl: projectConfig?.defaultUrl,
     configPath: join(configDir, 'config.json'),
     customCommandDefaults: projectSettings.customCommands?.defaults,
 });

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.14.2",
+  "version": "1.15.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -21,7 +21,7 @@ import { registerPluginsCommand } from './commands/plugins/register';
 import { PluginRegistry } from './plugin/registry';
 import { loadPluginPeerInfo, checkPeerRange } from './plugin/peer-version';
 import { PluginPeerMismatchError } from './plugin/errors';
-import { registerSetupCommand, setupAction } from './commands/setup/setup';
+import { registerSetupCommand, setupAction, setupUrlDefault } from './commands/setup/setup';
 import { registerConfigCommand } from './commands/config/register';
 import { registerGenerateCommand } from './commands/generate/generate';
 import { registerUpgradeCommand } from './commands/upgrade/upgrade';
@@ -466,6 +466,7 @@ export function createCli(options: CliOptions): Cli {
                 allowedCidrs: options.allowedCidrs,
                 configPath: options.configPath,
                 displayName,
+                defaultUrl: options.defaultUrl,
             });
             registerConfigCommand(program, cliName, {
                 configPath: options.configPath,
@@ -511,7 +512,8 @@ export function createCli(options: CliOptions): Cli {
             ) {
                 console.log(`${displayName} Setup\n`);
                 const envName = await prompt('Environment name [default]: ', 'default');
-                const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+                const urlDefault = setupUrlDefault(options.defaultUrl);
+                const url = await prompt(`URL [${urlDefault}]: `, urlDefault);
                 const user = await prompt('Username/Email: ');
                 const password = await hiddenPrompt('Password: ');
 

--- a/src/commands/setup/setup.test.ts
+++ b/src/commands/setup/setup.test.ts
@@ -1,5 +1,20 @@
 import { describe, test, expect, mock } from 'bun:test';
-import { setupAction } from './setup';
+import { setupAction, setupUrlDefault, DEFAULT_SETUP_URL } from './setup';
+
+describe('setupUrlDefault', () => {
+    test('falls back to localhost:8080 when no defaultUrl is configured', () => {
+        expect(setupUrlDefault(undefined)).toBe('http://localhost:8080');
+        expect(DEFAULT_SETUP_URL).toBe('http://localhost:8080');
+    });
+
+    test('uses the consumer-configured defaultUrl', () => {
+        expect(setupUrlDefault('http://localhost:7080')).toBe('http://localhost:7080');
+    });
+
+    test('ignores an empty defaultUrl', () => {
+        expect(setupUrlDefault('')).toBe('http://localhost:8080');
+    });
+});
 
 describe('setupAction', () => {
     test('calls saveEnvironment with provided credentials', async () => {

--- a/src/commands/setup/setup.ts
+++ b/src/commands/setup/setup.ts
@@ -3,6 +3,14 @@ import { saveEnvironment, verifyCredentials } from '../../config';
 import type { EnvironmentConfig } from '../../config';
 import { prompt, hiddenPrompt } from '../../prompt';
 
+/** URL offered by the interactive setup prompts when a consumer configures none. */
+export const DEFAULT_SETUP_URL = 'http://localhost:8080';
+
+/** Resolve the URL pre-fill for the setup prompts — the consumer's `defaultUrl`, else the built-in default. */
+export function setupUrlDefault(defaultUrl?: string): string {
+    return defaultUrl || DEFAULT_SETUP_URL;
+}
+
 export interface SetupInput {
     cliName: string;
     envName: string;
@@ -44,14 +52,17 @@ export function registerSetupCommand(
         configPath?: string;
         /** Display name for user-facing output. Defaults to cliName. */
         displayName?: string;
+        /** URL pre-filled in the setup prompt. Defaults to `DEFAULT_SETUP_URL`. */
+        defaultUrl?: string;
     },
 ): void {
     const displayName = opts?.displayName ?? cliName;
+    const urlDefault = setupUrlDefault(opts?.defaultUrl);
     const action = async (cmdOpts: { allowInsecureStorage?: boolean }) => {
         console.log(`${displayName} Setup\n`);
 
         const envName = await prompt('Environment name [default]: ', 'default');
-        const url = await prompt('URL [http://localhost:8080]: ', 'http://localhost:8080');
+        const url = await prompt(`URL [${urlDefault}]: `, urlDefault);
         const user = await prompt('Username/Email: ');
         const password = await hiddenPrompt('Password: ');
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -10,6 +10,8 @@ export interface ProjectConfig {
     generatedDir?: string;
     auth?: string;
     allowedCidrs?: string[];
+    /** URL pre-filled in the interactive setup prompts. Defaults to `http://localhost:8080`. */
+    defaultUrl?: string;
 }
 
 export function findProjectConfig(startDir: string): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,10 @@ export interface CliOptions {
     allowedCidrs?: string[];
     configPath?: string;
     customCommandDefaults?: { requiresAuth?: boolean };
+    /** URL pre-filled in the interactive setup prompts. Defaults to `http://localhost:8080`.
+     *  Prompt default only — it does not participate in the NAME_URL / saved-config
+     *  resolution chain used for non-interactive runs. */
+    defaultUrl?: string;
 }
 
 export type CommandRegistrar<R extends boolean = false> = R extends true


### PR DESCRIPTION
Closes #122

The interactive setup prompt no longer assumes your API runs on `localhost:8080`. Wrapper CLIs can now offer their own default, so new users aren't handed a URL that can't connect on the very first command they run.

## ✨ Features

- **Configurable setup URL default** (#123) — set `defaultUrl` in `.apijack.json` or pass it to `createCli` to change the URL pre-filled in `<cli> setup` and the first-run prompt. Purely a prompt default: the `<NAME>_URL` → saved-config resolution chain is unchanged, and omitting it keeps today's `http://localhost:8080`.

---

Shipped via `scripts/ship.sh`.
