### PR TITLE
ci: trigger stable publishes on a tag push, not a commit-message match (#128)

### DIFF
--- a/.claude/skills/patch-deployer/SKILL.md
+++ b/.claude/skills/patch-deployer/SKILL.md
@@ -120,9 +120,10 @@ The script edits the open `dev → main` PR if one exists, otherwise pushes `dev
 2. Find the existing PR (won't overwrite the curated title/body)
 3. Wait for CI
 4. Merge via `gh pr merge --merge --admin`
-5. Watch the publish workflow create the release + publish to npm
-6. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines in the PR body)
-7. Sync main and rebase dev
+5. Tag the merge commit `vX.Y.Z` and push the tag — the tag push is what triggers `publish.yml`; merging alone never publishes
+6. Watch the publish workflow create the release + publish to npm
+7. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines in the PR body)
+8. Sync main and rebase dev
 
 If ship.sh exits non-zero, leave the PR in place for a human and stop.
 

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -147,13 +147,14 @@ ship.sh will:
 2. Find the existing PR (won't overwrite the curated title/body)
 3. Wait for CI
 4. Merge via `gh pr merge --merge --admin`
-5. Watch the publish workflow
-6. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines from step 2)
-7. Sync main and rebase dev
+5. Tag the merge commit `vX.Y.Z` and push the tag — the tag push is what triggers `publish.yml`; merging alone never publishes
+6. Watch the publish workflow
+7. Promote every issue closed by the release to `deployed`, stripping the now-stale `ready-for-implement` and `merged to dev` (via `scripts/promote-shipped-issues.sh`, driven by the `Closes #N` lines from step 2)
+8. Sync main and rebase dev
 
-Step 6 is why the `Closes #N` lines matter twice over: they auto-close the issues *and* drive the label promotion. A release that closes no issues is a clean no-op. Labelling never aborts a ship — the release is already published by then, so a failure only warns.
+Step 7 is why the `Closes #N` lines matter twice over: they auto-close the issues *and* drive the label promotion. A release that closes no issues is a clean no-op. Labelling never aborts a ship — the release is already published by then, so a failure only warns.
 
-If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off.
+If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off. That includes the post-merge window: if a run dies after merging but before the tag is pushed, main is bumped but nothing is published, and a plain re-run detects the untagged release and finishes it.
 
 ## Red Flags
 

--- a/.claude/skills/ship-release/SKILL.md
+++ b/.claude/skills/ship-release/SKILL.md
@@ -154,7 +154,7 @@ ship.sh will:
 
 Step 7 is why the `Closes #N` lines matter twice over: they auto-close the issues *and* drive the label promotion. A release that closes no issues is a clean no-op. Labelling never aborts a ship — the release is already published by then, so a failure only warns.
 
-If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off. That includes the post-merge window: if a run dies after merging but before the tag is pushed, main is bumped but nothing is published, and a plain re-run detects the untagged release and finishes it.
+If ship.sh fails at any step, it prints what to do. Fix on dev, commit, re-run — it picks up where it left off. That includes the post-merge window: if a run dies after merging but before the tag is pushed, main is bumped but nothing is published. Preflight checks for that state on every run — main's version having no matching tag, with a merged dev → main PR behind it — and finishes the release before considering new work.
 
 ## Red Flags
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(node -p "require('./package.json').version")
+
+          # The tag is now the input that armed this run, so it is a second
+          # source of truth alongside package.json. ship.sh keeps them in step;
+          # a hand-pushed tag might not, and a mismatch would create a stray
+          # second tag here and then collide in npm publish. Fail loudly first.
+          if [ "${{ github.ref_name }}" != "v$VERSION" ]; then
+              echo "::error::Tag ${{ github.ref_name }} does not match package.json version $VERSION"
+              exit 1
+          fi
+
           BODY_FILE=$(mktemp)
 
           # github.sha is the commit the tag points at — the merge commit on

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,14 +2,26 @@ name: Publish
 
 on:
   push:
-    branches: [main, next]
+    branches: [next]
+    # Stable releases are armed by an explicit tag push, never by a branch push.
+    # Kept broad on purpose — a glob too strict to match a real release tag
+    # would fail silently at ship time. Prerelease tags are excluded in the
+    # job's `if:` below, where the expression semantics are unambiguous.
+    tags: ['v*']
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release
-    # Only publish stable releases from main when a version bump commit is in the push
-    if: "github.ref == 'refs/heads/main' && (contains(github.event.head_commit.message, 'chore(release):') || contains(toJSON(github.event.commits.*.message), 'chore(release):'))"
+    # Release intent lives out-of-band in the tag — it cannot be spelled
+    # accidentally in a commit message, a revert, or a doc that quotes the
+    # release convention. See #128.
+    #
+    # The `-` exclusion keeps the `v1.16.0-next.0` tags that `publish-next`
+    # creates via `gh release create` from arming a stable publish. Those tags
+    # are made with GITHUB_TOKEN, which does not trigger workflows today — this
+    # is the explicit gate rather than a dependency on that behaviour holding.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     permissions:
       contents: write
       id-token: write
@@ -38,19 +50,11 @@ jobs:
       # Verify pack works
       - run: npm pack --dry-run
 
-      # Create git tag from package.json version
-      - name: Tag release
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          VERSION=$(node -p "require('./package.json').version")
-          git tag -a "v$VERSION" -m "v$VERSION"
-          git push --tags
-
-      # Create GitHub release. Prefer the merged PR's body (the curated release
-      # notes drafted by the ship-release skill — see PRs #36, #40, #45 for the
-      # template). Fall back to a commit summary only if no PR is associated
-      # with the push (e.g., a direct push to main).
+      # Create GitHub release. The tag already exists — ship.sh created it on
+      # the merge commit and pushing it is what triggered this run. Prefer the
+      # merged PR's body (the curated release notes drafted by the ship-release
+      # skill — see PRs #36, #40, #45 for the template). Fall back to a commit
+      # summary only if no PR is associated with the tagged commit.
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +62,8 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           BODY_FILE=$(mktemp)
 
-          # The push that triggered this run is the merge commit on main. Its
-          # associated PR is the dev → main release PR.
+          # github.sha is the commit the tag points at — the merge commit on
+          # main. Its associated PR is the dev → main release PR.
           PR_BODY=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
               --jq '.[0].body // empty' 2>/dev/null || true)
 
