### PR TITLE
chore: promote shipped issues to the 'deployed' label (#125)

### DIFF
--- a/.claude/skills/patch-deployer/SKILL.md
+++ b/.claude/skills/patch-deployer/SKILL.md
@@ -121,7 +121,8 @@ The script edits the open `dev → main` PR if one exists, otherwise pushes `dev
 3. Wait for CI
 4. Merge via `gh pr merge --merge --admin`
 5. Watch the publish workflow create the release + publish to npm
-6. Sync main and rebase dev
+6. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines in the PR body)
+7. Sync main and rebase dev
 
 If ship.sh exits non-zero, leave the PR in place for a human and stop.
 

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -148,7 +148,10 @@ ship.sh will:
 3. Wait for CI
 4. Merge via `gh pr merge --merge --admin`
 5. Watch the publish workflow
-6. Sync main and rebase dev
+6. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines from step 2)
+7. Sync main and rebase dev
+
+Step 6 is why the `Closes #N` lines matter twice over: they auto-close the issues *and* drive the label promotion. A release that closes no issues is a clean no-op. Labelling never aborts a ship — the release is already published by then, so a failure only warns.
 
 If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off.
 

--- a/scripts/promote-shipped-issues.sh
+++ b/scripts/promote-shipped-issues.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Promote every issue referenced as `Closes #N` / `Fixes #N` / `Resolves #N`
+# in a release PR body to the terminal `deployed` label, and strip the
+# workflow-state labels that are stale once the code reaches main:
+#
+#   ready-for-implement — a triage-state label, meaningless post-ship
+#   merged to dev       — its own description reads "Will be closed once
+#                         merged to main", which has now happened
+#
+# The counterpart to final-review's label-merged-issues.sh, which applies
+# `merged to dev` at the dev-merge step. This runs one stage later, from
+# ship.sh after the release merges to main — so patch-deployer inherits it
+# too, since it shells out to the same ship.sh.
+#
+# Only the curated-PR path carries `Closes #N` lines (ship-release step 2
+# forward-ports them via collect-closes-refs.sh). A release PR that ship.sh
+# auto-generated has none, and is a clean no-op — consistent with GitHub,
+# which wouldn't auto-close those issues either.
+#
+# Idempotent: re-adding an existing label is a no-op for the GitHub API, and
+# deleting an absent one 404s harmlessly.
+#
+# Usage: promote-shipped-issues.sh <release-pr>
+
+set -euo pipefail
+
+source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+
+pr="${1:?release PR number required}"
+repo="normalled/apijack"
+add_label="deployed"
+strip_labels=("ready-for-implement" "merged to dev")
+
+body=$(gh api "repos/$repo/pulls/$pr" --jq '.body // ""')
+
+# Match GitHub's recognized closing keywords:
+#   close / closes / closed
+#   fix / fixes / fixed
+#   resolve / resolves / resolved
+# followed by whitespace, `#`, and a number. Case-insensitive on the keyword.
+# The leading `\b` matters: without it, "discloses #15" would match and this
+# script would strip `ready-for-implement` off an unrelated open issue.
+#
+# `|| true` is load-bearing under `set -euo pipefail`: grep exits 1 when nothing
+# matches, which would abort the script on the legitimate no-closing-refs case
+# before the friendly message below could run.
+issues=$(printf '%s\n' "$body" \
+    | grep -oiE '\b(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+    | grep -oE '[0-9]+' \
+    | sort -un || true)
+
+if [ -z "$issues" ]; then
+    echo "promote-shipped-issues: no closing references in PR #$pr body; nothing to promote."
+    exit 0
+fi
+
+# The REST API rather than `gh issue edit --add-label`: the projects-classic
+# deprecation broke the edit path. Same workaround as ship.sh.
+failed=0
+while IFS= read -r issue; do
+    if gh api -X POST "repos/$repo/issues/$issue/labels" -f "labels[]=$add_label" >/dev/null 2>&1; then
+        for label in "${strip_labels[@]}"; do
+            # A 404 just means the label wasn't on the issue — expected.
+            gh api -X DELETE "repos/$repo/issues/$issue/labels/${label// /%20}" >/dev/null 2>&1 || true
+        done
+        echo "  + promoted issue #$issue to '$add_label'"
+    else
+        echo "  ! failed to promote issue #$issue (does it exist?)" >&2
+        failed=$((failed + 1))
+    fi
+done <<<"$issues"
+
+# Exit non-zero when nothing could be promoted, so ship.sh's `|| warn` is
+# reachable and a total failure isn't buried in an otherwise green ship.
+[ "$failed" -eq 0 ]

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -22,6 +22,16 @@ ok()    { echo -e "${GREEN}✓${NC} $1"; }
 fail()  { echo -e "${RED}✗${NC} $1"; }
 warn()  { echo -e "${YELLOW}!${NC} $1"; }
 
+# Promote issues closed by the release PR to `deployed`. Called from both the
+# published and the no-publish-needed paths — the PR is merged to main by the
+# time either runs. Never aborts: the release has already landed, so a
+# labelling hiccup must not leave the caller thinking the ship failed.
+promote_issues() {
+    info "Promoting shipped issues..."
+    "$(git rev-parse --show-toplevel)/scripts/promote-shipped-issues.sh" "$PR_NUM" \
+        || warn "Could not promote issue labels — release has landed; label by hand."
+}
+
 # ── Preflight ───────────────────────────────────────────────────────
 
 BRANCH=$(git branch --show-current)
@@ -227,6 +237,7 @@ done
 if [ -z "$PUBLISH_RUN" ] || [ "$PUBLISH_RUN" = "null" ]; then
     warn "Could not find publish workflow run."
     warn "The merge commit may have been the version bump (skipped by CI)."
+    promote_issues
     info "Pulling main..."
     git checkout main --quiet && git pull --quiet
     git checkout dev --quiet && git rebase main --quiet
@@ -247,7 +258,11 @@ gh run watch "$PUBLISH_RUN" --exit-status 2>/dev/null || {
 
 ok "Published to npm"
 
-# ── Step 8: Cleanup ────────────────────────────────────────────────
+# ── Step 8: Promote shipped issues ─────────────────────────────────
+
+promote_issues
+
+# ── Step 9: Cleanup ────────────────────────────────────────────────
 
 info "Syncing branches..."
 git checkout main --quiet && git pull --quiet


### PR DESCRIPTION
Closes #125

## Summary

Nothing in the release pipeline moved an issue to a terminal label once its code actually reached `main`. `deployed` was applied consistently through #84, then stopped — every issue from #91 onward closed still carrying `ready-for-implement` (a *triage*-state label) and, in most cases, `merged to dev`, whose own description reads "Will be closed once merged to main" and so is stale by definition the moment the release lands.

The 11 affected issues (#91, #98, #99, #100, #106, #109, #111, #115, #116, #118, #122) have been backfilled by hand. This PR is the automation so it stops recurring.

## What changes

### New `scripts/promote-shipped-issues.sh <release-pr>`

The direct counterpart to final-review's `label-merged-issues.sh`, one stage later in the pipeline — that script applies `merged to dev` at the dev-merge step; this one promotes to `deployed` after the release merges to `main`. It deliberately mirrors the sibling's structure, parse, and best-effort semantics.

Parses the release PR body for closing references, adds `deployed`, strips `ready-for-implement` and `merged to dev`. REST API for the label mutations, matching the existing workaround at `ship.sh:157` (`gh pr edit --add-label` is broken by the projects-classic deprecation).

### Wired into `ship.sh`, not the skill markdown

`ship.sh` gets a `promote_issues` helper called from **both** post-merge paths — after a successful publish, and in the `no publish needed` early-exit branch, which also runs with the PR already merged to `main`. Putting it in `ship.sh` rather than in `ship-release/SKILL.md` means `patch-deployer` inherits the behavior for free, since it shells out to the same script.

It never aborts a release: by the time it runs the code has already landed, so a labelling hiccup must not report a failed ship.

### Docs

Both `ship-release/SKILL.md` and `patch-deployer/SKILL.md` step lists updated (the latter was already stale-by-omission relative to the change).

## Acceptance criteria

- [ ] A release closing issues leaves each one labeled `deployed`, without `ready-for-implement` or `merged to dev`
- [ ] A chore-only release closing no issues is a clean no-op, exit 0
- [ ] Re-running against an already-promoted issue is idempotent
- [ ] A labelling failure does not abort a release that has already published

## Test plan

Verified against live PRs (all are idempotent re-runs against already-shipped releases):

- [x] `promote-shipped-issues.sh 124` → `+ promoted issue #122`, exit 0
- [x] `promote-shipped-issues.sh 121` → promoted #115, #116, #118, exit 0
- [x] `promote-shipped-issues.sh 114` (no closing refs) → friendly message, exit 0
- [x] Missing arg → usage error, exit 1
- [x] Failure accounting → synthetic bogus issue number yields exit 1, so `ship.sh`'s `|| warn` is reachable
- [x] `bash -n` on both scripts

Regex fixture, covering the false-positive case that motivated the leading `\b` — without it, `Discloses #15` would match and the script would strip `ready-for-implement` off an unrelated **open** issue:

```
Closes #10 / Fixed #11 / Resolved #12 / close #13 / Fixes #16   → 10 11 12 13 16   ✓
This prefixes #14 nothing / Discloses #15                       → not matched      ✓
```

## Reviewer notes

Two things worth a second look:

**The `|| true` on the issues pipeline is load-bearing.** Under `set -euo pipefail`, `grep` exiting 1 on no-match aborts the script before the friendly no-op message can run. I hit this as a live regression while testing and added it back with an accurate comment.

**The same bug exists in `label-merged-issues.sh` today** — `.claude/skills/final-review/scripts/label-merged-issues.sh 114` exits 1 silently, making its `if [ -z "$issues" ]` branch dead code. Pre-existing and out of scope here; filed separately.
