### PR TITLE
fix: read a setext underline as a heading, not a list item (#142)

### DIFF
--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -46,8 +46,8 @@
 #
 # Known and deliberate gaps. Most leave a reference VISIBLE (a possible false
 # positive) rather than hiding a real one, which is the safer direction to err —
-# the two that can hide one, the early-close reopen above and the setext
-# underline below, say so where they are described:
+# the one that can hide one, the early-close reopen above, says so where it is
+# described:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
@@ -62,9 +62,6 @@
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
 #     because the opener is looked for at the line indent, not past the marker
-#   - a setext heading underline (`Title` over a bare `-`) reads as a list item
-#     and pushes a container, since detecting it needs previous-line state; the
-#     container it pushes can open indented code under it as a fence
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -211,7 +208,7 @@ function list_offset(p,   w, n, c, t) {
 
 BEGIN {
     in_fence = 0; fence_char = ""; fence_len = 0; fence_indent = 0; fence_base = 0
-    depth = 0; base = 0
+    depth = 0; base = 0; prev_text = 0
 }
 {
     # Leading spaces, counted with a loop rather than /^ */ because the count is
@@ -242,6 +239,7 @@ BEGIN {
                     fence_indent = 0; fence_base = 0
                 }
             }
+            prev_text = 0
             next
         }
         # Dedented out of the list item holding the fence, so the fence ended
@@ -251,11 +249,13 @@ BEGIN {
         fence_indent = 0; fence_base = 0
     }
 
+    no_para = 0
     if (!blank) {
         # A list item may contain blank lines, so only a non-blank line closes
         # containers. Popping eagerly lowers base, which makes a deep fence
         # LESS likely to be recognized — the false-positive direction.
-        while (depth > 0 && indent < stack[depth]) depth--
+        popped = 0
+        while (depth > 0 && indent < stack[depth]) { depth--; popped = 1 }
         base = 0
         if (depth > 0) base = stack[depth]
 
@@ -267,9 +267,22 @@ BEGIN {
         if (indent <= base + 3) {
             off = list_offset(probe)
             if (off > 0) {
-                depth++
-                stack[depth] = indent + off
-                base = stack[depth]
+                # An empty marker right after open paragraph text never starts
+                # a list item (#142): for `-` it is a setext underline, for the
+                # rest a lazy continuation ("an empty list item cannot
+                # interrupt a paragraph"). The one exception is a marker that
+                # dedented to pop a container on its way in — that is a real
+                # sibling empty item (`- foo` then `-` at column 0), told
+                # apart here by `popped`.
+                empty_marker = (probe ~ /^([-*+]|[0-9]+[.)])[[:space:]]*$/)
+                if (empty_marker && prev_text && !popped) {
+                    no_para = 1
+                } else {
+                    depth++
+                    stack[depth] = indent + off
+                    base = stack[depth]
+                    if (empty_marker) no_para = 1
+                }
             } else if (match(probe, /^(```+|~~~+)/)) {
                 ch = substr(probe, 1, 1)
                 # A backtick info string cannot itself contain a backtick, so
@@ -277,12 +290,14 @@ BEGIN {
                 if (ch != "`" || index(substr(probe, RLENGTH + 1), "`") == 0) {
                     in_fence = 1; fence_char = ch; fence_len = RLENGTH
                     fence_indent = indent; fence_base = base
+                    prev_text = 0
                     next
                 }
             }
         }
     }
     print strip_spans($0)
+    prev_text = (!blank && !no_para)
 }
 
 # A closing fence cannot carry a trailing info string, so one stray character on

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -44,10 +44,18 @@
 # the state machine is there for exactly that reason. Weigh it before touching
 # the escape.
 #
+# An empty list marker right after open paragraph text pushes no container
+# (#142): for `-` that's a setext heading underline, for `*`/`+`/ordered
+# markers a lazy paragraph continuation ("an empty list item cannot interrupt
+# a paragraph"). The one exception is a marker that dedents back to a sibling
+# position — `- foo` then `-` at column 0 — which pops a container on its way
+# in and still pushes; that pop is how the state machine tells a real empty
+# item apart from the underline.
+#
 # Known and deliberate gaps. Most leave a reference VISIBLE (a possible false
 # positive) rather than hiding a real one, which is the safer direction to err —
-# the one that can hide one, the early-close reopen above, says so where it is
-# described:
+# the two that can hide one, the early-close reopen above and the empty-marker
+# suppression below, say so where they are described:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
@@ -62,6 +70,11 @@
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
 #     because the opener is looked for at the line indent, not past the marker
+#   - a line that opens no paragraph but reads as one here (an ATX heading, a
+#     thematic break, an HTML block, an indented code line) suppresses the empty
+#     marker under it, so a fence indented into what CommonMark calls that list
+#     item keeps its lower fence_base and does not end at a dedent — the second
+#     rule that can hide a reference, and unlike the reopen above it is silent
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -273,7 +286,10 @@ BEGIN {
                 # interrupt a paragraph"). The one exception is a marker that
                 # dedented to pop a container on its way in — that is a real
                 # sibling empty item (`- foo` then `-` at column 0), told
-                # apart here by `popped`.
+                # apart here by `popped`. The digit run below is unbounded,
+                # unlike the 9-digit cap in list_offset — safe only because
+                # off > 0 already excludes a 10+-digit marker; keep the two
+                # coupled.
                 empty_marker = (probe ~ /^([-*+]|[0-9]+[.)])[[:space:]]*$/)
                 if (empty_marker && prev_text && !popped) {
                     no_para = 1

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -279,7 +279,7 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
     describe('documented gaps', () => {
         // Most of these leak a reference rather than hide one — the safer
-        // direction. The one that can hide one is pinned last, and says so. All
+        // direction. The two that can hide one are pinned last, and say so. All
         // of them are here so the behavior can't drift silently; see the header
         // comment in scripts/extract-closing-refs.sh.
 
@@ -319,6 +319,23 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual([]);
             expect(stderr).toContain('unterminated code fence');
         });
+
+        test('a line that opens no paragraph still suppresses the empty marker under it — silently', async () => {
+            // HIDES a reference, and this one is silent where the early-close
+            // reopen above at least warns. An ATX heading (like indented code, a
+            // thematic break, or an HTML block) opens no paragraph in CommonMark,
+            // but the state machine has no model of ATX headings, so it sets
+            // prev_text = 1 anyway and suppresses the empty marker below it. The
+            // fence indented into what CommonMark calls that list item keeps a
+            // lower fence_base and never ends at the dedent, so `Closes #7`
+            // is swallowed with no unterminated-fence warning. dev has the
+            // symmetric defect here: it reports #7 AND fires a spurious
+            // unterminated-fence warning, since CommonMark agrees the ref is code.
+            const { issues, stderr, exitCode } = await extract('# Title\n-\n  ```\n  code\nCloses #7\n  ```\n');
+            expect(issues).toEqual([]);
+            expect(stderr).toBe('');
+            expect(exitCode).toBe(0);
+        });
     });
 
     describe('a setext underline is not a list item', () => {
@@ -341,8 +358,14 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         });
 
         test('an underline at an item content column is a heading inside the item, not a new container', async () => {
-            const { issues } = await extract('- Title\n  -\n\n      Closes #100\n');
-            expect(issues).toEqual(['100']);
+            // Without the fence this doesn't discriminate: indent 6 is within
+            // base + 3 whether base is 2 (no new container, correct) or 4 (dev's
+            // buggy push). The fence makes it load-bearing: at base 2 it sits 4
+            // past the item's content column — indented code, stays visible — but
+            // dev wrongly pushes a second container to base 4, where the same
+            // fence opens and swallows #100.
+            const { issues } = await extract('- Title\n  -\n\n      ```\n      Closes #100\n      ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
         });
 
         test('a lone `-` that dedents back to sibling position is still a real empty item', async () => {

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -328,9 +328,12 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             // prev_text = 1 anyway and suppresses the empty marker below it. The
             // fence indented into what CommonMark calls that list item keeps a
             // lower fence_base and never ends at the dedent, so `Closes #7`
-            // is swallowed with no unterminated-fence warning. dev has the
-            // symmetric defect here: it reports #7 AND fires a spurious
-            // unterminated-fence warning, since CommonMark agrees the ref is code.
+            // is swallowed with no unterminated-fence warning. On this shape
+            // dev was CommonMark-correct on both counts — the flush-left line
+            // ends the item and its fence, so it printed #7 and warned about
+            // the genuinely unterminated fence the trailing line opens.
+            // Accepted anyway: the shape is contrived, and #157 tracks
+            // narrowing prev_text so the marker reads as a real item again.
             const { issues, stderr, exitCode } = await extract('# Title\n-\n  ```\n  code\nCloses #7\n  ```\n');
             expect(issues).toEqual([]);
             expect(stderr).toBe('');

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -279,7 +279,7 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
     describe('documented gaps', () => {
         // Most of these leak a reference rather than hide one — the safer
-        // direction. The two that can hide one are pinned last, and say so. All
+        // direction. The one that can hide one is pinned last, and says so. All
         // of them are here so the behavior can't drift silently; see the header
         // comment in scripts/extract-closing-refs.sh.
 
@@ -308,17 +308,6 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual(['7']);
         });
 
-        test('a setext underline hides the indented code beneath it — and is silent', async () => {
-            // HIDES a reference. A heading underlined with a bare lone `-` needs
-            // previous-line state to tell from a list item, so it pushes a
-            // container, and the indented code under it opens as a fence instead
-            // of staying visible. Narrow (`--` and `---` both take other paths)
-            // but this is one of the two shapes nothing else flags.
-            const { issues, stderr } = await extract('Title\n-\n\n    ```\n    Closes #1\n    ```\n');
-            expect(issues).toEqual([]);
-            expect(stderr).toBe('');
-        });
-
         test('a fence closed after an early close hides the rest — but warns', async () => {
             // Pins the MECHANISM, not a divergence. Flush-left code under a
             // bullet dedents out of the item, so the fence ends early and its
@@ -329,6 +318,57 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             const { issues, stderr } = await extract('- Steps:\n  ```bash\nnpm install\n  ```\n\nCloses #7\n');
             expect(issues).toEqual([]);
             expect(stderr).toContain('unterminated code fence');
+        });
+    });
+
+    describe('a setext underline is not a list item', () => {
+        // An empty list marker on the line right after open paragraph text
+        // never starts a list item (#142): for `-` it is a setext underline,
+        // for `*`/`+`/ordered markers it is a lazy paragraph continuation —
+        // "an empty list item cannot interrupt a paragraph". Either way no
+        // container is pushed, so indented code beneath it stays indented
+        // code rather than opening as a fence.
+        test('leaves the indented code beneath it visible', async () => {
+            const { issues, stderr, exitCode } = await extract('Title\n-\n\n    ```\n    Closes #1\n    ```\n');
+            expect(issues).toEqual(['1']);
+            expect(stderr).toBe('');
+            expect(exitCode).toBe(0);
+        });
+
+        test('trailing whitespace on the underline does not change that', async () => {
+            const { issues } = await extract('Title\n-   \n\n    ```\n    Closes #1\n    ```\n');
+            expect(issues).toEqual(['1']);
+        });
+
+        test('an underline at an item content column is a heading inside the item, not a new container', async () => {
+            const { issues } = await extract('- Title\n  -\n\n      Closes #100\n');
+            expect(issues).toEqual(['100']);
+        });
+
+        test('a lone `-` that dedents back to sibling position is still a real empty item', async () => {
+            // The one exception: dedenting to a sibling marker position pops a
+            // container on the way in, which is how this case is told apart
+            // from the underline above.
+            const { issues } = await extract('- foo\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('the underline closes the paragraph, so a second lone `-` is a genuine item', async () => {
+            const { issues } = await extract('Title\n-\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('other empty markers cannot interrupt a paragraph either', async () => {
+            const star = await extract('Title\n*\n\n    ```\n    Closes #1\n    ```\n');
+            expect(star.issues).toEqual(['1']);
+
+            const ordered = await extract('Title\n1.\n\n    ```\n    Closes #1\n    ```\n');
+            expect(ordered.issues).toEqual(['1']);
+        });
+
+        test('after a closed fence a lone `-` is a genuine empty item', async () => {
+            const { issues } = await extract('```\ncode\n```\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
         });
     });
 


### PR DESCRIPTION
Closes #142

## Summary

`scripts/extract-closing-refs.sh`'s awk pre-pass reads a setext H2 underline — a bare lone `-` on the line after paragraph text — as an empty list-item marker, because telling the two apart needs previous-line state the line-oriented pass didn't carry. The container it pushes raises the content column enough that the 4-space-indented block beneath opens as a *fence* (stripped) instead of staying *indented code* (kept, per #129) — silently hiding a real closing reference. A false negative, introduced by #141, tracked by #142.

This PR adds that one bit of look-behind state. The unifying CommonMark rule (every expectation below was verified against the reference `commonmark` parser): **an empty list marker on the line after open paragraph text never starts a list item** — for `-` it is a setext underline (`Title` + `-` → `<h2>`), and for `*`, `+`, `1.`, `1)` it is a lazy paragraph continuation ("an empty list item cannot interrupt a paragraph"). Either way, no container. The one exception, also per CommonMark: a lone marker that dedents back to a sibling position of an open list (`- foo` then `-` at column 0) is a genuine empty sibling item — and in this state machine that case is exactly identifiable as "the line popped a container on its way in".

## What changes

### `scripts/extract-closing-refs.sh`

One new state variable in the awk pre-pass, `prev_text` — "a paragraph is open":

- Set by any printed non-blank line (including a marker line with content, whose content opens a paragraph); cleared by blank lines, fence openers/content/closers, empty-marker lines, and a line consumed as a setext underline (the underline closes the paragraph, so `Title` / `-` / `-` reads the second `-` as a real empty item — matching CommonMark).
- The pop loop now records whether the line popped a container (`popped`).
- When `list_offset()` sees a marker but the line is an *empty* marker (`^([-*+]|[0-9]+[.)])[[:space:]]*$`), the push is suppressed iff `prev_text && !popped`.

Suppressing a push only ever lowers `base`, which for fence *recognition* strictly errs in the safe direction (a reference stays visible). The final review found the one place that reasoning inverts: `fence_base` also floors the fence *early-close* escape, so a line that sets `prev_text` without opening a CommonMark paragraph (ATX heading, thematic break, HTML block, indented code) can suppress a genuine empty item and let a nested fence swallow a flush-left dedent line — silently. On that shape dev was CommonMark-correct (the reference stays visible prose and the trailing fence line genuinely is unterminated, so dev printed the ref and warned), which makes this a real, accepted trade-off rather than a wash: the shape is contrived (the 150-body sweep never reaches it), so per this file's convention it is **documented as the second known gap that can hide a reference and pinned in `documented gaps`**, not chased. A follow-up issue covers the optional narrowing.

Header comment updated accordingly: the fixed setext behavior is stated where the gap bullet used to be, and the "gaps that can hide a reference" framing is restored to two (early-close reopen, and the new suppression shape).

### `tests/extract-closing-refs.test.ts`

- The old `documented gaps` pin (`a setext underline hides the indented code beneath it — and is silent`) is removed — it pinned the divergence this PR fixes.
- 7 new tests pin the fixed semantics, all pre-verified against reference CommonMark: the underline leaves indented code beneath it visible (`['1']` where dev yields `[]`), trailing-whitespace underline, underline at an item's content column (with a fence proving the no-push: `['7','100']` where dev yields `['7']`), popped sibling still pushes, underline-then-genuine-empty-item, `*`/`1.` cannot interrupt a paragraph, lone `-` after a closed fence still pushes.
- 1 new `documented gaps` pin for the second silent gap above (`[]`, exit 0, empty stderr).

## Acceptance criteria

- [x] A setext H2 underline (bare lone `-` beneath paragraph text) does not push a list container
- [x] The indented code block beneath it stays visible, matching pre-#141 `dev` and reference CommonMark
- [x] Real single-item lists (`-` followed by content, and a lone `-` that genuinely opens an empty list item) still push a container
- [x] The `documented gaps` pin is updated to assert the fixed behavior rather than pinning the divergence
- [x] No regression against the full-repo sweep — dev vs. branch differ on zero real bodies

## Test plan

- [x] `bun test` — 1050 pass / 0 fail (52 in `extract-closing-refs.test.ts`: 7 new semantics tests + 1 new gap pin, 1 stale pin removed)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings, none in changed files)
- [x] Full-repo differential sweep: all 150 issue/PR bodies (47 issues + 103 PRs, all states) run through dev's script and this branch's — 0 stdout/exit-code diffs, 0 stderr diffs
- [x] Every new test expectation cross-checked against the reference `commonmark` npm parser; awk portability re-verified under mawk, busybox awk, nawk, and `gawk --posix`
- [x] Adversarial final review traced the state machine for cross-line leaks (none) and confirmed the fix never hides a reference that dev showed on any constructible input outside the documented gap
