### PR TITLE
test: cover the pre-codegen alias guard's partial-codegen state (#138)

### DIFF
--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -160,7 +160,8 @@ export interface RewriteResult {
  *   (error emitted, CLI continues without the alias) -- unless
  *   `opts.generatedCommandsPresent` is `false`, in which case they are skipped
  *   silently, since there is nothing meaningful to validate against before
- *   `generate` has run.
+ *   `generate` has run, or if it ran incompletely (generated command
+ *   registration didn't actually complete).
  * - Longest-prefix wins: multi-token aliases are matched before shorter ones.
  * - Trailing args (positional and flags) are appended verbatim.
  */

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -641,6 +641,8 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 9. Create ApiClient and register generated commands
+            let generatedCommandsRegistered = false;
+
             if (commandsModule && ApiClientClass) {
                 const registerFn = commandsModule.registerGeneratedCommands as (
                     program: Command, client: unknown, onResult: (result: unknown) => void,
@@ -745,6 +747,7 @@ export function createCli(options: CliOptions): Cli {
                 };
 
                 registerFn(program, client, onResult);
+                generatedCommandsRegistered = true;
             }
 
             // 10. Register consumer commands and attach per-command requiresAuth preAction hooks.
@@ -960,10 +963,9 @@ export function createCli(options: CliOptions): Cli {
                     process.argv.slice(2),
                     aliasMap,
                     realPaths,
-                    // Mirrors the registration condition above — an existing client
-                    // module that doesn't export ApiClient leaves ApiClientClass
-                    // `undefined`, not `null`.
-                    { generatedCommandsPresent: !!commandsModule && !!ApiClientClass },
+                    // Set iff generated-command registration actually ran, so this
+                    // guard cannot diverge from the registration condition above.
+                    { generatedCommandsPresent: generatedCommandsRegistered },
                 );
 
                 for (const w of warnings) {

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -260,7 +260,7 @@ describe('rewriteArgv()', () => {
         // Pre-codegen, "customers get-customer-order-summary" hasn't been registered
         // yet, so it's absent from realPaths — same situation as an unknown expansion.
         const aliases: AliasMap = { cs: 'customers get-customer-order-summary' };
-        const result = rewriteArgv(['cs', '42'], aliases, new Set(['generate', 'config']), {
+        const result = rewriteArgv(['cs', '42'], aliases, builtinPaths, {
             generatedCommandsPresent: false,
         });
 

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -860,6 +860,68 @@ describe('alias validation before codegen has run (#136)', () => {
 
         expect(stderrOut).not.toContain('does not resolve to a known command');
     });
+
+    test('does not report unresolved generated-command aliases when codegen is partial (client exports no ApiClient) (#138)', async () => {
+        const workDir = join(tmpdir(), `apijack-alias-partialcodegen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        const cliConfigDir = join(workDir, '.testcli');
+        const generatedDir = join(workDir, 'src', 'generated');
+        mkdirSync(cliConfigDir, { recursive: true });
+        mkdirSync(generatedDir, { recursive: true });
+        // Points at an operation that would only exist once `generate` has fully run.
+        writeFileSync(
+            join(cliConfigDir, 'aliases.json'),
+            JSON.stringify({ cs: 'customers list-customers' }),
+        );
+        // commandsModule exists (so `commandsModule` is truthy)...
+        writeFileSync(
+            join(generatedDir, 'commands.ts'),
+            'export function registerGeneratedCommands(): void {}\n',
+        );
+        // ...but the client module imports cleanly without exporting `ApiClient`,
+        // leaving `ApiClientClass` undefined and registration skipped.
+        writeFileSync(join(generatedDir, 'client.ts'), 'export const somethingElse = 1;\n');
+
+        const origArgv = process.argv;
+        const origStderr = process.stderr.write.bind(process.stderr);
+        const origStdout = process.stdout.write.bind(process.stdout);
+        const origLog = console.log;
+        const origExit = process.exit;
+        let stderrOut = '';
+
+        try {
+            process.argv = ['node', 'testcli', 'config', 'list'];
+            process.stderr.write = ((c: string | Uint8Array) => {
+                stderrOut += String(c);
+
+                return true;
+            }) as never;
+            process.stdout.write = (() => true) as never;
+            console.log = () => {};
+            process.exit = (() => {
+                throw new Error('__exit__');
+            }) as never;
+
+            const cli = createCli(makeOptions({
+                configPath: join(cliConfigDir, 'config.json'),
+                generatedDir,
+            }));
+
+            try {
+                await cli.run();
+            } catch (e) {
+                if ((e as Error).message !== '__exit__') throw e;
+            }
+        } finally {
+            process.argv = origArgv;
+            process.stderr.write = origStderr as never;
+            process.stdout.write = origStdout as never;
+            console.log = origLog;
+            process.exit = origExit;
+            rmSync(workDir, { recursive: true, force: true });
+        }
+
+        expect(stderrOut).not.toContain('does not resolve to a known command');
+    });
 });
 
 describe('cli.runRoutine', () => {


### PR DESCRIPTION
Closes #138

## Summary

#137 gated pre-codegen alias validation on `{ generatedCommandsPresent: !!commandsModule && !!ApiClientClass }`, which had to stay textually mirrored with the registration condition `if (commandsModule && ApiClientClass)` it sits ~320 lines below. Review on #137 caught a divergence (`!== null` vs truthiness — `ApiClientClass` is `undefined`, not `null`, when `generated/client.ts` omits the `ApiClient` export) that no test would have caught: mutating the guard back to the divergent form left the whole suite green.

This PR closes both gaps. The guard is now derived from a flag set at the single point where generated-command registration actually runs, making divergence structurally impossible — and a regression test pins the partial-codegen state so the behavior stays covered even if the structure changes again. While triaging we confirmed codegen always emits `export class ApiClient` (`src/codegen/client.ts`), so the partial state is only reachable via hand-editing or an interrupted `generate` — which is why the issue's "cheaper alternative" (structural fix) applies; the test rides along because it's cheap and outlives future refactors.

## What changes

### `src/cli-builder.ts` — single source of truth for the alias guard

`let generatedCommandsRegistered = false` is declared before the registration block and set to `true` immediately after `registerFn(program, client, onResult)` — the sole, unconditional call site inside `if (commandsModule && ApiClientClass)`. The alias block now passes `{ generatedCommandsPresent: generatedCommandsRegistered }`; the stale "Mirrors the registration condition above" comment is replaced accordingly. The `if` condition itself is unchanged (TypeScript narrowing). No behavior change: `commandsModule` / `ApiClientClass` are never reassigned between the two blocks, so early vs. late evaluation is observationally identical.

### `tests/cli-builder.test.ts` — partial-codegen regression test

New test in the `#136` describe block: fixture `generatedDir` where `commands.ts` exports `registerGeneratedCommands` but `client.ts` imports cleanly with **no** `ApiClient` export, plus an alias pointing at a generated command path. Asserts `cli.run()` emits no `does not resolve to a known command` stderr noise. Mutation-checked: with the divergent guard form the test fails with exactly that stderr line; with the fix it passes — so it discriminates the bug rather than duplicating the pre-codegen sibling.

### Minor polish

- `tests/aliases.test.ts` — the first pre-codegen test now uses the hoisted `builtinPaths` const like its two siblings (the inline set was a strict subset; behavior identical). Folded in per the issue's nitpick.
- `src/aliases.ts` — the `generatedCommandsPresent` JSDoc now mentions incomplete codegen alongside the pre-`generate` case.

## Acceptance criteria

- [ ] Registration and the alias guard derive from a single source of truth — no textual mirroring left to maintain
- [ ] Regression test covers the partial-codegen state (valid `commands.ts`, `client.ts` without `ApiClient`) and fails against the divergent guard form
- [ ] Alias pointing at a generated operation is skipped silently (no per-alias stderr spam) under partial codegen
- [ ] `tests/aliases.test.ts` pre-codegen test uses the hoisted `builtinPaths`
- [ ] No behavior change for complete-codegen and no-codegen states (existing #136 tests untouched and green)

## Test plan

- [x] `bun test` — 1044 pass / 0 fail (83 files)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings, none in touched files)
- [x] Mutation check: guard reverted to `commandsModule !== null && ApiClientClass !== null` → new test fails with `does not resolve to a known command` in stderr; restored → passes
- [x] Independent whole-branch review (read-only) re-ran suite + lint and confirmed the fixture is non-vacuous (fixture import genuinely yields truthy `commandsModule` with `undefined` `ApiClient`)
