### PR TITLE
fix: skip alias validation before codegen has run (#136)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,7 @@ Resolution rules:
 - Longest-prefix wins when multiple aliases could match.
 - An alias that shadows a real command path emits a startup warning and the real command keeps winning.
 - An expansion that doesn't resolve to a known command emits a startup error; the CLI continues without that alias applied.
+- Before `generate` has run (no generated commands registered), unresolved expansions are skipped silently instead — there is nothing meaningful to validate against yet.
 - A global `~/.<cliName>/aliases.json` is also consulted; project-local entries override global entries on conflict.
 - **Routines and MCP tool resolution use canonical names only.** Aliases are a CLI ergonomics layer; routine YAML and MCP tool names are not affected.
 

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -157,7 +157,10 @@ export interface RewriteResult {
  * - Aliases that match a real command path are skipped (warning emitted, real
  *   command keeps winning).
  * - Aliases whose expansion does not resolve to a real command path are skipped
- *   (error emitted, CLI continues without the alias).
+ *   (error emitted, CLI continues without the alias) -- unless
+ *   `opts.generatedCommandsPresent` is `false`, in which case they are skipped
+ *   silently, since there is nothing meaningful to validate against before
+ *   `generate` has run.
  * - Longest-prefix wins: multi-token aliases are matched before shorter ones.
  * - Trailing args (positional and flags) are appended verbatim.
  */
@@ -165,7 +168,9 @@ export function rewriteArgv(
     args: string[],
     aliases: AliasMap,
     realPaths: Set<string>,
+    opts?: { generatedCommandsPresent?: boolean },
 ): RewriteResult {
+    const generatedCommandsPresent = opts?.generatedCommandsPresent ?? true;
     const warnings: string[] = [];
     const errors: string[] = [];
     const valid = new Map<string, string[]>();
@@ -179,9 +184,12 @@ export function rewriteArgv(
         }
 
         if (!realPaths.has(expansion)) {
-            errors.push(
-                `alias "${alias}" → "${expansion}" does not resolve to a known command`,
-            );
+            if (generatedCommandsPresent) {
+                errors.push(
+                    `alias "${alias}" → "${expansion}" does not resolve to a known command`,
+                );
+            }
+
             continue;
         }
 

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -949,7 +949,10 @@ export function createCli(options: CliOptions): Cli {
 
             // 13. Apply project-local aliases (.apijack/aliases.json) by rewriting argv
             // before Commander parses. Real command paths always win over aliases;
-            // expansions that don't resolve to a known command are skipped with an error.
+            // expansions that don't resolve to a known command are skipped with an error
+            // — unless codegen hasn't run yet (or ran incompletely), in which case
+            // there's nothing meaningful to validate against and unresolved expansions
+            // are skipped silently.
             // The map was already loaded at the top of run() for early best-effort
             // resolution of pre-build argv reads — we reuse it here for the validated
             // rewrite now that the full Commander tree exists.
@@ -959,7 +962,7 @@ export function createCli(options: CliOptions): Cli {
                     process.argv.slice(2),
                     aliasMap,
                     realPaths,
-                    { generatedCommandsPresent: commandsModule !== null },
+                    { generatedCommandsPresent: commandsModule !== null && ApiClientClass !== null },
                 );
 
                 for (const w of warnings) {

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -959,6 +959,7 @@ export function createCli(options: CliOptions): Cli {
                     process.argv.slice(2),
                     aliasMap,
                     realPaths,
+                    { generatedCommandsPresent: commandsModule !== null },
                 );
 
                 for (const w of warnings) {

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -962,7 +962,10 @@ export function createCli(options: CliOptions): Cli {
                     process.argv.slice(2),
                     aliasMap,
                     realPaths,
-                    { generatedCommandsPresent: commandsModule !== null && ApiClientClass !== null },
+                    // Mirrors the registration condition above — an existing client
+                    // module that doesn't export ApiClient leaves ApiClientClass
+                    // `undefined`, not `null`.
+                    { generatedCommandsPresent: !!commandsModule && !!ApiClientClass },
                 );
 
                 for (const w of warnings) {

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -250,6 +250,60 @@ describe('rewriteArgv()', () => {
         const result = rewriteArgv(['config', 'cs'], aliases, realPaths);
         expect(result.rewrittenArgs).toEqual(['config', 'cs']);
     });
+
+    test('pre-codegen: alias pointing at a generated path is skipped silently', () => {
+        // Pre-codegen, "customers get-customer-order-summary" hasn't been registered
+        // yet, so it's absent from realPaths — same situation as an unknown expansion.
+        const aliases: AliasMap = { cs: 'customers get-customer-order-summary' };
+        const result = rewriteArgv(['cs', '42'], aliases, new Set(['generate', 'config']), {
+            generatedCommandsPresent: false,
+        });
+
+        expect(result.rewrittenArgs).toEqual(['cs', '42']);
+        expect(result.errors).toEqual([]);
+    });
+
+    test('pre-codegen: alias pointing at a built-in path still rewrites', () => {
+        const aliases: AliasMap = { g: 'generate' };
+        const result = rewriteArgv(['g'], aliases, realPaths, {
+            generatedCommandsPresent: false,
+        });
+
+        expect(result.rewrittenArgs).toEqual(['generate']);
+        expect(result.errors).toEqual([]);
+    });
+
+    test('pre-codegen: shadow warning is still emitted', () => {
+        const aliases: AliasMap = { customers: 'config switch' };
+        const result = rewriteArgv(['customers', 'list'], aliases, realPaths, {
+            generatedCommandsPresent: false,
+        });
+
+        expect(result.rewrittenArgs).toEqual(['customers', 'list']);
+        expect(result.warnings.length).toBe(1);
+        expect(result.warnings[0]).toContain('shadows a real command');
+        expect(result.errors).toEqual([]);
+    });
+
+    test('post-codegen: broken alias still emits an error', () => {
+        const aliases: AliasMap = { cs: 'customers nope' };
+        const result = rewriteArgv(['cs', '42'], aliases, realPaths, {
+            generatedCommandsPresent: true,
+        });
+
+        expect(result.rewrittenArgs).toEqual(['cs', '42']);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0]).toContain('does not resolve');
+    });
+
+    test('option omitted: broken alias still emits an error (default is validation on)', () => {
+        const aliases: AliasMap = { cs: 'customers nope' };
+        const result = rewriteArgv(['cs', '42'], aliases, realPaths);
+
+        expect(result.rewrittenArgs).toEqual(['cs', '42']);
+        expect(result.errors.length).toBe(1);
+        expect(result.errors[0]).toContain('does not resolve');
+    });
 });
 
 describe('resolveLeadingTokens()', () => {

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -151,6 +151,11 @@ describe('rewriteArgv()', () => {
         'generate',
     ]);
 
+    // Pre-codegen, only built-in commands are registered — no "customers *"
+    // paths exist yet. Used by the pre-codegen tests below so they reflect the
+    // actual state under test, rather than reusing the post-codegen `realPaths`.
+    const builtinPaths = new Set(['generate', 'config', 'config switch']);
+
     test('rewrites a single-token alias and appends trailing args', () => {
         const aliases: AliasMap = { cs: 'customers get-customer-order-summary' };
         const result = rewriteArgv(['cs', '42', '--foo', 'bar'], aliases, realPaths);
@@ -262,11 +267,6 @@ describe('rewriteArgv()', () => {
         expect(result.rewrittenArgs).toEqual(['cs', '42']);
         expect(result.errors).toEqual([]);
     });
-
-    // Pre-codegen, only built-in commands are registered — no "customers *"
-    // paths exist yet. Used by the two tests below so they reflect the actual
-    // state under test, rather than reusing the post-codegen `realPaths`.
-    const builtinPaths = new Set(['generate', 'config', 'config switch']);
 
     test('pre-codegen: alias pointing at a built-in path still rewrites', () => {
         const aliases: AliasMap = { g: 'generate' };

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -263,9 +263,14 @@ describe('rewriteArgv()', () => {
         expect(result.errors).toEqual([]);
     });
 
+    // Pre-codegen, only built-in commands are registered — no "customers *"
+    // paths exist yet. Used by the two tests below so they reflect the actual
+    // state under test, rather than reusing the post-codegen `realPaths`.
+    const builtinPaths = new Set(['generate', 'config', 'config switch']);
+
     test('pre-codegen: alias pointing at a built-in path still rewrites', () => {
         const aliases: AliasMap = { g: 'generate' };
-        const result = rewriteArgv(['g'], aliases, realPaths, {
+        const result = rewriteArgv(['g'], aliases, builtinPaths, {
             generatedCommandsPresent: false,
         });
 
@@ -274,12 +279,14 @@ describe('rewriteArgv()', () => {
     });
 
     test('pre-codegen: shadow warning is still emitted', () => {
-        const aliases: AliasMap = { customers: 'config switch' };
-        const result = rewriteArgv(['customers', 'list'], aliases, realPaths, {
+        // Pre-codegen, "customers" isn't a registered command, so an alias named
+        // "customers" can't shadow anything yet. Shadow a built-in instead.
+        const aliases: AliasMap = { config: 'generate' };
+        const result = rewriteArgv(['config', 'switch'], aliases, builtinPaths, {
             generatedCommandsPresent: false,
         });
 
-        expect(result.rewrittenArgs).toEqual(['customers', 'list']);
+        expect(result.rewrittenArgs).toEqual(['config', 'switch']);
         expect(result.warnings.length).toBe(1);
         expect(result.warnings[0]).toContain('shadows a real command');
         expect(result.errors).toEqual([]);

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -806,6 +806,62 @@ describe('cli.run() plugin validation', () => {
     });
 });
 
+describe('alias validation before codegen has run (#136)', () => {
+    test('does not report unresolved generated-command aliases before `generate` has run', async () => {
+        const workDir = join(tmpdir(), `apijack-alias-precodegen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        const cliConfigDir = join(workDir, '.testcli');
+        mkdirSync(cliConfigDir, { recursive: true });
+        // Points at an operation that would only exist once `generate` has run.
+        writeFileSync(
+            join(cliConfigDir, 'aliases.json'),
+            JSON.stringify({ cs: 'customers list-customers' }),
+        );
+
+        const origArgv = process.argv;
+        const origStderr = process.stderr.write.bind(process.stderr);
+        const origStdout = process.stdout.write.bind(process.stdout);
+        const origLog = console.log;
+        const origExit = process.exit;
+        let stderrOut = '';
+
+        try {
+            process.argv = ['node', 'testcli', 'config', 'list'];
+            process.stderr.write = ((c: string | Uint8Array) => {
+                stderrOut += String(c);
+
+                return true;
+            }) as never;
+            process.stdout.write = (() => true) as never;
+            console.log = () => {};
+            process.exit = (() => {
+                throw new Error('__exit__');
+            }) as never;
+
+            const cli = createCli(makeOptions({
+                configPath: join(cliConfigDir, 'config.json'),
+                // No `generated/` at this path — the same state as a fresh
+                // install where `generate` has not been run yet.
+                generatedDir: join(workDir, 'src', 'generated'),
+            }));
+
+            try {
+                await cli.run();
+            } catch (e) {
+                if ((e as Error).message !== '__exit__') throw e;
+            }
+        } finally {
+            process.argv = origArgv;
+            process.stderr.write = origStderr as never;
+            process.stdout.write = origStdout as never;
+            console.log = origLog;
+            process.exit = origExit;
+            rmSync(workDir, { recursive: true, force: true });
+        }
+
+        expect(stderrOut).not.toContain('does not resolve to a known command');
+    });
+});
+
 describe('cli.runRoutine', () => {
     let tmpHome: string;
     let configPath: string;


### PR DESCRIPTION
Closes #136

## Summary

Before `generate` has run, a consumer's `aliases.json` points at generated commands that aren't registered yet — so `rewriteArgv` reported *every* alias as broken, one stderr line each, on *every* invocation:

```
$ rrc --version
apijack: aliases: alias "matter list" → "matter matter-list" does not resolve to a known command
apijack: aliases: alias "matter create" → "admin matters create-matter" does not resolve to a known command
... 8 more ...
1.15.0
```

That's the state every fresh install starts in (`.apijack/generated/` is gitignored by design, so standalone-binary distributions can never ship it), and it lands on the worst possible surface: `setup`, a new user's very first command. Not a correctness bug — the aliases were right the whole time, and go silent once codegen runs.

This takes the issue's primary suggestion rather than the coarse fallback. `cli-builder.ts` already knows whether the generated command surface exists, so "codegen hasn't run" is an exact signal, not a name-based heuristic: when generated commands aren't registered, unresolved expansions are skipped silently — there is nothing meaningful to validate against. When they *are* registered, a genuinely broken alias still errors exactly as before.

## What changes

### `src/aliases.ts`

`rewriteArgv` takes a fourth parameter, defaulting to validation-on so the change is purely additive for every existing caller:

```ts
opts?: { generatedCommandsPresent?: boolean }
```

When `false`, an expansion missing from `realPaths` is dropped from the valid map **silently** instead of pushing an error. Everything else is untouched: the shadow-warning branch, longest-prefix matching, tail passthrough, and the return shape are all unchanged, and `continue` runs on both paths — no alias that previously applied stops applying, and none previously dropped now applies.

### `src/cli-builder.ts`

The single call site opts in, gated on both halves of the registration condition:

```ts
{ generatedCommandsPresent: commandsModule !== null && ApiClientClass !== null }
```

Both are required because registration itself requires both. `commandsModule` is assigned as soon as `generated/commands` imports, but the `generated/client` import follows it inside the same `try` — so a partial codegen (valid `commands.ts`, missing `client.ts`) would otherwise leave `commandsModule` non-null while no generated commands were ever registered, resurrecting the full spam in exactly the broken state this PR is meant to quiet.

### Tests

Five unit tests on `rewriteArgv` (both states, plus the omitted-option default), and one integration test that drives a real `cli.run()` with an `aliases.json` pointing at a generated operation and no `generated/` on disk, asserting the noise never reaches stderr.

### Docs

The alias resolution rules in `CLAUDE.md` note the pre-codegen exception.

## Acceptance criteria

- [x] Pre-codegen, aliases pointing at generated commands produce zero stderr output
- [x] Pre-codegen, an alias expanding to a built-in still rewrites correctly — the fix does not disable aliasing wholesale
- [x] Post-codegen, a genuinely broken alias still emits its per-alias error
- [x] Shadow warnings (`alias "X" shadows a real command`) are unaffected in both states
- [x] The new parameter defaults to validation-on, so existing callers are unaffected
- [x] Unit coverage for the new gate in both states, plus integration coverage of the call site

## Test plan

- [x] `bun test` — 989 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings, unchanged)
- [x] Mutation-checked the integration test: hardcoding `generatedCommandsPresent: true` makes it fail with `testcli: aliases: alias "cs" → "customers list-customers" does not resolve to a known command`, confirming it actually guards the fix rather than passing vacuously.

## Reviewer notes

Two judgment calls worth a second opinion:

- **Silent suppression also silences a typo'd alias pointing at a built-in.** `{"cfg": "config swtich"}` errors post-codegen but is silent pre-codegen, so whether you learn about the typo depends on whether `generate` has run. The user still gets Commander's `error: unknown command 'cfg'` at parse time, so it's not a silent no-op — and the alternative (per-alias "does this look generated?" heuristics) is exactly what the issue rules out.
- **`resolveLeadingTokens` is deliberately untouched.** It never validated against the command tree (see its JSDoc), so it behaves identically pre- and post-codegen and needs no equivalent gate.
