### PR TITLE
fix: validate .apijack/settings.json values instead of casting blindly (#146)

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,14 +36,14 @@ function validateProjectSettings(parsed: unknown): ProjectSettings {
             warnAndIgnore('customCommands', 'an object');
             delete settings.customCommands;
         } else {
-            const customCommands = settings.customCommands as Record<string, unknown>;
+            const customCommands = settings.customCommands;
 
             if ('defaults' in customCommands) {
                 if (!isPlainObject(customCommands.defaults)) {
                     warnAndIgnore('customCommands.defaults', 'an object');
                     delete customCommands.defaults;
                 } else {
-                    const defaults = customCommands.defaults as Record<string, unknown>;
+                    const defaults = customCommands.defaults;
 
                     if ('requiresAuth' in defaults && typeof defaults.requiresAuth !== 'boolean') {
                         warnAndIgnore('customCommands.defaults.requiresAuth', 'a boolean');
@@ -59,7 +59,7 @@ function validateProjectSettings(parsed: unknown): ProjectSettings {
             warnAndIgnore('auth', 'an object');
             delete settings.auth;
         } else {
-            const auth = settings.auth as Record<string, unknown>;
+            const auth = settings.auth;
 
             if ('refreshOn' in auth) {
                 const refreshOn = auth.refreshOn;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,13 +14,76 @@ export interface ProjectSettings {
     };
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function warnAndIgnore(key: string, expected: string): void {
+    console.warn(`[apijack] .apijack/settings.json: '${key}' must be ${expected} — ignoring`);
+}
+
+function validateProjectSettings(parsed: unknown): ProjectSettings {
+    if (!isPlainObject(parsed)) {
+        console.warn('[apijack] .apijack/settings.json: settings must be a JSON object — ignoring');
+
+        return {};
+    }
+
+    const settings = parsed as ProjectSettings & Record<string, unknown>;
+
+    if ('customCommands' in settings) {
+        if (!isPlainObject(settings.customCommands)) {
+            warnAndIgnore('customCommands', 'an object');
+            delete settings.customCommands;
+        } else {
+            const customCommands = settings.customCommands as Record<string, unknown>;
+
+            if ('defaults' in customCommands) {
+                if (!isPlainObject(customCommands.defaults)) {
+                    warnAndIgnore('customCommands.defaults', 'an object');
+                    delete customCommands.defaults;
+                } else {
+                    const defaults = customCommands.defaults as Record<string, unknown>;
+
+                    if ('requiresAuth' in defaults && typeof defaults.requiresAuth !== 'boolean') {
+                        warnAndIgnore('customCommands.defaults.requiresAuth', 'a boolean');
+                        delete defaults.requiresAuth;
+                    }
+                }
+            }
+        }
+    }
+
+    if ('auth' in settings) {
+        if (!isPlainObject(settings.auth)) {
+            warnAndIgnore('auth', 'an object');
+            delete settings.auth;
+        } else {
+            const auth = settings.auth as Record<string, unknown>;
+
+            if ('refreshOn' in auth) {
+                const refreshOn = auth.refreshOn;
+
+                if (!Array.isArray(refreshOn) || !refreshOn.every(v => typeof v === 'number')) {
+                    warnAndIgnore('auth.refreshOn', 'an array of numbers');
+                    delete auth.refreshOn;
+                }
+            }
+        }
+    }
+
+    return settings;
+}
+
 export function loadProjectSettings(apijackDir: string): ProjectSettings {
     const settingsPath = join(apijackDir, 'settings.json');
 
     if (!existsSync(settingsPath)) return {};
 
     try {
-        return JSON.parse(readFileSync(settingsPath, 'utf-8')) as ProjectSettings;
+        const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+
+        return validateProjectSettings(parsed);
     } catch {
         return {};
     }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, spyOn } from 'bun:test';
+import { describe, test, expect, afterEach, beforeEach, spyOn } from 'bun:test';
 import { loadProjectSettings } from '../src/settings';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -47,12 +47,15 @@ describe('loadProjectSettings()', () => {
     describe('validation', () => {
         let warnSpy: ReturnType<typeof spyOn>;
 
-        afterEach(() => {
-            warnSpy?.mockRestore();
+        beforeEach(() => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
         });
 
-        test('strips auth.refreshOn when it is a scalar and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        test('strips auth.refreshOn when it is a scalar and warns with the exact message', () => {
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: 401 } }));
 
@@ -60,12 +63,12 @@ describe('loadProjectSettings()', () => {
 
             expect(settings.auth?.refreshOn).toBeUndefined();
             expect(warnSpy).toHaveBeenCalledTimes(1);
-            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
-            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+            expect(warnSpy.mock.calls[0][0]).toBe(
+                "[apijack] .apijack/settings.json: 'auth.refreshOn' must be an array of numbers — ignoring",
+            );
         });
 
         test('strips auth.refreshOn when it contains a non-number and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: [401, 'x'] } }));
 
@@ -77,8 +80,19 @@ describe('loadProjectSettings()', () => {
             expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
         });
 
+        test('strips auth when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: 'nope' }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
         test('strips customCommands.defaults.requiresAuth when not a boolean and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(
                 join(testRoot, 'settings.json'),
@@ -93,12 +107,36 @@ describe('loadProjectSettings()', () => {
             expect(warnSpy.mock.calls[0][0]).toContain('boolean');
         });
 
-        test('leaves a valid settings file unchanged with no warnings', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        test('strips customCommands when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ customCommands: 'nope' }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
+        test('strips customCommands.defaults when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ customCommands: { defaults: 'nope' } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands?.defaults).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands.defaults'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
+        test('leaves a valid settings file unchanged with no warnings, including unknown keys', () => {
             mkdirSync(testRoot, { recursive: true });
             const valid = {
                 customCommands: { defaults: { requiresAuth: true } },
                 auth: { refreshOn: [401] },
+                someFutureOption: 'preserved',
             };
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify(valid));
 
@@ -109,7 +147,6 @@ describe('loadProjectSettings()', () => {
         });
 
         test('returns {} and warns when top-level value is not an object (array)', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), '[1,2,3]');
 
@@ -121,7 +158,6 @@ describe('loadProjectSettings()', () => {
         });
 
         test('returns {} and warns when top-level value is not an object (string)', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), '"hello"');
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterEach, spyOn } from 'bun:test';
 import { loadProjectSettings } from '../src/settings';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -42,5 +42,94 @@ describe('loadProjectSettings()', () => {
         mkdirSync(testRoot, { recursive: true });
         writeFileSync(join(testRoot, 'settings.json'), '{ not json');
         expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+
+    describe('validation', () => {
+        let warnSpy: ReturnType<typeof spyOn>;
+
+        afterEach(() => {
+            warnSpy?.mockRestore();
+        });
+
+        test('strips auth.refreshOn when it is a scalar and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: 401 } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth?.refreshOn).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
+            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+        });
+
+        test('strips auth.refreshOn when it contains a non-number and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: [401, 'x'] } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth?.refreshOn).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
+            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+        });
+
+        test('strips customCommands.defaults.requiresAuth when not a boolean and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(
+                join(testRoot, 'settings.json'),
+                JSON.stringify({ customCommands: { defaults: { requiresAuth: 'yes' } } }),
+            );
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands?.defaults?.requiresAuth).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands.defaults.requiresAuth'");
+            expect(warnSpy.mock.calls[0][0]).toContain('boolean');
+        });
+
+        test('leaves a valid settings file unchanged with no warnings', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            const valid = {
+                customCommands: { defaults: { requiresAuth: true } },
+                auth: { refreshOn: [401] },
+            };
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify(valid));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual(valid);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test('returns {} and warns when top-level value is not an object (array)', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), '[1,2,3]');
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual({});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain('settings must be a JSON object');
+        });
+
+        test('returns {} and warns when top-level value is not an object (string)', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), '"hello"');
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual({});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain('settings must be a JSON object');
+        });
     });
 });


### PR DESCRIPTION
Closes #146

## Summary

`loadProjectSettings` (`src/settings.ts`) was a bare `JSON.parse` + cast, so a wrong-typed value in `.apijack/settings.json` propagated untouched and failed far from its cause — e.g. `{ "auth": { "refreshOn": 401 } }` (scalar instead of array) reached the generated client and blew up with `this.refreshOn.includes is not a function`.

This PR adds warn-and-ignore validation covering the whole `ProjectSettings` surface: a wrong-typed key emits one warning naming the key and the expected type, and is stripped instead of propagated. A bad settings file never takes the CLI down.

## What changes

### `src/settings.ts`

Validation applied to the parsed JSON before returning, in place (no whitelist copy — valid keys and unknown keys round-trip identically to before):

- Top-level non-object (array, string, number, `null`, boolean) → warn + return `{}`
- `customCommands` / `customCommands.defaults` / `auth` present but not a plain object → warn + strip
- `customCommands.defaults.requiresAuth` not a boolean → warn + strip
- `auth.refreshOn` not an array of numbers (scalar, or array with a non-number element) → warn + strip
- Nested checks only run when the parent is valid, so one bad container produces exactly one warning
- Presence-gated with `in`, so `requiresAuth: false` and `refreshOn: []` survive validation
- Malformed/unparseable JSON keeps the existing `try/catch` → `{}` behavior

Warning format:

```
[apijack] .apijack/settings.json: 'auth.refreshOn' must be an array of numbers — ignoring
```

### `tests/settings.test.ts`

9 new validation tests (13 total in the file): scalar and mixed-array `refreshOn`, non-boolean `requiresAuth`, the three container-level rules, top-level array/string, valid-file round-trip (including an unknown top-level key) with zero warnings, and one `toBe` assertion pinning the full warning string byte-for-byte.

## Acceptance criteria

- [ ] A wrong-typed value for any `ProjectSettings` key emits a warning naming the key and the expected type, and is ignored rather than propagated
- [ ] A valid settings file behaves exactly as before (no new warnings, unknown keys preserved)
- [ ] A malformed/unparseable file still degrades to `{}` without throwing
- [ ] Test coverage for at least `auth.refreshOn` and `customCommands.defaults.requiresAuth`

## Test plan

- [x] `bun test` — 1053 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings, none in the touched files)
- [x] Consumer trace: neither `bin/apijack.ts` nor `src/run-routine.ts` distinguishes a stripped-empty container (`{ auth: {} }`) from an absent one — both read through optional chains with safe fallbacks
