### PR TITLE
chore: add shellcheck gate to CI (#132)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
       - 'bun.lockb'
       - 'tsconfig*.json'
       - '.github/workflows/ci.yml'
+      - 'scripts/**'
+      - '.claude/skills/**/scripts/**'
 
 jobs:
   lint:
@@ -25,6 +27,47 @@ jobs:
           bun-version: latest
       - run: bun install
       - run: bun run lint
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install shellcheck v0.10.0
+        run: |
+          set -euo pipefail
+          url="https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz"
+          sha256="6c881ab0698e4e6ea235245f22832860544f17ba386442fe7e9d629f8cbedf87"
+          curl -sSL --fail --retry 3 --retry-all-errors "$url" -o "$RUNNER_TEMP/shellcheck.tar.xz"
+          echo "$sha256  $RUNNER_TEMP/shellcheck.tar.xz" | sha256sum -c -
+          tar -xJf "$RUNNER_TEMP/shellcheck.tar.xz" -C "$RUNNER_TEMP"
+          echo "$RUNNER_TEMP/shellcheck-v0.10.0" >> "$GITHUB_PATH"
+      - name: Run shellcheck
+        run: |
+          set -euo pipefail
+          # severity=warning: `error` is a no-op gate (0 findings measured against
+          # this tree); `warning` catches the real issues (2 SC2034 in scripts/ship.sh,
+          # both fixed) without the noise of `style` (5). No --enable=all:
+          # SC2310/SC2311 fire zero times here, so enabling `all` would only add
+          # ~35 info + ~592 style findings for no signal on the case it was
+          # proposed for.
+          shopt -s nullglob globstar
+
+          script_files=(scripts/**/*.sh)
+          if [ "${#script_files[@]}" -eq 0 ]; then
+            echo "::error::scripts/**/*.sh matched no files"
+            exit 1
+          fi
+
+          skill_files=(.claude/skills/**/scripts/*.sh)
+          if [ "${#skill_files[@]}" -eq 0 ]; then
+            echo "::error::.claude/skills/**/scripts/*.sh matched no files"
+            exit 1
+          fi
+
+          shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}"
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
           # in scripts/ship.sh, both fixed here) without the noise of `style`
           # (5 on the current tree — all SC1091/SC2016/SC2317, none real
           # defects). No --enable=all: SC2310/SC2311 fire zero times here, so
-          # enabling `all` would only add ~35 info + ~592 style findings for no
-          # signal on the case it was proposed for.
+          # enabling `all` would only add tens of info and hundreds of style
+          # findings (37 and 614 when this was written) for no signal on the
+          # case it was proposed for.
           shopt -s nullglob globstar
 
           script_files=(scripts/**/*.sh)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,13 @@ jobs:
       - name: Run shellcheck
         run: |
           set -euo pipefail
-          # severity=warning: `error` is a no-op gate (0 findings measured against
-          # this tree); `warning` catches the real issues (2 SC2034 in scripts/ship.sh,
-          # both fixed) without the noise of `style` (5). No --enable=all:
-          # SC2310/SC2311 fire zero times here, so enabling `all` would only add
-          # ~35 info + ~592 style findings for no signal on the case it was
-          # proposed for.
+          # severity=warning: `error` is a no-op gate (0 findings against this
+          # tree, before and after); `warning` caught the real issues (2 SC2034
+          # in scripts/ship.sh, both fixed here) without the noise of `style`
+          # (5 on the current tree — all SC1091/SC2016/SC2317, none real
+          # defects). No --enable=all: SC2310/SC2311 fire zero times here, so
+          # enabling `all` would only add ~35 info + ~592 style findings for no
+          # signal on the case it was proposed for.
           shopt -s nullglob globstar
 
           script_files=(scripts/**/*.sh)
@@ -61,11 +62,17 @@ jobs:
             exit 1
           fi
 
-          skill_files=(.claude/skills/**/scripts/*.sh)
+          skill_files=(.claude/skills/**/scripts/**/*.sh)
           if [ "${#skill_files[@]}" -eq 0 ]; then
-            echo "::error::.claude/skills/**/scripts/*.sh matched no files"
+            echo "::error::.claude/skills/**/scripts/**/*.sh matched no files"
             exit 1
           fi
+
+          # shellcheck is silent when clean, so without this the log records no
+          # evidence of WHAT was checked. It also surfaces a partial-coverage
+          # regression that leaves both groups non-empty — the case the guards
+          # above cannot see.
+          echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/"
 
           shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}"
 

