### PR TITLE
fix: measure fence indent from the container content column (#134)

### DIFF
--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -44,6 +44,8 @@
 #     indent 0 and a tab-indented list item as a marker at column 0
 #   - a lazy paragraph continuation dedented out of its list item pops the
 #     container early, which only lowers the column a fence must beat
+#   - a fence opener sharing a line with its list marker (`- ```) is not seen,
+#     because the opener is looked for at the line indent, not past the marker
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -142,7 +144,10 @@ function strip_spans(s,   out, i, n, run, j, closerun, found) {
 
 # How far past its own indent the content of a list item starts — the marker width
 # plus the spaces after it. 0 when the line is not a list item. A marker at end
-# of line still opens an item whose content column is one past the marker.
+# of line still opens an item whose content column is one past the marker, and so
+# does one followed by 5+ spaces: per CommonMark those extra spaces are indented
+# code inside the item, so counting them would raise the column and let a fence
+# open where code was meant — swallowing a reference, the direction #134 avoids.
 function list_offset(p,   w, n, c) {
     w = 0
     c = substr(p, 1, 1)
@@ -161,6 +166,7 @@ function list_offset(p,   w, n, c) {
     if (substr(p, w + 1, 1) != " ") return 0
     n = 0
     while (substr(p, w + n + 1, 1) == " ") n++
+    if (n > 4) n = 1
     return w + n
 }
 

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -18,21 +18,32 @@
 # unrelated release PRs from months earlier.
 #
 # So: strip code before matching.
-#   - fenced blocks (``` and ~~~, per CommonMark: 3+ delimiters, up to 3
-#     spaces of indent, closing fence at least as long as the opening one)
+#   - fenced blocks (``` and ~~~, per CommonMark: 3+ delimiters, closing fence
+#     at least as long as the opening one)
 #   - inline code spans (`x`, ``x``, ...), scanned by matching delimiter-run
 #     length so ``Closes #10`` isn't half-stripped into a live reference
+#
+# Fence indent is measured from the content column of the enclosing list item,
+# not from column 0 (#134): a fence nested in a list legitimately sits at 4+
+# spaces, and reading it as prose leaked everything inside it. The awk pre-pass
+# therefore tracks open list items and allows a fence within 3 of that column.
+# List markers are capped the same way, and that cap is what makes the rule
+# safe: base + 4 is by definition an indented code block, so a fence marker or
+# a `- item` line inside indented code opens nothing. Recognizing a fence at any
+# indent instead was rejected — a stray fence marker in indented code would open
+# a phantom fence and swallow every real reference after it, and a swallowed
+# reference is the one failure nothing flags.
 #
 # Known and deliberate gaps — all of them leave a reference VISIBLE (a possible
 # false positive), never hide a real one, which is the safer direction to err:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
-#   - a fence indented 4+ spaces is not recognized, so a fence nested inside a
-#     list item leaks its contents (#134). Allowing any indent would be worse:
-#     an indented-code-block fence marker would open a phantom fence and
-#     swallow every real reference after it.
 #   - code spans are scanned per line, so a span that wraps across a newline
 #     leaks its contents
+#   - tabs are not expanded to tab stops, so a tab-indented fence reads as
+#     indent 0 and a tab-indented list item as a marker at column 0
+#   - a lazy paragraph continuation dedented out of its list item pops the
+#     container early, which only lowers the column a fence must beat
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -129,38 +140,93 @@ function strip_spans(s,   out, i, n, run, j, closerun, found) {
     return out
 }
 
-BEGIN { in_fence = 0; fence_char = ""; fence_len = 0 }
+# How far past its own indent the content of a list item starts — the marker width
+# plus the spaces after it. 0 when the line is not a list item. A marker at end
+# of line still opens an item whose content column is one past the marker.
+function list_offset(p,   w, n, c) {
+    w = 0
+    c = substr(p, 1, 1)
+    if (c == "-" || c == "*" || c == "+") {
+        w = 1
+    } else {
+        n = 0
+        while (substr(p, n + 1, 1) ~ /^[0-9]$/) n++
+        if (n > 0) {
+            c = substr(p, n + 1, 1)
+            if (c == "." || c == ")") w = n + 1
+        }
+    }
+    if (w == 0) return 0
+    if (length(p) == w) return w + 1
+    if (substr(p, w + 1, 1) != " ") return 0
+    n = 0
+    while (substr(p, w + n + 1, 1) == " ") n++
+    return w + n
+}
+
+BEGIN {
+    in_fence = 0; fence_char = ""; fence_len = 0; fence_indent = 0; fence_base = 0
+    depth = 0; base = 0
+}
 {
-    probe = $0
-    # Up to 3 spaces of indent still opens a fence; a 4th makes it an indented
-    # code block. Trimmed with a loop rather than /^ {0,3}/ because interval
-    # expressions are not portable across awk implementations.
+    # Leading spaces, counted with a loop rather than /^ */ because the count is
+    # needed and interval expressions are not portable across awk implementations.
     indent = 0
-    while (indent < 3 && substr(probe, 1, 1) == " ") {
-        probe = substr(probe, 2)
-        indent++
-    }
-    if (match(probe, /^(```+|~~~+)/)) {
-        marker = substr(probe, 1, RLENGTH)
-        ch = substr(marker, 1, 1)
-        len = RLENGTH
-        rest = substr(probe, RLENGTH + 1)
-        if (in_fence == 0) {
-            # A backtick info string cannot itself contain a backtick, so
-            # ```` `a` ```` opens nothing — it is an inline span.
-            if (ch == "`" && index(rest, "`") > 0) {
-                print strip_spans($0)
-                next
+    while (substr($0, indent + 1, 1) == " ") indent++
+    probe = substr($0, indent + 1)
+    blank = ($0 ~ /^[[:space:]]*$/)
+
+    if (in_fence) {
+        if (blank || indent >= fence_base) {
+            if (match(probe, /^(```+|~~~+)/)) {
+                ch = substr(probe, 1, 1)
+                # The closer is measured against the opener rather than the
+                # container: the lenient reading, which closes sooner.
+                if (ch == fence_char && RLENGTH >= fence_len && indent <= fence_indent + 3 &&
+                    substr(probe, RLENGTH + 1) ~ /^[[:space:]]*$/) {
+                    in_fence = 0; fence_char = ""; fence_len = 0
+                }
             }
-            in_fence = 1; fence_char = ch; fence_len = len
             next
         }
-        if (ch == fence_char && len >= fence_len && rest ~ /^[[:space:]]*$/) {
-            in_fence = 0; fence_char = ""; fence_len = 0
-            next
+        # Dedented out of the list item holding the fence, so the fence ended
+        # with it. Fall through and process this line normally — an unclosed
+        # nested fence must not swallow the rest of the body.
+        in_fence = 0; fence_char = ""; fence_len = 0
+    }
+
+    if (!blank) {
+        # A list item may contain blank lines, so only a non-blank line closes
+        # containers. Popping eagerly lowers base, which makes a deep fence
+        # LESS likely to be recognized — the false-positive direction.
+        while (depth > 0 && indent < stack[depth]) depth--
+        base = 0
+        if (depth > 0) base = stack[depth]
+
+        # Both markers below are capped at 3 past the content column of the
+        # container. base + 4 is by definition an indented code block, so a fence
+        # marker there is inert without tracking indented code separately — and
+        # the cap on list markers is what keeps a `- item` line inside indented
+        # code from opening a container that would re-enable deep fences.
+        if (indent <= base + 3) {
+            off = list_offset(probe)
+            if (off > 0) {
+                depth++
+                stack[depth] = indent + off
+                base = stack[depth]
+            } else if (match(probe, /^(```+|~~~+)/)) {
+                ch = substr(probe, 1, 1)
+                # A backtick info string cannot itself contain a backtick, so
+                # ```` `a` ```` opens nothing — it is an inline span.
+                if (ch != "`" || index(substr(probe, RLENGTH + 1), "`") == 0) {
+                    in_fence = 1; fence_char = ch; fence_len = RLENGTH
+                    fence_indent = indent; fence_base = base
+                    next
+                }
+            }
         }
     }
-    if (in_fence == 0) print strip_spans($0)
+    print strip_spans($0)
 }
 
 # A closing fence cannot carry a trailing info string, so one stray character on

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -44,18 +44,20 @@
 # the state machine is there for exactly that reason. Weigh it before touching
 # the escape.
 #
-# Known and deliberate gaps — all but the one noted above leave a reference
-# VISIBLE (a possible false positive) rather than hiding a real one, which is the
-# safer direction to err:
+# Known and deliberate gaps. Most leave a reference VISIBLE (a possible false
+# positive) rather than hiding a real one, which is the safer direction to err —
+# the two that can hide one, the early-close reopen above and the setext
+# underline below, say so where they are described:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
 #     leaks its contents
 #   - tabs are not expanded to tab stops, so a tab-indented fence reads as
-#     indent 0 and a tab-indented list item as a marker at column 0. Tab-led
-#     lines are exempt from the fence early-close above, which covers the one
-#     shape of this that hid references; a tab after leading spaces does not
-#     get that exemption
+#     indent 0 and a tab-indented list item as a marker at column 0. A tab in
+#     column 1 is exempt from the fence early-close above while the fence sits
+#     at container column 4 or less — that is as far as a tab reaches, and it is
+#     the shape of this that hid references. A tab after leading spaces gets no
+#     exemption and lands wherever its space count puts it
 #   - a lazy paragraph continuation dedented out of its list item pops the
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
@@ -219,7 +221,11 @@ BEGIN {
         # to column 4 and keeps the line inside the fence. Without the exemption
         # the fence ends here and its real closer opens a second one, swallowing
         # every reference after it — silently, when that second fence is closed.
-        if (blank || indent >= fence_base || substr($0, 1, 1) == "\t") {
+        # Column 4 is also where the exemption stops: in a container deeper than
+        # that the tab really does land short, so the line is out of the fence
+        # and its reference is prose. Holding it in would swallow that reference
+        # the same silent way, just deeper.
+        if (blank || indent >= fence_base || (substr($0, 1, 1) == "\t" && fence_base <= 4)) {
             if (match(probe, /^(```+|~~~+)/)) {
                 ch = substr(probe, 1, 1)
                 # The closer is measured against the opener rather than the

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -171,7 +171,9 @@ function list_offset(p,   w, n, c, t) {
     # A thematic break wears a marker character but is not a list item, and the
     # container it would push raises the column enough to open the indented code
     # under it as a fence. Spaces are allowed between the dashes, so compare the
-    # whitespace-stripped line: 3+ of the same character and nothing else.
+    # whitespace-stripped line: 3+ of one character and nothing else. That also
+    # catches `- ---`, which CommonMark reads as a list item CONTAINING a break;
+    # returning 0 there only lowers the column, so it errs the safe way.
     t = p
     gsub(/[[:space:]]/, "", t)
     c = substr(t, 1, 1)
@@ -185,9 +187,12 @@ function list_offset(p,   w, n, c, t) {
     if (c == "-" || c == "*" || c == "+") {
         w = 1
     } else {
+        # CommonMark caps an ordered marker at 9 digits; a longer run is a
+        # paragraph, and treating it as an item would raise the column for
+        # everything under it — the unsafe direction.
         n = 0
         while (substr(p, n + 1, 1) ~ /^[0-9]$/) n++
-        if (n > 0) {
+        if (n > 0 && n <= 9) {
             c = substr(p, n + 1, 1)
             if (c == "." || c == ")") w = n + 1
         }

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -171,9 +171,10 @@ function list_offset(p,   w, n, c, t) {
     # A thematic break wears a marker character but is not a list item, and the
     # container it would push raises the column enough to open the indented code
     # under it as a fence. Spaces are allowed between the dashes, so compare the
-    # whitespace-stripped line: 3+ of one character and nothing else. That also
-    # catches `- ---`, which CommonMark reads as a list item CONTAINING a break;
-    # returning 0 there only lowers the column, so it errs the safe way.
+    # whitespace-stripped line: 3+ of one character and nothing else. `- ---`
+    # lands here too and should: a thematic break outranks a list item when a
+    # line could be read as either, so four dashes with a space among them are
+    # a break, and returning 0 matches CommonMark rather than merely erring safe.
     t = p
     gsub(/[[:space:]]/, "", t)
     c = substr(t, 1, 1)

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -34,18 +34,35 @@
 # a phantom fence and swallow every real reference after it, and a swallowed
 # reference is the one failure nothing flags.
 #
-# Known and deliberate gaps — all of them leave a reference VISIBLE (a possible
-# false positive), never hide a real one, which is the safer direction to err:
+# The one rule that can hide a reference is the flip side of that: a fence still
+# open when its list item ends is closed with the item, so an unterminated nested
+# fence cannot swallow the rest of the body. But if the item did not really end,
+# the fence's own closing line is then read as a NEW opener and everything after
+# it is swallowed instead — and when that second fence gets closed too, silently,
+# with no unterminated-fence warning. Anything that makes a line inside a fence
+# look shallower than the fence's container walks into this; the tab exemption in
+# the state machine is there for exactly that reason. Weigh it before touching
+# the escape.
+#
+# Known and deliberate gaps — all but the one noted above leave a reference
+# VISIBLE (a possible false positive) rather than hiding a real one, which is the
+# safer direction to err:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
 #     leaks its contents
 #   - tabs are not expanded to tab stops, so a tab-indented fence reads as
-#     indent 0 and a tab-indented list item as a marker at column 0
+#     indent 0 and a tab-indented list item as a marker at column 0. Tab-led
+#     lines are exempt from the fence early-close above, which covers the one
+#     shape of this that hid references; a tab after leading spaces does not
+#     get that exemption
 #   - a lazy paragraph continuation dedented out of its list item pops the
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
 #     because the opener is looked for at the line indent, not past the marker
+#   - a setext heading underline (`Title` over a bare `-`) reads as a list item
+#     and pushes a container, since detecting it needs previous-line state; the
+#     container it pushes can open indented code under it as a fence
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -148,7 +165,19 @@ function strip_spans(s,   out, i, n, run, j, closerun, found) {
 # does one followed by 5+ spaces: per CommonMark those extra spaces are indented
 # code inside the item, so counting them would raise the column and let a fence
 # open where code was meant — swallowing a reference, the direction #134 avoids.
-function list_offset(p,   w, n, c) {
+function list_offset(p,   w, n, c, t) {
+    # A thematic break wears a marker character but is not a list item, and the
+    # container it would push raises the column enough to open the indented code
+    # under it as a fence. Spaces are allowed between the dashes, so compare the
+    # whitespace-stripped line: 3+ of the same character and nothing else.
+    t = p
+    gsub(/[[:space:]]/, "", t)
+    c = substr(t, 1, 1)
+    if (c == "-" || c == "*" || c == "_") {
+        n = 0
+        while (substr(t, n + 1, 1) == c) n++
+        if (n >= 3 && n == length(t)) return 0
+    }
     w = 0
     c = substr(p, 1, 1)
     if (c == "-" || c == "*" || c == "+") {
@@ -162,7 +191,9 @@ function list_offset(p,   w, n, c) {
         }
     }
     if (w == 0) return 0
-    if (length(p) == w) return w + 1
+    # Nothing but whitespace after the marker is an empty item, whose content
+    # column CommonMark also puts one past the marker.
+    if (substr(p, w + 1) ~ /^[[:space:]]*$/) return w + 1
     if (substr(p, w + 1, 1) != " ") return 0
     n = 0
     while (substr(p, w + n + 1, 1) == " ") n++
@@ -183,7 +214,12 @@ BEGIN {
     blank = ($0 ~ /^[[:space:]]*$/)
 
     if (in_fence) {
-        if (blank || indent >= fence_base) {
+        # A tab-led line is exempt from the dedent escape below: indent counts
+        # spaces only, so it reads as column 0, but CommonMark expands the tab
+        # to column 4 and keeps the line inside the fence. Without the exemption
+        # the fence ends here and its real closer opens a second one, swallowing
+        # every reference after it — silently, when that second fence is closed.
+        if (blank || indent >= fence_base || substr($0, 1, 1) == "\t") {
             if (match(probe, /^(```+|~~~+)/)) {
                 ch = substr(probe, 1, 1)
                 # The closer is measured against the opener rather than the
@@ -191,6 +227,7 @@ BEGIN {
                 if (ch == fence_char && RLENGTH >= fence_len && indent <= fence_indent + 3 &&
                     substr(probe, RLENGTH + 1) ~ /^[[:space:]]*$/) {
                     in_fence = 0; fence_char = ""; fence_len = 0
+                    fence_indent = 0; fence_base = 0
                 }
             }
             next
@@ -199,6 +236,7 @@ BEGIN {
         # with it. Fall through and process this line normally — an unclosed
         # nested fence must not swallow the rest of the body.
         in_fence = 0; fence_char = ""; fence_len = 0
+        fence_indent = 0; fence_base = 0
     }
 
     if (!blank) {

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -176,6 +176,48 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual(['7']);
         });
 
+        test('a tab-indented line inside a nested fence does not end it', async () => {
+            // Indent counts spaces only, so a tab read as column 0 used to dedent
+            // out of the fence and leave the genuine closer to open a new one,
+            // swallowing everything after it. CommonMark puts a tab at column 4.
+            const { issues } = await extract('- a\n  ```\n\tcode\n  ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('a tab-indented line inside a nested fence does not silently reopen it', async () => {
+            // The variant of the above with a real second fence: the whole body
+            // shifted by one fence, exit 0, and no warning — a false negative
+            // with nothing to flag it.
+            const { issues, exitCode, stderr } = await extract('- a\n  ```\n\tcode\n  ```\n  Closes #7\n  ```\nCloses #8\n');
+            expect(issues).toEqual(['7', '8']);
+            expect(exitCode).toBe(0);
+            expect(stderr).toBe('');
+        });
+
+        test('a thematic break is not a list item', async () => {
+            // `- - -` and `* * *` are rules. Pushing a container for them raises
+            // the column enough for the indented code below to open as a fence.
+            const dashes = await extract('- - -\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(dashes.issues).toEqual(['7', '100']);
+
+            const stars = await extract('* * *\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(stars.issues).toEqual(['7', '100']);
+        });
+
+        test('a marker followed only by whitespace puts content one column past it', async () => {
+            // An empty list item, per CommonMark — counting the trailing spaces
+            // instead would raise the column and open the code block below.
+            const { issues } = await extract('-   \n      ```\n      Closes #100\n      ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
+        });
+
+        test('a reference on the list-marker line itself is still printed', async () => {
+            // The one new code path that runs on a line carrying a live
+            // reference: it pushes a container and must still reach the print.
+            const { issues } = await extract('- Closes #7\n1. Closes #8\n- [ ] Closes #9\n');
+            expect(issues).toEqual(['7', '8', '9']);
+        });
+
         test('ignores refs inside a single-backtick inline span', async () => {
             const { issues } = await extract('Start the body with `Closes #100`. Closes #7\n');
             expect(issues).toEqual(['7']);
@@ -225,6 +267,13 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             // spaces is made inert) but deliberately does not strip it: per #129
             // a reference is better left visible than swallowed.
             const { issues } = await extract('para\n\n    Closes #100\n');
+            expect(issues).toEqual(['100']);
+        });
+
+        test('indented code inside a list item is not stripped either', async () => {
+            // The case the container fix actually introduces: base is 2 here, so
+            // the block starts at 6 rather than 4. Still visible, same as above.
+            const { issues } = await extract('- a\n\n      Closes #100\n');
             expect(issues).toEqual(['100']);
         });
 

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -216,6 +216,14 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(stars.issues).toEqual(['7', '100']);
         });
 
+        test('an ordered marker longer than 9 digits is not a list item', async () => {
+            // CommonMark caps ordered markers at 9 digits, so this is a
+            // paragraph. Accepting it pushes a container that raises the column
+            // for everything indented under it — the unsafe direction.
+            const { issues } = await extract('1234567890. outer\n            ```\n            Closes #100\n            ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
+        });
+
         test('a marker followed only by whitespace puts content one column past it', async () => {
             // An empty list item, per CommonMark — counting the trailing spaces
             // instead would raise the column and open the code block below.
@@ -270,9 +278,10 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
     });
 
     describe('documented gaps', () => {
-        // These leak a reference rather than hide one — the safer direction. They
-        // are pinned so the behavior can't drift silently; see the header comment
-        // in scripts/extract-closing-refs.sh.
+        // Most of these leak a reference rather than hide one — the safer
+        // direction. The two that can hide one are pinned last, and say so. All
+        // of them are here so the behavior can't drift silently; see the header
+        // comment in scripts/extract-closing-refs.sh.
 
         test('an indented code block is not stripped', async () => {
             // The fix models indented code (that is how a fence marker at 4+
@@ -297,6 +306,27 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         test('blockquotes are not stripped', async () => {
             const { issues } = await extract('> Closes #7\n');
             expect(issues).toEqual(['7']);
+        });
+
+        test('a setext underline hides the indented code beneath it — and is silent', async () => {
+            // HIDES a reference. A heading underlined with a bare lone `-` needs
+            // previous-line state to tell from a list item, so it pushes a
+            // container, and the indented code under it opens as a fence instead
+            // of staying visible. Narrow (`--` and `---` both take other paths)
+            // but this is one of the two shapes nothing else flags.
+            const { issues, stderr } = await extract('Title\n-\n\n    ```\n    Closes #1\n    ```\n');
+            expect(issues).toEqual([]);
+            expect(stderr).toBe('');
+        });
+
+        test('a fence closed after an early close hides the rest — but warns', async () => {
+            // HIDES a reference. Flush-left code under a bullet dedents out of
+            // the item, so the fence ends early and its real closer opens a
+            // second one over the remainder. CommonMark agrees the reference is
+            // code here, and the unterminated warning fires, so it stays audible.
+            const { issues, stderr } = await extract('- Steps:\n  ```bash\nnpm install\n  ```\n\nCloses #7\n');
+            expect(issues).toEqual([]);
+            expect(stderr).toContain('unterminated code fence');
         });
     });
 

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -320,10 +320,12 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         });
 
         test('a fence closed after an early close hides the rest — but warns', async () => {
-            // HIDES a reference. Flush-left code under a bullet dedents out of
-            // the item, so the fence ends early and its real closer opens a
-            // second one over the remainder. CommonMark agrees the reference is
-            // code here, and the unterminated warning fires, so it stays audible.
+            // Pins the MECHANISM, not a divergence. Flush-left code under a
+            // bullet dedents out of the item, so the fence ends early and its
+            // real closer opens a second one over the remainder. In this shape
+            // CommonMark agrees the reference is code and the warning fires, so
+            // nothing is actually hidden — a shape where the mechanism does
+            // diverge is hard to construct, which is why this stands in for it.
             const { issues, stderr } = await extract('- Steps:\n  ```bash\nnpm install\n  ```\n\nCloses #7\n');
             expect(issues).toEqual([]);
             expect(stderr).toContain('unterminated code fence');

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -104,6 +104,70 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual(['7']);
         });
 
+        test('a fence nested inside a list item is recognized', async () => {
+            // CommonMark measures fence indent from the enclosing list item's
+            // content column, so a nested fence sits at 4+ spaces and used to
+            // leak everything inside it (#134).
+            const { issues } = await extract('Closes #7\n\n- outer\n  - inner\n    ```\n    Closes #100\n    ```\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('recognizes a fence at a single list item content column', async () => {
+            // One level of nesting is the common shape in a PR body, and the
+            // fence still opens when a blank line separates it from the marker.
+            const { issues } = await extract('Closes #7\n\n- outer\n\n    ```\n    Closes #100\n    ```\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('an ordered list marker sets the content column too', async () => {
+            // The content column cannot be assumed to be 2: `1. ` is three wide.
+            const { issues } = await extract('1. outer\n   ```\n   Closes #100\n   ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('a fence marker inside an indented code block opens nothing', async () => {
+            // The reason "recognize a fence at any indent" was rejected: a
+            // phantom fence here would swallow every real reference after it,
+            // which is the false-negative direction.
+            const { issues } = await extract('Closes #7\n\n    ```\n    not a fence\n\nCloses #8\n');
+            expect(issues).toEqual(['7', '8']);
+        });
+
+        test('a list marker inside an indented code block opens no container', async () => {
+            // Without the indent cap on list markers, this would push a
+            // container and re-enable the deep fence below it.
+            const { issues } = await extract('Closes #7\n\n    - item\n      ```\n      Closes #100\n\nCloses #8\n');
+            expect(issues).toEqual(['7', '8', '100']);
+        });
+
+        test('a closer indented up to three deeper than its opener still closes', async () => {
+            // The lenient reading of CommonMark's closer indent rule: it closes
+            // sooner, which leaves later references visible.
+            const { issues } = await extract('Closes #7\n\n- outer\n  ```\n  Closes #100\n    ```\n\nCloses #8\n');
+            expect(issues).toEqual(['7', '8']);
+        });
+
+        test('a deeper fence marker inside an open fence is content, not a closer', async () => {
+            // 4+ past the opener is code inside the block; treating it as a
+            // closer would expose the rest of the block as prose.
+            const { issues } = await extract('- a\n  ```\n      ```\n  Closes #100\n  ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('a fence left open inside a list item ends with the list item', async () => {
+            // Otherwise one unclosed nested fence hides every reference in the
+            // rest of the body.
+            const { issues } = await extract('- item\n  ```\n  code\n\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('a fence after the list has ended is measured from column 0 again', async () => {
+            // Containers have to be popped on dedent, or the body keeps the
+            // deepest content column it ever saw.
+            const { issues } = await extract('- a\n  - b\n\npara\n\n    ```\n    x\n\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
         test('ignores refs inside a single-backtick inline span', async () => {
             const { issues } = await extract('Start the body with `Closes #100`. Closes #7\n');
             expect(issues).toEqual(['7']);
@@ -148,12 +212,12 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         // are pinned so the behavior can't drift silently; see the header comment
         // in scripts/extract-closing-refs.sh.
 
-        test('a fence indented 4+ spaces is not recognized', async () => {
-            // Legitimate inside a nested list item. Tracked as #134. Permitting any
-            // indent would be worse: an indented-code-block fence marker would open
-            // a phantom fence and swallow every real reference after it.
-            const { issues } = await extract('Closes #7\n\n- outer\n  - inner\n    ```\n    Closes #100\n    ```\n');
-            expect(issues).toEqual(['7', '100']);
+        test('an indented code block is not stripped', async () => {
+            // The fix models indented code (that is how a fence marker at 4+
+            // spaces is made inert) but deliberately does not strip it: per #129
+            // a reference is better left visible than swallowed.
+            const { issues } = await extract('para\n\n    Closes #100\n');
+            expect(issues).toEqual(['100']);
         });
 
         test('a code span wrapping across a newline is not stripped', async () => {

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -194,6 +194,18 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(stderr).toBe('');
         });
 
+        test('the tab exemption stops where a tab stops, at column 4', async () => {
+            // A leading tab reaches column 4 and no further, so once the fence
+            // sits in a container deeper than that, the line really is dedented
+            // out of it and the reference is prose. Holding it inside would
+            // swallow that reference silently — the defect the exemption above
+            // exists to fix, just moved deeper.
+            const { issues, exitCode, stderr } = await extract('- a\n  - b\n    - c\n      ```\n\tCloses #100\n      ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
+            expect(exitCode).toBe(0);
+            expect(stderr).toBe('');
+        });
+
         test('a thematic break is not a list item', async () => {
             // `- - -` and `* * *` are rules. Pushing a container for them raises
             // the column enough for the indented code below to open as a fence.

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -140,6 +140,14 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual(['7', '8', '100']);
         });
 
+        test('a list marker followed by 5+ spaces starts indented code, not a deeper content column', async () => {
+            // CommonMark caps the content column at marker + 1 space when 5 or more
+            // follow; without the cap, base lands at 6 and the fence below opens —
+            // swallowing a real reference, the direction #134 exists to avoid.
+            const { issues } = await extract('-     item\n      ```\n      Closes #100\n      ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
+        });
+
         test('a closer indented up to three deeper than its opener still closes', async () => {
             // The lenient reading of CommonMark's closer indent rule: it closes
             // sooner, which leaves later references visible.


### PR DESCRIPTION
Closes #134

## Summary

`scripts/extract-closing-refs.sh` stripped fenced code blocks before matching closing keywords, but only recognized a fence opener at indent 0–3. CommonMark measures fence indent relative to the enclosing list item's **content column**, so a fence nested inside a list legitimately sits at 4+ spaces — and the extractor read straight through it:

```
$ printf 'Closes #7\n\n- outer\n  - inner\n    ```\n    Closes #100\n    ```\n' \
    | ./scripts/extract-closing-refs.sh -
7
100      <-- inside a real fence
```

That matters because the consumers mutate labels: `promote-shipped-issues.sh` *strips* `ready-for-implement` and `merged to dev` on every number it sees, and `collect-closes-refs.sh` writes matches into release PR bodies as `Closes #N`. Release PR bodies are nested-bullet-heavy with pasted YAML — exactly the shape that leaks.

The fix is one rule: **a fence opener — and a list marker — is recognized only within 3 spaces of the current container's content column, not of column 0.** Because an indented code block starts at `base + 4` by definition, that same rule makes a fence marker sitting inside indented code inert for free. No separate "am I in indented code" state exists, and none is needed.

That distinction is the whole reason #130 deferred this. Permitting a fence at *any* indent would have let a stray fence marker in an indented block open a phantom fence and swallow every real reference after it — trading a rare false positive for a broad false **negative**, which is an issue that silently never auto-closes and nothing flags.

## What changes

### `scripts/extract-closing-refs.sh`

The awk pre-pass now carries block context: a stack of open list-item content columns, plus the indent and container depth each fence was opened at.

- **List markers push a content column.** `-`, `*`, `+`, and ordered `N.` / `N)` markers push `indent + markerWidth + spacesAfter`. Recognized only at `indent <= base + 3`, so a `- item` line inside an indented code block can't open a phantom container and re-enable deep fences.
- **CommonMark's 5+-space rule is honored**: a marker followed by five or more spaces caps the content column at `marker + 1`, the extra spaces being indented code inside the item. Without the cap, `base` overshoots and a fence opens where CommonMark says code — the false-negative direction.
- **Containers pop aggressively** — any non-blank line at a lower indent pops. Popping early lowers `base`, which makes a deep fence *less* likely to be recognized; the bias is deliberate.
- **A fence closes when its list item ends.** A non-blank line indented below the fence's container closes the fence and is then processed normally. Without this, a fence left open inside a list item would swallow every reference in the rest of the body.
- **Closers** match on fence char, run length `>= fence_len`, blank remainder, and `indent <= fence_indent + 3` — the lenient reading, which closes sooner.
- **A tab-led line does not trigger the early close while the fence's container sits at column 4 or below.** Indent is counted in spaces, so `\tcode` would otherwise read as column 0, dedent out of the fence, and leave the genuine closer to be re-read as a fresh opener — swallowing everything after it, silently. A tab expands to column 4, so the exemption stops there: at container column 5+ a tab-led line really is dedented out, and the reference really is prose. Both sides of that boundary are pinned.

Every listed gap in the header still errs the same direction: visible reference, never hidden one. The 4+-indent entry is gone; tabs-not-expanded and lazy-paragraph-continuation are now named.

`strip_spans`, the keyword regex, CRLF tolerance, the unterminated-fence stderr warning, and the awk-outside-the-pipeline exit handling are untouched. Indented code blocks and blockquotes are still **not** stripped — that stays the #129 decision, and the new code models indented code without stripping it.

### `tests/extract-closing-refs.test.ts`

The pinned gap test `a fence indented 4+ spaces is not recognized` moves out of `documented gaps` and into `code is not a reference`, asserting the fixed result. Sixteen cases added, each pinning a direction the state machine could fail in: single-level and nested list fences, ordered markers, a fence marker inside indented code, a list marker inside indented code, indented code *inside* a list item, a closer indented deeper than its opener, a deeper fence marker inside an open fence, a fence left open when its list ends, a fence after the list has ended, the 5+-space marker cap, thematic breaks not pushing a container, a reference carried on the marker line itself (`- Closes #7`, `1. Closes #7`, `- [ ] Closes #7`), and both sides of the tab boundary. `documented gaps` gains an explicit pin that indented code is still not stripped.

## Acceptance criteria

- [x] A fence nested inside a list item (4+ spaces of indent) has its contents ignored
- [x] An indented code block containing a fence marker does **not** open a phantom fence — references after it are still matched
- [x] The existing `documented gaps` test for this behavior asserts the fixed behavior rather than pinning the leak
- [x] No regression against the #126 and #80 bodies, or the full-repo sweep

## Test plan

- [x] `bun test` — 1000 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `bash -n scripts/extract-closing-refs.sh` — clean
- [x] Portability matrix, the script's 42 tests run against each awk via a PATH shim: **GNU awk 5.2.1** 42/0, **mawk** 42/0, **busybox awk** 42/0. `gawk --posix` is 40/42, the same two pre-existing `/dev/stderr` failures reproduced identically against `dev`
- [x] Issue repro: the nested-list body above now yields `7` alone
- [x] Tab boundary swept across container columns 0–7 against reference CommonMark — strip at 0–4, visible at 5–7, matching at every row
- [x] **Full-repo sweep** — all 135 issue and PR bodies in the repo, extracted three ways: the pre-#129 raw regex, the extractor as it stands on `dev`, and the extractor on this branch.
  - **`dev`-vs-branch: 0 differences.** No live body's result changes; the fix only closes the shape #134 describes.
  - raw-vs-branch: 4 bodies, all dropping false positives only — #126 (`10 11 12 13 14 15 16 125` → `125`) and #80 (`65 70` → nothing), the two #130 identified, plus #130 (`10 14 15 125 127 129` → `127 129`) and #134 itself (`7 100` → nothing), both filed after that sweep was taken and both carrying fenced fixtures.