@@ -76,9 +80,17 @@ jobs:
                   "$COMMITS" "${PREV_TAG:-main}" "$VERSION" > "$BODY_FILE"
           fi
 
-          gh release create "v$VERSION" \
-              --title "v$VERSION" \
-              --notes-file "$BODY_FILE"
+          # Idempotent: re-running this workflow after a failed npm publish must
+          # not die here because the release already exists.
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+              gh release edit "v$VERSION" \
+                  --title "v$VERSION" \
+                  --notes-file "$BODY_FILE"
+          else
+              gh release create "v$VERSION" \
+                  --title "v$VERSION" \
+                  --notes-file "$BODY_FILE"
+          fi
           rm -f "$BODY_FILE"
 
       # Publish to npm via trusted publishing (OIDC — no token needed)

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -57,7 +57,7 @@ resolve_merge_sha() {
 # merge commit maps back to the dev → main release PR.
 tag_and_publish() {
     local sha="$1" version="$2"
-    local tag="v$2"
+    local tag="v$version"
     local existing run attempt
 
     # The merge commit is created server-side — fetch before tagging it.
@@ -153,7 +153,6 @@ resume_untagged_release() {
     warn "A previous ship merged PR #$merged_pr without tagging it — finishing that release."
 
     PR_NUM="$merged_pr"
-    NEW_VERSION="$main_version"
     resolve_merge_sha "$PR_NUM"
     tag_and_publish "$MERGE_SHA" "$main_version"
     promote_issues
@@ -178,12 +177,16 @@ if [ -n "$(git status --porcelain)" ]; then
     exit 1
 fi
 
+# Finish any half-finished ship before evaluating new work. This runs ahead of
+# the COMMITS check for two reasons: it refreshes origin/main (nothing else
+# does until tag_and_publish, so a run that died earlier would leave the ref
+# stale and COMMITS wrongly non-zero), and a stranded untagged release must be
+# recoverable even once dev has moved on. Exits 0 if it resumes; returns
+# silently when nothing is stuck.
+resume_untagged_release
+
 COMMITS=$(git log origin/main..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
 if [ "$COMMITS" = "0" ]; then
-    # Nothing ahead of main is also what a half-finished ship looks like:
-    # merged and bumped, but never tagged and so never published. Finish that
-    # before declaring there is nothing to do. Exits 0 if it resumes.
-    resume_untagged_release
     fail "No commits ahead of main. Nothing to ship."
     exit 1
 fi

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -32,6 +32,139 @@ promote_issues() {
         || warn "Could not promote issue labels — release has landed; label by hand."
 }
 
+# Resolve a merged PR's merge commit into $MERGE_SHA.
+#
+# `gh pr merge` returns once the REST merge completes, but `gh pr view` reads
+# GraphQL, which is eventually consistent — mergeCommit is briefly null. Retry
+# rather than hard-stop: past this point a bail leaves the release unpublished.
+resolve_merge_sha() {
+    local pr="$1" attempt
+    MERGE_SHA=""
+    for attempt in $(seq 1 5); do
+        MERGE_SHA=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null || true)
+        [ -n "$MERGE_SHA" ] && [ "$MERGE_SHA" != "null" ] && return 0
+        sleep 3
+    done
+    fail "Could not resolve the merge commit for PR #$pr after 5 attempts."
+    warn "Re-run ./scripts/ship.sh — it will detect the untagged release and finish it."
+    exit 1
+}
+
+# Tag <sha> as v<version>, push the tag, and watch the run it triggers.
+#
+# Tags the merge commit rather than main's tip: publish.yml resolves the
+# curated release body via the tagged commit's associated PR, and only the
+# merge commit maps back to the dev → main release PR.
+tag_and_publish() {
+    local sha="$1" version="$2"
+    local tag="v$2"
+    local existing run attempt
+
+    # The merge commit is created server-side — fetch before tagging it.
+    git fetch origin main --quiet || {
+        fail "Could not fetch origin/main."
+        warn "Re-run ./scripts/ship.sh — it will detect the untagged release and finish it."
+        exit 1
+    }
+
+    # A tag already on origin makes the push a no-op, so publish.yml would
+    # never fire and we would block for 5 minutes waiting on a phantom run.
+    if [ -n "$(git ls-remote --tags origin "refs/tags/$tag" 2>/dev/null)" ]; then
+        fail "Tag $tag already exists on origin — pushing it would not trigger a publish."
+        warn "If $version never published, re-run publish.yml from the Actions tab."
+        exit 1
+    fi
+
+    if existing=$(git rev-parse -q --verify "refs/tags/$tag^{commit}" 2>/dev/null); then
+        if [ "$existing" != "$sha" ]; then
+            fail "Local tag $tag points at $existing, but the release commit is $sha."
+            warn "Remove the stale tag and re-run: git tag -d $tag"
+            exit 1
+        fi
+        warn "Tag $tag already exists locally at the release commit — reusing it"
+    else
+        git tag -a "$tag" -m "$tag" "$sha" || {
+            fail "Could not create tag $tag at $sha."
+            exit 1
+        }
+    fi
+
+    info "Pushing tag $tag..."
+    git push origin "$tag" --quiet || {
+        fail "Could not push tag $tag."
+        warn "main is merged and bumped but unpublished. Recover with:"
+        warn "  git push origin $tag"
+        exit 1
+    }
+    ok "Tag $tag pushed"
+
+    # The tag push triggers publish.yml, so a run will appear — poll only for
+    # registration lag, then fail loudly rather than exiting 0 on a guess.
+    info "Waiting for publish workflow..."
+    run=""
+    for attempt in $(seq 1 30); do
+        run=$(gh run list --workflow publish.yml --commit "$sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+        [ -n "$run" ] && break
+        sleep 10
+    done
+
+    if [ -z "$run" ]; then
+        fail "No publish workflow run appeared for $tag after 300s."
+        warn "The tag is pushed. Check the Actions tab and re-run publish.yml there."
+        exit 1
+    fi
+
+    info "Watching publish run #$run..."
+    gh run watch "$run" --exit-status 2>/dev/null || {
+        fail "Publish workflow failed!"
+        echo ""
+        gh run view "$run" --log-failed 2>&1 | tail -20
+        echo ""
+        warn "The tag is pushed — fix the cause and re-run publish.yml from the Actions tab."
+        warn "Switch back: git checkout dev && git pull origin main --rebase"
+        exit 1
+    }
+
+    ok "Published to npm"
+}
+
+# Finish a release that was merged but never tagged.
+#
+# If a previous run died between `gh pr merge` and the tag push, main carries
+# the bump, dev has nothing ahead of it, and nothing is published — the plain
+# preflight would refuse to ship with no way forward. Detect that state and
+# complete it instead. Returns without acting when nothing is stuck.
+resume_untagged_release() {
+    local main_version merged_pr
+
+    git fetch origin main --tags --quiet 2>/dev/null || return 0
+    main_version=$(git show origin/main:package.json 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+    [ -n "$main_version" ] || return 0
+
+    # Tag present (locally or on origin) means the release was armed — not stuck.
+    git rev-parse -q --verify "refs/tags/v$main_version" >/dev/null 2>&1 && return 0
+    [ -n "$(git ls-remote --tags origin "refs/tags/v$main_version" 2>/dev/null)" ] && return 0
+
+    merged_pr=$(gh pr list --base main --head dev --state merged --limit 1 \
+        --json number --jq '.[0].number // empty' 2>/dev/null || true)
+    [ -n "$merged_pr" ] || return 0
+
+    warn "main is at v$main_version but no v$main_version tag exists."
+    warn "A previous ship merged PR #$merged_pr without tagging it — finishing that release."
+
+    PR_NUM="$merged_pr"
+    NEW_VERSION="$main_version"
+    resolve_merge_sha "$PR_NUM"
+    tag_and_publish "$MERGE_SHA" "$main_version"
+    promote_issues
+
+    info "Syncing branches..."
+    git checkout main --quiet && git pull --quiet
+    git checkout dev --quiet && git rebase main --quiet
+    ok "Resumed and shipped v$main_version"
+    exit 0
+}
+
 # ── Preflight ───────────────────────────────────────────────────────
 
 BRANCH=$(git branch --show-current)
@@ -47,6 +180,10 @@ fi
 
 COMMITS=$(git log origin/main..HEAD --oneline 2>/dev/null | wc -l | tr -d ' ')
 if [ "$COMMITS" = "0" ]; then
+    # Nothing ahead of main is also what a half-finished ship looks like:
+    # merged and bumped, but never tagged and so never published. Finish that
+    # before declaring there is nothing to do. Exits 0 if it resumes.
+    resume_untagged_release
     fail "No commits ahead of main. Nothing to ship."
     exit 1
 fi
@@ -219,44 +356,15 @@ info "Merging PR #$PR_NUM..."
 gh pr merge "$PR_NUM" --merge --delete-branch=false --admin
 ok "PR merged to main"
 
-# ── Step 7: Wait for publish workflow ──────────────────────────────
+# ── Step 7: Tag the release ────────────────────────────────────────
 
-info "Waiting for publish workflow..."
-sleep 10  # Give GitHub time to trigger the workflow
-
-# Find the publish run
-PUBLISH_RUN=""
-for i in $(seq 1 12); do
-    PUBLISH_RUN=$(gh run list --branch main --workflow publish.yml --limit 1 --json databaseId,status --jq '.[0].databaseId' 2>/dev/null || true)
-    if [ -n "$PUBLISH_RUN" ] && [ "$PUBLISH_RUN" != "null" ]; then
-        break
-    fi
-    sleep 5
-done
-
-if [ -z "$PUBLISH_RUN" ] || [ "$PUBLISH_RUN" = "null" ]; then
-    warn "Could not find publish workflow run."
-    warn "The merge commit may have been the version bump (skipped by CI)."
-    promote_issues
-    info "Pulling main..."
-    git checkout main --quiet && git pull --quiet
-    git checkout dev --quiet && git rebase main --quiet
-    ok "Done (no publish needed)"
-    exit 0
-fi
-
-info "Watching publish run #$PUBLISH_RUN..."
-gh run watch "$PUBLISH_RUN" --exit-status 2>/dev/null || {
-    fail "Publish workflow failed!"
-    echo ""
-    gh run view "$PUBLISH_RUN" --log-failed 2>&1 | tail -20
-    echo ""
-    warn "Fix the issue on dev, then re-run this script."
-    warn "Switch back: git checkout dev && git pull origin main --rebase"
-    exit 1
-}
-
-ok "Published to npm"
+# Everything below runs *after* the PR is merged, so main is already bumped.
+# The tag push is the only thing that triggers publish.yml, which makes the
+# merge → tag window the one place a failure leaves a release merged but
+# unpublished. Two things close it: every step here reports what to do, and
+# preflight's resume_untagged_release() finishes the job on a plain re-run.
+resolve_merge_sha "$PR_NUM"
+tag_and_publish "$MERGE_SHA" "$NEW_VERSION"
 
 # ── Step 8: Promote shipped issues ─────────────────────────────────
 


### PR DESCRIPTION
Closes #128

## Summary

`publish.yml` gated stable npm publishes by string-matching commit messages: `contains(toJSON(github.event.commits.*.message), 'chore(release):')` scanned **every** commit in a push to `main`. Any commit whose *text* happened to contain that literal armed a publish — a revert (`Revert "chore(release): v1.15.0"`), a docs or skill commit quoting the release convention (this repo's own `ship-release/SKILL.md` documents that exact string), or a branch merged to `main` carrying an older bump commit. The only backstop was npm refusing to republish an existing version, which fails open if `package.json` were also bumped.

Release intent now lives out-of-band in a git tag — you cannot accidentally write a git tag in prose. `ship.sh` tags the merge commit after the release PR merges and pushes it; that tag push is the sole publish trigger. Merging to `main` is now completely inert.

## What changes

### `.github/workflows/publish.yml`

Trigger moves off `main` and onto tags:

```yaml
on:
  push:
    branches: [next]
    tags: ['v*']

jobs:
  publish:
    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
```

- The redundant `Tag release` step (old `publish.yml:41-48`) is deleted — it derived the tag from `package.json` *after* the fact.
- `gh release create` became idempotent (`gh release view … || create`, else `edit`). Previously, re-running the workflow after an npm publish flake died on "release already exists" *before* reaching `npm publish`.
- Release notes are unchanged: `github.sha` on a tag push is the **commit** sha, so `commits/${{ github.sha }}/pulls` still resolves the tagged merge commit to the dev → main release PR.

### `scripts/ship.sh`

- Resolves the merge commit via `gh pr view --json mergeCommit` **with retries** — `gh pr merge` returns when the REST call completes, but `gh pr view` reads GraphQL, which is eventually consistent and briefly returns null.
- Refuses to push a tag that already exists on `origin` (the push would be a silent no-op and no workflow would fire) or that points at a commit other than the release commit.
- **New resume path.** The merge → tag window is the one place a failure now leaves a release merged-and-bumped but unpublished — and because `dev` then has nothing ahead of `main`, a plain re-run would dead-end at the preflight's "No commits ahead of main." `resume_untagged_release()` detects that exact state (main's version has no corresponding tag, a merged dev→main PR exists) and finishes the release. It returns silently in every other state.
- Dropped the 12×5s poll for a run that a branch-push trigger may never have started, along with its exit-0 "no publish needed" path. Run discovery now filters by `--commit "$MERGE_SHA"` (matching the existing `wait-for-publish-next.sh` pattern) and fails loudly.

### Docs

`ship-release/SKILL.md` and `patch-deployer/SKILL.md` both enumerate ship.sh's steps; added the tag step and renumbered. Corrected the "picks up where it left off" claim to describe the post-merge window explicitly.

## Note on the tag glob

The issue proposed `tags: ['v[0-9]+.[0-9]+.[0-9]+']`. I kept `v*` and moved the prerelease exclusion into the `if:`. GitHub documents `+` support in ref filters, but I could not verify `[]` range support or whether patterns anchor to the full ref — and the failure modes are asymmetric. A glob too *loose* lets a prerelease through, which the `if:` catches; a glob too *strict* means a stable release silently never publishes and you find out at ship time. `contains`/`startsWith` semantics are unambiguous, so the precision lives there.

This matters because `publish-next` creates prerelease tags: `gh release create "v1.16.0-next.0"` creates a git tag matching `v*`. Today those don't trigger workflows only because they're created with `GITHUB_TOKEN`. The `!contains(github.ref, '-')` gate makes that explicit rather than a dependency on that behaviour holding. (`github.ref` is `refs/tags/<tag>` — it never contains `owner/repo`, so `normalled/apijack`'s hyphen is irrelevant.)

## Acceptance criteria

- [ ] Merging anything to `main` without pushing a tag never publishes to npm
- [ ] Pushing a `vX.Y.Z` tag publishes that commit to npm and creates the GitHub release
- [ ] The GitHub release body is still the curated release-PR body, not a commit dump
- [ ] `next` prerelease publishing is unaffected
- [ ] Prerelease tags (`v1.16.0-next.0`) cannot arm the stable publish job
- [ ] `ship.sh` tags the merge commit on `main` and no longer relies on polling for a run that may not exist
- [ ] The redundant `Tag release` workflow step is removed

## Test plan

- [x] `bun test` — 958 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `bash -n scripts/ship.sh`; `publish.yml` parses and the trigger/`if:` fields resolve to the intended scalars
- [x] New ship.sh helpers exercised with stubbed `git`/`gh`:
  - tag already on `origin` → refuses instead of pushing a no-op
  - local tag at the wrong commit → refuses with a `git tag -d` hint
  - `mergeCommit` null for 2 polls then populated → resolves on attempt 3
  - `resume_untagged_release` across 4 states: tag exists locally / on origin / no merged PR → all return silently; merged-bumped-untagged → tags, promotes, syncs
- [x] Verified `set -e` does not trip on the `X && return 0` guards in the resume path

**Not verifiable pre-merge:** the tag trigger itself only exercises on a real release. The first ship after this merges is the live test — if no publish run appears, the tag is already pushed and `publish.yml` can be re-run from the Actions tab.