--- a/scripts/ship.sh
+++ b/scripts/ship.sh
@@ -38,9 +38,9 @@ promote_issues() {
 # GraphQL, which is eventually consistent — mergeCommit is briefly null. Retry
 # rather than hard-stop: past this point a bail leaves the release unpublished.
 resolve_merge_sha() {
-    local pr="$1" attempt
+    local pr="$1" _
     MERGE_SHA=""
-    for attempt in $(seq 1 5); do
+    for _ in $(seq 1 5); do
         MERGE_SHA=$(gh pr view "$pr" --json mergeCommit --jq '.mergeCommit.oid // empty' 2>/dev/null || true)
         [ -n "$MERGE_SHA" ] && [ "$MERGE_SHA" != "null" ] && return 0
         sleep 3
@@ -58,7 +58,7 @@ resolve_merge_sha() {
 tag_and_publish() {
     local sha="$1" version="$2"
     local tag="v$version"
-    local existing run attempt
+    local existing run _
 
     # The merge commit is created server-side — fetch before tagging it.
     git fetch origin main --quiet || {
@@ -102,7 +102,7 @@ tag_and_publish() {
     # registration lag, then fail loudly rather than exiting 0 on a guess.
     info "Waiting for publish workflow..."
     run=""
-    for attempt in $(seq 1 30); do
+    for _ in $(seq 1 30); do
         run=$(gh run list --workflow publish.yml --commit "$sha" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
         [ -n "$run" ] && break
         sleep 10


### PR DESCRIPTION
Closes #132

## Summary

`.github/workflows/ci.yml` ran eslint (`bun run lint`, scoped to `src/ tests/ bin/`) and `bun test`. The 37 shell scripts under `scripts/` and `.claude/skills/*/scripts/` had no static checking at all. This adds a `shellcheck` job that gates them.

The configuration was chosen by measuring shellcheck v0.10.0 against the actual tree rather than by adopting the issue's suggested defaults — and that measurement contradicted the issue's stated rationale. See "On the issue's premise" below; it matters for how the workflow comment is worded, and for anyone who later wonders why `--enable=all` was declined.

## What changes

### New `shellcheck` job

Runs on `ubuntu-latest` only (shell linting is OS-independent — it is not added to the Windows matrix). Installs shellcheck **pinned to v0.10.0** from the official koalaman release with sha256 verification, rather than using a third-party action or the runner image's preinstalled binary:

- the repo's CI uses only `actions/checkout` and `oven-sh/setup-bun`; this keeps that property
- pinning stops a runner-image bump from silently changing what the gate enforces

Each glob group is asserted non-empty independently, and the resolved counts are logged:

```bash
shopt -s nullglob globstar

script_files=(scripts/**/*.sh)
if [ "${#script_files[@]}" -eq 0 ]; then
  echo "::error::scripts/**/*.sh matched no files"
  exit 1
fi

skill_files=(.claude/skills/**/scripts/**/*.sh)
if [ "${#skill_files[@]}" -eq 0 ]; then
  echo "::error::.claude/skills/**/scripts/**/*.sh matched no files"
  exit 1
fi

echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/"

shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}"
```

The per-group check is load-bearing. `nullglob` makes an unmatched glob expand to nothing, so a single merged non-empty check would keep the job green while silently checking only 11 of 37 files if `.claude/skills` were ever renamed or the skill scripts moved. Guarding each group separately, and naming the offending glob in the error, is what makes a path rename fail loudly.

Both globs are recursive, so a future `scripts/lib/foo.sh` or `.claude/skills/foo/scripts/lib/helper.sh` is picked up rather than silently skipped. The count `echo` exists because shellcheck is silent when clean: without it the log carries no record of *what* was checked, and a partial-coverage regression that still leaves both groups non-empty — one skill's `scripts/` dir renamed while others keep theirs — would be invisible. The guards cannot catch that case; the logged count is the mitigation.

### Extended `pull_request` paths filter

Added `scripts/**` and `.claude/skills/**/scripts/**`. Without this the new job would never run on a PR that only touches shell scripts — precisely the PRs it exists to gate. The filter is shared across jobs, so shell-only PRs now also run `lint` and `unit-tests`; that's cheaper than a second workflow file and those jobs are fast. (`push:` to `main`/`dev` carries no `paths:` filter, so branch heads are always gated regardless.)

### `scripts/ship.sh` — two `SC2034` fixes

Two unused loop counters (`for attempt in $(seq 1 N)`, at lines 43 and 105) renamed to `_`. Behaviour-preserving: iteration counts (5 and 30) and `sleep` values are unchanged, and `ship.sh` never reads bash's automatic `$_`.

Worth noting for anyone re-running the numbers: shellcheck dedups `SC2034` by variable name per file, so a first pass reports only **one** of these. The second surfaces only once the first is fixed. Fixed, not suppressed — no `# shellcheck disable=` was added anywhere.

## On the issue's premise

The issue proposes `--enable=all` on the grounds that SC2310/SC2311 catch the #127 class of bug. Measured against this tree, they do not:

- SC2310 and SC2311 fire **zero** times across all 37 scripts, even at `--enable=all --severity=style`.
- Reconstructing the actual pre-fix `label-merged-issues.sh` pipeline from b6c48da — the `grep … | grep … | sort -un` under `set -euo pipefail` with the now-dead `if [ -z "$issues" ]` branch below it — shellcheck exits **0** at `--enable=all --severity=info`. The only output at `style` is SC2250 (brace preference) and SC2292 (prefer `[[`), unrelated cosmetics.
- The second #130 bug (blanket `|| true` on a multi-stage pipeline) is likewise undetected.

So **neither of the two bugs cited in the issue would have been caught by shellcheck at any severity or check set.** The gate is still worth having — it covers real defect classes on future scripts, and `scripts/` currently has zero static checking — but not on the stated justification. The workflow comment records the measured rationale rather than the SC2310/SC2311 one, so it doesn't hand a future reader a false claim.

### Measurements

All figures from the identical 37-file invocation the CI job uses. Per-file arithmetic does not reconcile these — `SC2034` dedups by variable name per file, and `SC1091` resolution shifts with how many files are passed in one invocation — so both trees were measured whole.

| setting | pre-change (`e5673e5`) | post-change |
|---|---|---|
| default checks, `--severity=error` | 0 | 0 |
| default checks, `--severity=warning` | 1 | 0 |
| default checks, `--severity=style` | 6 | 5 |
| `--enable=all --severity=info` | 38 | 37 |
| `--enable=all --severity=style` | 615 | 614 |

`error` alone gates on nothing, which is why `warning` is the floor. The 5 remaining at `style` are 3×`SC1091`, 1×`SC2016`, 1×`SC2317` — none of them real defects.

## Acceptance criteria

- [x] CI fails on a shellcheck violation in `scripts/` or `.claude/skills/*/scripts/`
- [x] The job actually runs on PRs that touch only shell scripts (`paths:` filter extended)
- [x] A renamed/moved script directory fails the job loudly instead of silently checking fewer files
- [x] Existing scripts pass at the chosen severity, fixed rather than suppressed
- [x] The severity level and `--enable` set are recorded in the workflow with a comment explaining the choice, and that comment is accurate against the real measurements

## Test plan

- [x] `bun test` — 1018 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `shellcheck --severity=warning` over the real tree — 37 files (11 + 26), exit 0
- [x] Canary in a `scripts/*.sh` file → exit 1; reverted → exit 0
- [x] Canary in a `.claude/skills/*/scripts/*.sh` file → exit 1; reverted → exit 0
- [x] Partial-glob simulation: each directory renamed in turn → exit 1 with the offending glob named (this case silently passed before the per-group check)
- [x] `globstar` widening check: a symlinked directory under `scripts/` containing a live SC2034 is **not** matched (bash `**` does not follow symlinked dirs); no duplicate expansions, 37 unique paths
- [x] Pinned sha256 verified against the real tarball; `sha256sum -c -` exits 1 on mismatch and `set -euo pipefail` propagates it
- [x] `.github/workflows/ci.yml` parses as YAML

## Follow-up

#144 tracks the two shell scripts outside the gate's globs (`.claude-jobs/_internal-authors.sh`, `tests/e2e-tutorial/run.sh`) — out of scope for #132, to be either folded in or documented as a deliberate exclusion. `.claude-jobs/**` is likewise absent from the `paths:` filter, which belongs in that issue's scope.
