### PR TITLE
fix: warn on endpoint-less sessionAuth, document programmatic refreshOn route (#135)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,8 @@ When the generated client receives a status in `refreshOn`, it calls the wired r
 
 The refresh callback re-invokes the custom strategy's `authenticate()` rather than re-bootstrapping `/session`. `settings.json` `auth.refreshOn` takes precedence over `sessionAuth.refreshOn` when both are set.
 
+`.apijack/settings.json` only applies to consumers of the shared `apijack` binary; a project with its own `bin/<cli>.ts` sets the same option programmatically instead: `createCli({ refreshOn: [401], /* ... */ })`.
+
 ### Dropping base-strategy headers post-handshake (opt-in)
 
 By default, `SessionAuthStrategy` mirrors the wrapped base strategy's headers (e.g. `Authorization: Basic …` from `BasicAuthStrategy`) onto every post-handshake API request. For stateful backends — Spring Security with 2FA, for instance — re-presenting the base credentials on every call re-triggers the auth filter and either re-prompts, 401s, or invalidates the active session. Opt in to `dropBaseHeaders` to strip them:
@@ -250,7 +252,7 @@ The `.apijack/` directory at a project root is auto-loaded when the CLI runs ins
 | `.apijack/auth.ts` | Project-level `AuthStrategy` and optional `onChallenge` |
 | `.apijack/plugins.ts` | Project-level plugin registrations (`default: ApijackPlugin[]` — each entry passed to `cli.use(...)`) |
 | `.apijack/routines/*.yaml` | Routines available via `routine run <name>` |
-| `.apijack/settings.json` | Framework defaults (see below) |
+| `.apijack/settings.json` | Framework defaults (see below; also `auth.refreshOn` — see "Stale-session refresh and retry" above) |
 | `.apijack/aliases.json` | Project-local command aliases (see below) |
 
 ### Command aliases

--- a/src/auth/refresh-wiring.ts
+++ b/src/auth/refresh-wiring.ts
@@ -36,5 +36,11 @@ export function resolveRefreshWiring(
     const mergedSessionAuth = rawSessionAuth?.session?.endpoint ? rawSessionAuth : undefined;
     const refreshOn = options.refreshOn ?? rawSessionAuth?.refreshOn;
 
+    if (rawSessionAuth && !mergedSessionAuth) {
+        console.warn(
+            '[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used.',
+        );
+    }
+
     return { mergedSessionAuth, refreshOn };
 }

--- a/tests/auth/refresh-wiring.test.ts
+++ b/tests/auth/refresh-wiring.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, spyOn } from 'bun:test';
 import { resolveRefreshWiring } from '../../src/auth/refresh-wiring';
 import type { SessionAuthConfig } from '../../src/auth/types';
 
