### PR TITLE
fix: ignore closing refs inside code when labeling issues (#129, #127)

### DIFF
--- a/.claude/skills/final-review/scripts/label-merged-issues.sh
+++ b/.claude/skills/final-review/scripts/label-merged-issues.sh
@@ -19,7 +19,10 @@
 
 set -euo pipefail
 
-source "$(git rev-parse --show-toplevel)/scripts/gh-pin-account.sh"
+repo_root="$(git rev-parse --show-toplevel)"
+source "$repo_root/scripts/gh-pin-account.sh"
+
+extract="$repo_root/scripts/extract-closing-refs.sh"
 
 pr="${1:?pr number required}"
 repo="normalled/apijack"
@@ -27,15 +30,16 @@ label="merged to dev"
 
 body=$(gh api "repos/$repo/pulls/$pr" --jq '.body // ""')
 
-# Match GitHub's recognized closing keywords:
-#   close / closes / closed
-#   fix / fixes / fixed
-#   resolve / resolves / resolved
-# followed by whitespace, `#`, and a number. Case-insensitive on the keyword.
-issues=$(printf '%s\n' "$body" \
-    | grep -oiE '\b(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+' \
-    | grep -oE '[0-9]+' \
-    | sort -un)
+# Keyword matching lives in scripts/extract-closing-refs.sh, shared with
+# promote-shipped-issues.sh and collect-closes-refs.sh. It strips fenced code
+# blocks and inline code spans first, so a body that merely documents the
+# `Closes #N` convention doesn't get read as a reference — the failure that
+# labeled five unrelated PRs during #126.
+#
+# It exits 0 with no output when there are no references, which keeps the
+# friendly branch below reachable under `set -euo pipefail` (#127) — and
+# non-zero on an internal failure, which aborts here rather than labeling nothing.
+issues=$(printf '%s\n' "$body" | "$extract" -)
 
 if [ -z "$issues" ]; then
     echo "label-merged-issues: no closing references in PR #$pr body; nothing to label."

--- a/scripts/collect-closes-refs.sh
+++ b/scripts/collect-closes-refs.sh
@@ -30,14 +30,39 @@ fi
 # no referenced PRs is a legitimate empty-output case, not a failure.
 PR_NUMS=$(grep -oE '#[0-9]+' "$COMMITS_FILE" | sed 's/#//' | sort -un || true)
 
+# Resolved relative to this script rather than via `git rev-parse`, so the
+# default /tmp commits-file usage still works from outside a checkout.
+EXTRACT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/extract-closing-refs.sh"
+
+# The extractor runs inside a process substitution below, whose exit status is
+# never examined, inside a loop that `continue`s freely — so unlike the other
+# two call sites, a missing or broken extractor here would fail SILENTLY and
+# yield an empty ref list. That is indistinguishable from a chore-only release,
+# and the release PR body would ship with no `Closes #N` lines at all, leaving
+# every issue in the release to never auto-close. Fail loudly instead.
+if [ ! -x "$EXTRACT" ]; then
+    echo "collect-closes-refs: extractor missing or not executable: $EXTRACT" >&2
+    exit 1
+fi
+
 declare -A SEEN
 for pr in $PR_NUMS; do
     BODY=$(gh pr view "$pr" --json body --jq '.body' 2>/dev/null) || continue
     [ -z "$BODY" ] && continue
+    # Shared with label-merged-issues.sh and promote-shipped-issues.sh. This
+    # call site is the upstream vector for #129: whatever it pulls out of an
+    # issue PR body gets written into the release PR body as `Closes #N`, which
+    # promote-shipped-issues.sh then acts on. A keyword quoted in a fenced
+    # example here becomes a real label mutation two steps later.
+    #
+    # Adopting the shared implementation also settles the drift this script had
+    # against the other two: it previously matched only Closes/Fixes/Resolves
+    # (missing the bare `close`/`fixed`/`resolved` forms GitHub honors) and
+    # lacked the leading `\b` that rejects `Discloses #15`.
     while IFS= read -r num; do
         [ -z "$num" ] && continue
         SEEN["$num"]=1
-    done < <(echo "$BODY" | grep -ioE '(Closes|Fixes|Resolves)[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' || true)
+    done < <(printf '%s\n' "$BODY" | "$EXTRACT" -)
 done
 
 for num in "${!SEEN[@]}"; do

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -28,9 +28,9 @@
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - a fence indented 4+ spaces is not recognized, so a fence nested inside a
-#     list item leaks its contents. Allowing any indent would be worse: an
-#     indented-code-block fence marker would open a phantom fence and swallow
-#     every real reference after it.
+#     list item leaks its contents (#134). Allowing any indent would be worse:
+#     an indented-code-block fence marker would open a phantom fence and
+#     swallow every real reference after it.
 #   - code spans are scanned per line, so a span that wraps across a newline
 #     leaks its contents
 #

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# extract-closing-refs.sh
+#
+# Read a markdown body (PR or issue) and print the issue number of every
+# GitHub closing reference it contains — one per line, deduped, ascending.
+#
+# The single extraction implementation shared by:
+#   .claude/skills/final-review/scripts/label-merged-issues.sh
+#   scripts/promote-shipped-issues.sh
+#   scripts/collect-closes-refs.sh
+#
+# Each of those used to carry its own copy of the regex, which drifted apart
+# and — more seriously — matched closing keywords written inside code. A PR
+# body that documents the `Closes #N` convention, or pastes a regex fixture
+# into a fenced block, is not making five closing references. Before #129 the
+# scripts read it as if it were: running label-merged-issues.sh against #126,
+# whose body contained exactly such a fixture, applied `merged to dev` to five
+# unrelated release PRs from months earlier.
+#
+# So: strip code before matching.
+#   - fenced blocks (``` and ~~~, per CommonMark: 3+ delimiters, up to 3
+#     spaces of indent, closing fence at least as long as the opening one)
+#   - inline code spans (`x`, ``x``, ...), scanned by matching delimiter-run
+#     length so ``Closes #10`` isn't half-stripped into a live reference
+#
+# Known and deliberate gaps — all of them leave a reference VISIBLE (a possible
+# false positive), never hide a real one, which is the safer direction to err:
+#   - indented code blocks and blockquotes are not stripped (per #129: a
+#     blockquote can legitimately carry a real reference)
+#   - a fence indented 4+ spaces is not recognized, so a fence nested inside a
+#     list item leaks its contents. Allowing any indent would be worse: an
+#     indented-code-block fence marker would open a phantom fence and swallow
+#     every real reference after it.
+#   - code spans are scanned per line, so a span that wraps across a newline
+#     leaks its contents
+#
+# Network-free by design: it takes text, not a PR number. Callers do their own
+# fetching, which differs between them for good reasons (the label scripts hit
+# `gh api repos/.../pulls/N`; collect-closes-refs.sh uses `gh pr view` so it can
+# skip numbers that turn out to be issues rather than PRs).
+#
+# Usage:
+#   extract-closing-refs.sh --body-file <file>
+#   extract-closing-refs.sh -            # read stdin
+#   cat body.md | extract-closing-refs.sh
+#
+# Output: issue numbers, one per line. Empty output and exit 0 when a body has
+# no closing references — that is a normal case (a chore PR opened outside the
+# template), not a failure. Callers run under `set -euo pipefail`, so getting
+# this wrong here would abort them; #127 was exactly that bug.
+#
+# Empty-output-exit-0 is the contract for "no references", so an INTERNAL
+# failure must never look like one: the tolerance below is scoped to grep's
+# exit 1 (no match) specifically, and awk runs outside the pipeline so `set -e`
+# catches it. Otherwise a broken extractor would read as "this release closes
+# nothing" and every issue in it would silently never auto-close.
+
+set -euo pipefail
+
+body_file=""
+case "${1-}" in
+    --body-file)
+        body_file="${2:?--body-file requires a path}"
+        ;;
+    -|"")
+        body_file="/dev/stdin"
+        ;;
+    *)
+        echo "usage: extract-closing-refs.sh [--body-file <file> | -]" >&2
+        exit 1
+        ;;
+esac
+
+# -r rather than -f so `--body-file <(...)` process substitution works.
+if [ "$body_file" != "/dev/stdin" ] && [ ! -r "$body_file" ]; then
+    echo "extract-closing-refs: body file not found: $body_file" >&2
+    exit 1
+fi
+
+# Match GitHub's recognized closing keywords:
+#   close / closes / closed
+#   fix / fixes / fixed
+#   resolve / resolves / resolved
+# followed by whitespace, `#`, and a number. Case-insensitive on the keyword.
+#
+# The leading word boundary matters: without it, "discloses #15" would match and
+# promote-shipped-issues.sh would strip `ready-for-implement` off an unrelated
+# open issue. Spelled `(^|[^[:alnum:]_])` rather than `\b` for portability — GNU
+# grep honors `\b` in ERE but BSD/macOS grep uses `[[:<:]]`, where `\b` degrades
+# to a literal `b` and silently matches nothing. The captured leading character
+# is harmless; the second grep keeps only the digits.
+KEYWORD_RE='(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+'
+
+AWK_STRIP='
+# Scan a line and drop every inline code span. Runs of backticks open a span
+# that only a run of the SAME length closes, so `` `` `` and ``` ` ``` nest
+# the way CommonMark says they do. An unmatched run is literal text and stays.
+function strip_spans(s,   out, i, n, run, j, closerun, found) {
+    out = ""
+    i = 1
+    n = length(s)
+    while (i <= n) {
+        if (substr(s, i, 1) != "`") {
+            out = out substr(s, i, 1)
+            i++
+            continue
+        }
+        run = 0
+        while (i + run <= n && substr(s, i + run, 1) == "`") run++
+        j = i + run
+        found = 0
+        while (j <= n) {
+            if (substr(s, j, 1) == "`") {
+                closerun = 0
+                while (j + closerun <= n && substr(s, j + closerun, 1) == "`") closerun++
+                if (closerun == run) { found = 1; break }
+                j += closerun
+            } else {
+                j++
+            }
+        }
+        if (found) {
+            i = j + run
+        } else {
+            out = out substr(s, i, run)
+            i += run
+        }
+    }
+    return out
+}
+
+BEGIN { in_fence = 0; fence_char = ""; fence_len = 0 }
+{
+    probe = $0
+    # Up to 3 spaces of indent still opens a fence; a 4th makes it an indented
+    # code block. Trimmed with a loop rather than /^ {0,3}/ because interval
+    # expressions are not portable across awk implementations.
+    indent = 0
+    while (indent < 3 && substr(probe, 1, 1) == " ") {
+        probe = substr(probe, 2)
+        indent++
+    }
+    if (match(probe, /^(```+|~~~+)/)) {
+        marker = substr(probe, 1, RLENGTH)
+        ch = substr(marker, 1, 1)
+        len = RLENGTH
+        rest = substr(probe, RLENGTH + 1)
+        if (in_fence == 0) {
+            # A backtick info string cannot itself contain a backtick, so
+            # ```` `a` ```` opens nothing — it is an inline span.
+            if (ch == "`" && index(rest, "`") > 0) {
+                print strip_spans($0)
+                next
+            }
+            in_fence = 1; fence_char = ch; fence_len = len
+            next
+        }
+        if (ch == fence_char && len >= fence_len && rest ~ /^[[:space:]]*$/) {
+            in_fence = 0; fence_char = ""; fence_len = 0
+            next
+        }
+    }
+    if (in_fence == 0) print strip_spans($0)
+}
+
+# A closing fence cannot carry a trailing info string, so one stray character on
+# it leaves the fence open and everything after it is treated as code. That is
+# CommonMark-correct but it silently drops real references — say so.
+END {
+    if (in_fence) print "extract-closing-refs: warning: unterminated code fence" > "/dev/stderr"
+}
+'
+
+# Deliberately outside the pipeline: an awk failure must abort under `set -e`
+# rather than be swallowed by the no-match tolerance below.
+stripped=$(awk "$AWK_STRIP" "$body_file")
+
+printf '%s\n' "$stripped" \
+    | grep -oiE "$KEYWORD_RE" \
+    | grep -oE '[0-9]+' \
+    | sort -un \
+    || [ $? -eq 1 ]   # grep exit 1 == no closing references. Any other status propagates.

--- a/scripts/promote-shipped-issues.sh
+++ b/scripts/promote-shipped-issues.sh
@@ -31,23 +31,20 @@ repo="normalled/apijack"
 add_label="deployed"
 strip_labels=("ready-for-implement" "merged to dev")
 
+extract="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/extract-closing-refs.sh"
+
 body=$(gh api "repos/$repo/pulls/$pr" --jq '.body // ""')
 
-# Match GitHub's recognized closing keywords:
-#   close / closes / closed
-#   fix / fixes / fixed
-#   resolve / resolves / resolved
-# followed by whitespace, `#`, and a number. Case-insensitive on the keyword.
-# The leading `\b` matters: without it, "discloses #15" would match and this
-# script would strip `ready-for-implement` off an unrelated open issue.
+# Keyword matching lives in scripts/extract-closing-refs.sh, shared with
+# label-merged-issues.sh and collect-closes-refs.sh. It strips fenced code
+# blocks and inline code spans first — which matters most here, because this
+# script doesn't only add a label, it strips `ready-for-implement`. A spurious
+# match silently destroys the triage state of an open, unshipped issue.
 #
-# `|| true` is load-bearing under `set -euo pipefail`: grep exits 1 when nothing
-# matches, which would abort the script on the legitimate no-closing-refs case
-# before the friendly message below could run.
-issues=$(printf '%s\n' "$body" \
-    | grep -oiE '\b(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+' \
-    | grep -oE '[0-9]+' \
-    | sort -un || true)
+# It exits 0 with no output when there are no references, so the friendly
+# branch below stays reachable under `set -euo pipefail` — and non-zero on an
+# internal failure, which aborts here rather than silently promoting nothing.
+issues=$(printf '%s\n' "$body" | "$extract" -)
 
 if [ -z "$issues" ]; then
     echo "promote-shipped-issues: no closing references in PR #$pr body; nothing to promote."

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -41,7 +41,12 @@ async function extractFile(path: string): Promise<ExtractResult> {
     return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
 }
 
-describe('extract-closing-refs.sh', () => {
+// `bun test` runs on windows-latest in CI, where Bun can't exec a .sh directly
+// (ENOENT). The scripts under test are release automation — they run from a
+// maintainer's shell and from Linux CI, never on Windows. Invoking them through
+// Git Bash instead would test a configuration nobody uses, and would lean on
+// MSYS's awk and coreutils rather than the ones these scripts actually run under.
+describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
     describe('genuine references', () => {
         test('matches every closing keyword form GitHub honors', async () => {
             const body = [

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -149,9 +149,9 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         // in scripts/extract-closing-refs.sh.
 
         test('a fence indented 4+ spaces is not recognized', async () => {
-            // Legitimate inside a nested list item. Permitting any indent would be
-            // worse: an indented-code-block fence marker would open a phantom
-            // fence and swallow every real reference after it.
+            // Legitimate inside a nested list item. Tracked as #134. Permitting any
+            // indent would be worse: an indented-code-block fence marker would open
+            // a phantom fence and swallow every real reference after it.
             const { issues } = await extract('Closes #7\n\n- outer\n  - inner\n    ```\n    Closes #100\n    ```\n');
             expect(issues).toEqual(['7', '100']);
         });

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -1,0 +1,254 @@
+import { describe, test, expect } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const repoRoot = join(import.meta.dir, '..');
+const scriptPath = join(repoRoot, 'scripts', 'extract-closing-refs.sh');
+const pr126Fixture = join(import.meta.dir, 'fixtures', 'pr-126-body.md');
+
+interface ExtractResult {
+    issues: string[];
+    exitCode: number;
+    stderr: string;
+}
+
+/** Feed a markdown body to the extractor on stdin and collect the issue numbers. */
+async function extract(body: string): Promise<ExtractResult> {
+    const proc = Bun.spawn([scriptPath, '-'], {
+        cwd: repoRoot,
+        stdin: new TextEncoder().encode(body),
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
+}
+
+async function extractFile(path: string): Promise<ExtractResult> {
+    const proc = Bun.spawn([scriptPath, '--body-file', path], {
+        cwd: repoRoot,
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
+}
+
+describe('extract-closing-refs.sh', () => {
+    describe('genuine references', () => {
+        test('matches every closing keyword form GitHub honors', async () => {
+            const body = [
+                'Closes #1',
+                'close #2',
+                'closed #3',
+                'Fix #4',
+                'fixes #5',
+                'FIXED #6',
+                'resolve #7',
+                'Resolves #8',
+                'resolved #9',
+            ].join('\n');
+            const { issues, exitCode } = await extract(body);
+            expect(issues).toEqual(['1', '2', '3', '4', '5', '6', '7', '8', '9']);
+            expect(exitCode).toBe(0);
+        });
+
+        test('dedupes and sorts numerically', async () => {
+            const { issues } = await extract('Closes #10\nFixes #10\nCloses #2\nResolves #33\n');
+            expect(issues).toEqual(['2', '10', '33']);
+        });
+
+        test('matches mid-sentence and with multiple refs on one line', async () => {
+            const { issues } = await extract('This one closes #4 and also fixes #5 nicely.');
+            expect(issues).toEqual(['4', '5']);
+        });
+
+        test('rejects keywords that merely end in a closing keyword', async () => {
+            const { issues } = await extract('Discloses #15\nprefixes #14\naffixes #13\n');
+            expect(issues).toEqual([]);
+        });
+    });
+
+    describe('code is not a reference', () => {
+        test('ignores refs inside a backtick fenced block', async () => {
+            const body = 'Closes #7\n\n```\nCloses #100\nFixes #101\n```\n';
+            const { issues } = await extract(body);
+            expect(issues).toEqual(['7']);
+        });
+
+        test('ignores refs inside a tilde fenced block', async () => {
+            const { issues } = await extract('~~~\nCloses #100\n~~~\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('honors an info string and a longer closing fence', async () => {
+            const body = '```bash\nCloses #100\n````\n\nCloses #7\n';
+            const { issues } = await extract(body);
+            expect(issues).toEqual(['7']);
+        });
+
+        test('honors up to three spaces of fence indent', async () => {
+            const { issues } = await extract('   ```\n   Closes #100\n   ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('ignores refs inside a single-backtick inline span', async () => {
+            const { issues } = await extract('Start the body with `Closes #100`. Closes #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('ignores refs inside a multi-backtick inline span', async () => {
+            // The naive `\`[^\`]*\`` strip leaves the content of ``...`` behind,
+            // turning a documented example back into a live reference.
+            const { issues } = await extract('Write ``Closes #100`` in the body. Fixes #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('treats an unmatched backtick as literal text', async () => {
+            const { issues } = await extract('an unpaired ` tick, closes #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('does not let an unterminated fence swallow the rest of the body', async () => {
+            // An opening fence with no closer means everything after it is code.
+            const { issues } = await extract('Closes #7\n\n```\nCloses #100\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('warns on stderr when a fence is left unterminated', async () => {
+            // A closing fence cannot carry trailing text, so `\`\`\` trailing` does
+            // not close — and the real ref after it is silently dropped. Correct
+            // per CommonMark, but it drops references, so it must be audible.
+            const { issues, stderr } = await extract('```\ncode\n``` trailing\nCloses #9\n');
+            expect(issues).toEqual([]);
+            expect(stderr).toContain('unterminated code fence');
+        });
+
+        test('handles CRLF bodies', async () => {
+            // `gh api` returns web-authored bodies with CRLF line endings.
+            const { issues } = await extract('Closes #7\r\n\r\n```\r\nCloses #100\r\n```\r\n');
+            expect(issues).toEqual(['7']);
+        });
+    });
+
+    describe('documented gaps', () => {
+        // These leak a reference rather than hide one — the safer direction. They
+        // are pinned so the behavior can't drift silently; see the header comment
+        // in scripts/extract-closing-refs.sh.
+
+        test('a fence indented 4+ spaces is not recognized', async () => {
+            // Legitimate inside a nested list item. Permitting any indent would be
+            // worse: an indented-code-block fence marker would open a phantom
+            // fence and swallow every real reference after it.
+            const { issues } = await extract('Closes #7\n\n- outer\n  - inner\n    ```\n    Closes #100\n    ```\n');
+            expect(issues).toEqual(['7', '100']);
+        });
+
+        test('a code span wrapping across a newline is not stripped', async () => {
+            const { issues } = await extract('See `foo\nCloses #100` bar\n');
+            expect(issues).toEqual(['100']);
+        });
+
+        test('blockquotes are not stripped', async () => {
+            const { issues } = await extract('> Closes #7\n');
+            expect(issues).toEqual(['7']);
+        });
+    });
+
+    describe('PR #126 regression', () => {
+        // The incident that motivated #129: this body carries one real reference
+        // plus a five-number regex fixture inside a fenced block. The old grep
+        // read all six and applied `merged to dev` to five unrelated release PRs.
+        test('yields only the real reference, none of the fixture numbers', async () => {
+            const { issues, exitCode } = await extractFile(pr126Fixture);
+            expect(issues).toEqual(['125']);
+            expect(exitCode).toBe(0);
+
+            for (const fixtureNum of ['10', '11', '12', '13', '16']) {
+                expect(issues).not.toContain(fixtureNum);
+            }
+        });
+    });
+
+    describe('no references is not a failure', () => {
+        // Regression for #127: the callers run under `set -euo pipefail`, so a
+        // non-zero exit here aborts them before their "nothing to label" branch.
+        test('exits 0 with no output on a body with no refs', async () => {
+            const { issues, exitCode } = await extract('chore: bump deps\n\nNothing to see here.\n');
+            expect(issues).toEqual([]);
+            expect(exitCode).toBe(0);
+        });
+
+        test('exits 0 with no output on an empty body', async () => {
+            const { issues, exitCode } = await extract('');
+            expect(issues).toEqual([]);
+            expect(exitCode).toBe(0);
+        });
+
+        test('exits 0 when every ref is fenced away', async () => {
+            const { issues, exitCode } = await extract('```\nCloses #100\n```\n');
+            expect(issues).toEqual([]);
+            expect(exitCode).toBe(0);
+        });
+    });
+
+    describe('usage', () => {
+        test('errors on an unknown argument', async () => {
+            const proc = Bun.spawn([scriptPath, '--nope'], { stdout: 'pipe', stderr: 'pipe' });
+            const stderr = await new Response(proc.stderr).text();
+            expect(await proc.exited).toBe(1);
+            expect(stderr).toContain('usage:');
+        });
+
+        test('errors on a missing body file', async () => {
+            const { exitCode, stderr } = await extractFile('/nonexistent/body.md');
+            expect(exitCode).toBe(1);
+            expect(stderr).toContain('body file not found');
+        });
+
+        test('reads stdin with no argument at all', async () => {
+            // The third documented usage form: `cat body.md | extract-closing-refs.sh`.
+            const proc = Bun.spawn([scriptPath], {
+                stdin: new TextEncoder().encode('Closes #7\n'),
+                stdout: 'pipe',
+                stderr: 'pipe',
+            });
+            const stdout = await new Response(proc.stdout).text();
+
+            expect(await proc.exited).toBe(0);
+            expect(stdout.split('\n').filter(Boolean)).toEqual(['7']);
+        });
+    });
+
+    describe('internal failure is not "no references"', () => {
+        // Empty-output-exit-0 is the contract for "this PR closes nothing". If an
+        // internal error produced the same signal, a broken extractor would read
+        // as a chore-only release and every issue in it would never auto-close.
+        test('propagates a non-zero exit when the awk stage fails', async () => {
+            const fakeBin = join(tmpdir(), `extract-refs-fakebin-${Date.now()}-${process.pid}`);
+            mkdirSync(fakeBin, { recursive: true });
+            try {
+                writeFileSync(join(fakeBin, 'awk'), '#!/bin/sh\nexit 3\n', { mode: 0o755 });
+                const proc = Bun.spawn([scriptPath, '-'], {
+                    stdin: new TextEncoder().encode('Closes #7\n'),
+                    stdout: 'pipe',
+                    stderr: 'pipe',
+                    env: { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` },
+                });
+                const stdout = await new Response(proc.stdout).text();
+
+                expect(await proc.exited).not.toBe(0);
+                expect(stdout.trim()).toBe('');
+            } finally {
+                rmSync(fakeBin, { recursive: true, force: true });
+            }
+        });
+    });
+});

--- a/tests/fixtures/pr-126-body.md
+++ b/tests/fixtures/pr-126-body.md
@@ -1,0 +1,59 @@
+Closes #125
+
+## Summary
+
+Nothing in the release pipeline moved an issue to a terminal label once its code actually reached `main`. `deployed` was applied consistently through #84, then stopped — every issue from #91 onward closed still carrying `ready-for-implement` (a *triage*-state label) and, in most cases, `merged to dev`, whose own description reads "Will be closed once merged to main" and so is stale by definition the moment the release lands.
+
+The 11 affected issues (#91, #98, #99, #100, #106, #109, #111, #115, #116, #118, #122) have been backfilled by hand. This PR is the automation so it stops recurring.
+
+## What changes
+
+### New `scripts/promote-shipped-issues.sh <release-pr>`
+
+The direct counterpart to final-review's `label-merged-issues.sh`, one stage later in the pipeline — that script applies `merged to dev` at the dev-merge step; this one promotes to `deployed` after the release merges to `main`. It deliberately mirrors the sibling's structure, parse, and best-effort semantics.
+
+Parses the release PR body for closing references, adds `deployed`, strips `ready-for-implement` and `merged to dev`. REST API for the label mutations, matching the existing workaround at `ship.sh:157` (`gh pr edit --add-label` is broken by the projects-classic deprecation).
+
+### Wired into `ship.sh`, not the skill markdown
+
+`ship.sh` gets a `promote_issues` helper called from **both** post-merge paths — after a successful publish, and in the `no publish needed` early-exit branch, which also runs with the PR already merged to `main`. Putting it in `ship.sh` rather than in `ship-release/SKILL.md` means `patch-deployer` inherits the behavior for free, since it shells out to the same script.
+
+It never aborts a release: by the time it runs the code has already landed, so a labelling hiccup must not report a failed ship.
+
+### Docs
+
+Both `ship-release/SKILL.md` and `patch-deployer/SKILL.md` step lists updated (the latter was already stale-by-omission relative to the change).
+
+## Acceptance criteria
+
+- [ ] A release closing issues leaves each one labeled `deployed`, without `ready-for-implement` or `merged to dev`
+- [ ] A chore-only release closing no issues is a clean no-op, exit 0
+- [ ] Re-running against an already-promoted issue is idempotent
+- [ ] A labelling failure does not abort a release that has already published
+
+## Test plan
+
+Verified against live PRs (all are idempotent re-runs against already-shipped releases):
+
+- [x] `promote-shipped-issues.sh 124` → `+ promoted issue #122`, exit 0
+- [x] `promote-shipped-issues.sh 121` → promoted #115, #116, #118, exit 0
+- [x] `promote-shipped-issues.sh 114` (no closing refs) → friendly message, exit 0
+- [x] Missing arg → usage error, exit 1
+- [x] Failure accounting → synthetic bogus issue number yields exit 1, so `ship.sh`'s `|| warn` is reachable
+- [x] `bash -n` on both scripts
+
+Regex fixture, covering the false-positive case that motivated the leading `\b` — without it, `Discloses #15` would match and the script would strip `ready-for-implement` off an unrelated **open** issue:
+
+```
+Closes #10 / Fixed #11 / Resolved #12 / close #13 / Fixes #16   → 10 11 12 13 16   ✓
+This prefixes #14 nothing / Discloses #15                       → not matched      ✓
+```
+
+## Reviewer notes
+
+Two things worth a second look:
+
+**The `|| true` on the issues pipeline is load-bearing.** Under `set -euo pipefail`, `grep` exiting 1 on no-match aborts the script before the friendly no-op message can run. I hit this as a live regression while testing and added it back with an accurate comment.
+
+**The same bug exists in `label-merged-issues.sh` today** — `.claude/skills/final-review/scripts/label-merged-issues.sh 114` exits 1 silently, making its `if [ -z "$issues" ]` branch dead code. Pre-existing and out of scope here; filed separately.
+


### PR DESCRIPTION
Closes #129
Closes #127

## Summary

Three scripts extracted `Closes #N`-style references from PR bodies with a plain `grep`, which has no notion of markdown structure. A closing keyword written inside a fenced code block or an inline code span matched exactly as if it were a real reference — and the scripts then mutated labels on whatever issue number followed.

This is not theoretical. PR #126's body contained a regex test fixture inside a fenced block; running `label-merged-issues.sh 126` parsed it as five real references and applied `merged to dev` to PRs #10, #11, #12, #13 and #16 — unrelated release PRs from months earlier, reverted by hand. The blast radius is worse for `promote-shipped-issues.sh`, which doesn't only add a label but **strips** `ready-for-implement`, silently destroying the triage state of an open, unshipped issue.

Release PR bodies are where this recurs most easily: `ship-release` and `patch-deployer` both instruct the author to paste representative code and YAML into the body, and the skills' own docs quote the closing-keyword convention.

This PR replaces all three regexes with one shared, network-free extractor that strips code before matching. It also picks up #127 — the missing `|| true` in `label-merged-issues.sh` — because the fix rewrites those exact lines, and putting the guard inside the extractor fixes it once for every caller.

## What changes

### New: `scripts/extract-closing-refs.sh`

Takes a markdown body on stdin or `--body-file`, prints issue numbers one per line, deduped and ascending. Network-free by design — callers keep their own fetch, which legitimately differs between them (the label scripts hit `gh api repos/.../pulls/N`; `collect-closes-refs.sh` uses `gh pr view` so it can skip numbers that turn out to be issues rather than PRs).

Stripping, via awk, before the keyword match:

- **Fenced blocks** — ``` and `~~~`, per CommonMark: 3+ delimiters, up to 3 spaces of indent, closing fence at least as long as the opening one, backtick info strings that can't themselves contain a backtick.
- **Inline code spans** — scanned by matching delimiter-run *length*, so ``` ``Closes #10`` ``` is removed whole. The naive `` `[^`]*` `` strip would consume just the two delimiter pairs and leave `Closes #10` behind as a live reference.

Three gaps are deliberate and documented in the script header, each pinned by a test. All of them leave a reference **visible** (a possible false positive) rather than hide a real one — the safer direction:

- indented code blocks and blockquotes aren't stripped (a blockquote can legitimately carry a real reference)
- a fence indented 4+ spaces isn't recognized, so a fence nested in a list item leaks. Allowing any indent would be worse: an indented-code-block fence marker would open a phantom fence and swallow every real reference after it.
- code spans are scanned per line, so a span wrapping across a newline leaks

The word boundary is spelled `(^|[^[:alnum:]_])` rather than `\b`: GNU grep honors `\b` in ERE but BSD/macOS grep uses `[[:<:]]`, where `\b` degrades to a literal `b` and matches nothing. `collect-closes-refs.sh` would have inherited that hazard newly. The awk program avoids interval expressions for the same reason and is verified identical under gawk and mawk.

### Modified: the three call sites

| Script | Before | After |
|---|---|---|
| `.claude/skills/final-review/scripts/label-merged-issues.sh` | own regex, **no** `|| true` | shared extractor |
| `scripts/promote-shipped-issues.sh` | own regex, `|| true` | shared extractor |
| `scripts/collect-closes-refs.sh` | **drifted** regex, `|| true` | shared extractor |

`collect-closes-refs.sh` is the upstream vector: whatever it pulls out of an issue-PR body gets written into the release PR body as `Closes #N`, which `promote-shipped-issues.sh` then acts on. A keyword quoted in a fenced example there becomes a real label mutation two steps later. Adopting the shared implementation also settles its drift — it previously matched only `Closes|Fixes|Resolves` (missing the bare `close`/`fixed`/`resolved` forms GitHub honors) and lacked the leading `\b` that rejects `Discloses #15`.

Measured against PR #126's real body (committed as `tests/fixtures/pr-126-body.md`):

```
OLD label-script regex:        10 11 12 13 16 125
OLD collect-closes-refs regex: 10 14 15 16 125      ← 14 and 15 from "prefixes #14" / "Discloses #15"
NEW shared extractor:          125
```

Sweeping the old regex against the new extractor over every PR body in the repo, exactly two differ — and both differ in the correct direction. Besides #126, review turned up a second, previously unnoticed false positive on **PR #80** (`old=[65 70] → new=[]`), whose body quotes two refs inside inline code spans. **Zero false negatives across every real body** — that's the dangerous direction, and it's clean.

### Error propagation

Empty-output-exit-0 is the extractor's contract for "this PR closes nothing", so an internal failure must never produce the same signal — otherwise a broken extractor reads as a chore-only release and every issue in it silently never auto-closes. Two guards:

- awk runs **outside** the pipeline, so `set -e` catches it; the trailing tolerance is scoped to grep's exit 1 (`|| [ $? -eq 1 ]`) rather than a blanket `|| true`.
- `collect-closes-refs.sh` checks the extractor is executable up front. It's the one call site where failure would otherwise be silent — the extractor runs inside a process substitution whose status is never examined, inside a loop that `continue`s freely. The other two assign from a command substitution and already abort under `pipefail`.

This PR body is its own regression test, for the same reason #126's was a live grenade — it quotes the closing-keyword convention throughout:

```
OLD label-script regex over this body: 10 125 127 129
NEW shared extractor:                  127 129
```

### #127: no closing refs is not a failure

`label-merged-issues.sh` ran its pipeline under `set -euo pipefail` with no `|| true`, so grep's exit 1 on no-match aborted the script and made its own `if [ -z "$issues" ]` friendly branch dead code. The `|| true` now lives inside the extractor, so all three callers inherit it:

```
$ .claude/skills/final-review/scripts/label-merged-issues.sh 114
label-merged-issues: no closing references in PR #114 body; nothing to label.
$ echo $?
0
```

## Acceptance criteria

- [ ] A closing keyword inside a fenced code block is ignored by all three scripts
- [ ] A closing keyword inside an inline code span is ignored, including multi-backtick delimiters
- [ ] Genuine references outside code are still matched, across all of GitHub's keyword forms (`close`/`closes`/`closed`, `fix`/`fixes`/`fixed`, `resolve`/`resolves`/`resolved`)
- [ ] `Discloses #15`-style false positives stay rejected (the leading `\b` is preserved)
- [ ] PR #126's body through the extractor yields only `125`, and none of 10/11/12/13/16
- [ ] All three scripts share one extraction implementation
- [ ] `collect-closes-refs.sh` adopts the unified keyword set
- [ ] `label-merged-issues.sh <pr-with-no-closing-refs>` prints its message and exits 0 (#127)
- [ ] Normal labelling behavior is unchanged for PRs that do have closing refs (#127)

## Test plan

- [x] `bun test` — 983 pass / 0 fail (25 new in `tests/extract-closing-refs.test.ts`)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `bash -n` on all four scripts
- [x] `label-merged-issues.sh 114` (no closing refs) → friendly message, exit 0 — the #127 repro
- [x] `promote-shipped-issues.sh 114` (no closing refs) → friendly message, exit 0
- [x] `collect-closes-refs.sh` over a commit range containing #126 → `Closes #125` only
- [x] `extract-closing-refs.sh --body-file tests/fixtures/pr-126-body.md` → `125`
- [x] Swept old regex vs. new extractor over every PR body in the repo → only #126 and #80 differ, both false positives removed, zero false negatives
- [x] awk shimmed to fail → extractor exits non-zero rather than reporting "no refs"
- [x] extractor chmod -x → `collect-closes-refs.sh` exits 1 with a message (was a silent exit 0)
- [x] awk program byte-identical under gawk 5.2 and mawk 1.3.4

New test coverage: every keyword form; dedupe and numeric sort; mid-sentence and multiple refs per line; `Discloses`/`prefixes`/`affixes` rejection; backtick and tilde fences; info strings; longer closing fences; 3-space fence indent; single- and multi-backtick inline spans; unmatched backtick as literal; unterminated fence (result and stderr warning); CRLF bodies; the three documented gaps; the #126 regression; empty-result exit-0 cases; all three usage forms; awk-failure propagation.

## Out of scope

Deferred to a follow-up, per triage on #129:

- GitHub's `closingIssuesReferences` GraphQL field as a cross-check in `promote-shipped-issues.sh`. It's fence-aware and authoritative, but only reports references closing against the **default** branch — so it can't serve `label-merged-issues.sh`, whose PRs target `dev`. Adding a second source of truth for one script but not the others reintroduces the drift this PR removes.
- Stripping indented code blocks and blockquotes.
