### PR TITLE
chore: cover .claude-jobs/ and tests/ scripts in shellcheck gate (#144)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,25 @@ jobs:
             exit 1
           fi
 
+          job_files=(.claude-jobs/**/*.sh)
+          if [ "${#job_files[@]}" -eq 0 ]; then
+            echo "::error::.claude-jobs/**/*.sh matched no files"
+            exit 1
+          fi
+
+          test_files=(tests/**/*.sh)
+          if [ "${#test_files[@]}" -eq 0 ]; then
+            echo "::error::tests/**/*.sh matched no files"
+            exit 1
+          fi
+
           # shellcheck is silent when clean, so without this the log records no
           # evidence of WHAT was checked. It also surfaces a partial-coverage
           # regression that leaves both groups non-empty — the case the guards
           # above cannot see.
-          echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/"
+          echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/, ${#job_files[@]} in .claude-jobs/, ${#test_files[@]} in tests/"
 
-          shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}"
+          shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}" "${job_files[@]}" "${test_files[@]}"
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
           # shellcheck is silent when clean, so without this the log records no
           # evidence of WHAT was checked. It also surfaces a partial-coverage
-          # regression that leaves both groups non-empty — the case the guards
+          # regression that leaves all groups non-empty — the case the guards
           # above cannot see.
           echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/, ${#job_files[@]} in .claude-jobs/, ${#test_files[@]} in tests/"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - '.github/workflows/ci.yml'
       - 'scripts/**'
       - '.claude/skills/**/scripts/**'
+      - '.claude-jobs/**'
 
 jobs:
   lint:


### PR DESCRIPTION
Closes #144

## Summary

#132 added the CI shellcheck gate over `scripts/**/*.sh` and `.claude/skills/**/scripts/**/*.sh`, deliberately leaving two tracked scripts outside it: `.claude-jobs/_internal-authors.sh` (feeds the triage cron's author classification — same "corrupts labels in production" blast radius as the #127 bug that motivated the gate) and `tests/e2e-tutorial/run.sh`. Issue #144 asked for a decision per script: fold in or document the exclusion.

This PR folds both in. Both already pass at `--severity=warning` against the pinned shellcheck v0.10.0, so the gate stays green today, and any future script added under either path is checked automatically instead of silently joining the gap.

## What changes

Single file: `.github/workflows/ci.yml`, three commits.

### New glob groups in the `Run shellcheck` step

Two groups, each with the per-group emptiness guard pattern established in #143 (a glob that matches nothing fails the job loudly):

```bash
job_files=(.claude-jobs/**/*.sh)
if [ "${#job_files[@]}" -eq 0 ]; then
  echo "::error::.claude-jobs/**/*.sh matched no files"
  exit 1
fi

test_files=(tests/**/*.sh)
if [ "${#test_files[@]}" -eq 0 ]; then
  echo "::error::tests/**/*.sh matched no files"
  exit 1
fi
```

The count-log echo and the final `shellcheck --severity=warning` invocation now cover all four groups.

### `pull_request.paths` trigger

Caught in review: the workflow's `on.pull_request.paths` filter did not include `.claude-jobs/**`, so a PR touching only `.claude-jobs/_internal-authors.sh` would have skipped the workflow entirely — the new guard would never run for exactly the change it guards. Added `- '.claude-jobs/**'` to the filter (`tests/**` was already present).

### Comment accuracy

The pre-existing comment above the count echo said "leaves both groups non-empty"; with four groups that became stale, so "both" → "all".

## Acceptance criteria

- [x] `.claude-jobs/_internal-authors.sh` and `tests/e2e-tutorial/run.sh` are covered by the shellcheck gate (fold-in path chosen; issue offered fold-in or documented exclusion)
- [x] Per-group emptiness guards extended to the new groups, per the #143 pattern — each new glob fails the job loudly if it matches nothing

## Test plan

- [x] Replayed the step's exact logic locally with the pinned shellcheck v0.10.0 binary (sha256-verified download, `nullglob` + `globstar`): `shellcheck: 11 in scripts/, 26 in .claude/skills/, 1 in .claude-jobs/, 1 in tests/`, exit 0 — the fold-in is a CI no-op today, as the issue predicted
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses
- [x] `bun test` — 1043 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