@@ -50,11 +50,17 @@ describe('resolveRefreshWiring', () => {
         // Not expressible through the SessionAuthConfig type from a fully-typed
         // caller, but envConfig.sessionAuth is only a Partial<SessionAuthConfig> —
         // a JS/dynamic caller could still hand cli-builder a refreshOn-only block.
+        const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
         const refreshOnlySessionAuth = { refreshOn: [401] } as unknown as SessionAuthConfig;
-        const result = resolveRefreshWiring({ sessionAuth: refreshOnlySessionAuth }, undefined);
-        expect(result.mergedSessionAuth).toBeUndefined();
-        // refreshOn still surfaces from the raw (unguarded) merge.
-        expect(result.refreshOn).toEqual([401]);
+
+        try {
+            const result = resolveRefreshWiring({ sessionAuth: refreshOnlySessionAuth }, undefined);
+            expect(result.mergedSessionAuth).toBeUndefined();
+            // refreshOn still surfaces from the raw (unguarded) merge.
+            expect(result.refreshOn).toEqual([401]);
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 
     test('does not mutate inputs', () => {
@@ -64,5 +70,42 @@ describe('resolveRefreshWiring', () => {
             { sessionAuth: { cookies: { applyTo: ['*'] } } },
         );
         expect(fullSessionAuth).toEqual(sessionAuthCopy);
+    });
+
+    describe('missing session.endpoint diagnostic warning', () => {
+        test('warns when sessionAuth is set but has no session.endpoint', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const refreshOnlySessionAuth = { refreshOn: [401] } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring({ sessionAuth: refreshOnlySessionAuth }, undefined);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                expect(warnSpy.mock.calls[0]![0]).toContain('session.endpoint');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('does not warn when there is no sessionAuth at all', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+            try {
+                resolveRefreshWiring({ refreshOn: [401] }, undefined);
+                expect(warnSpy).not.toHaveBeenCalled();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('does not warn when sessionAuth has a session.endpoint', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+            try {
+                resolveRefreshWiring({ sessionAuth: fullSessionAuth }, undefined);
+                expect(warnSpy).not.toHaveBeenCalled();
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
     });
 });


### PR DESCRIPTION
Follow-up to #135 / #145. No `Closes` line — #135 is already resolved and labeled `merged to dev`.

## Summary

#145 merged while this commit was still in flight, pinned to `92d73f8`, so `9eac68f` was left orphaned on the branch. It carries the three non-blocking observations from #145's automated review that were cheap and in-scope, and nothing else.

The out-of-scope observation from the same review — `.apijack/settings.json` values being cast without validation — is filed separately as #146.

## What changes

### Diagnosability: warn on an endpoint-less `sessionAuth` block

#135 narrowed `mergedSessionAuth` to blocks that define `session.endpoint`, because `resolveRequestHeaders` dereferences `config.cookies.applyTo` unguarded. That narrowing is correct but fails silently: `envConfig.sessionAuth` arrives from JSON as an untyped `Partial`, so a misspelled key (`sessions:` for `session:`) now falls through to `options.auth` with no `SessionAuthStrategy` at all — where previously the user got a loud failure fetching `<baseUrl>undefined`.

```ts
if (rawSessionAuth && !mergedSessionAuth) {
    console.warn(
        '[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used.',
    );
}
```

Failing soft is the improvement; failing soft *and quiet* was the regression. One line at the single shared decision point (`src/auth/refresh-wiring.ts`) covers both `cli-builder.ts` wiring sites.

### Docs: the programmatic opt-in route

The CLAUDE.md paragraph added in #135 only documented the `.apijack/settings.json` route, which applies to consumers on the shared `apijack` binary. A project with its own `bin/<cli>.ts` opts in via `createCli({ refreshOn: [401] })` — documented on `CliOptions.refreshOn` in `src/types.ts`, but invisible to a reader in CLAUDE.md. Now covered alongside the settings.json route.

Also cross-references the Project Extensions table's `.apijack/settings.json` row, whose only spelled-out example was `customCommands` — a reader scanning for settings keys wouldn't have found `auth.refreshOn` several sections earlier under Session Auth.

## Acceptance criteria

- [ ] An endpoint-less `sessionAuth` block emits a warning naming the missing `session.endpoint`
- [ ] No warning fires when there is no `sessionAuth` block at all, or when `session.endpoint` is present
- [ ] `refreshOn` behavior from #135 is unchanged — an endpoint-less block still activates refresh + retry, it just doesn't wrap the strategy
- [ ] CLAUDE.md documents the `createCli({ refreshOn })` route as well as the `.apijack/settings.json` one

## Test plan

- [x] `bun test` — 1041 pass / 0 fail (up from 1038 on `92d73f8`)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings, unchanged)

New coverage in `tests/auth/refresh-wiring.test.ts`: the warning fires for an endpoint-less block, and does not fire in either negative case. The existing assertion that an endpoint-less block still yields `refreshOn: [401]` with `mergedSessionAuth: undefined` is unchanged, so the warning is additive rather than a behavior change.
