### PR TITLE
fix: attribute injected onChallenge in endpoint-less sessionAuth warning (#150)

### DIFF
--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -120,6 +120,7 @@ if (!authResolved) {
 
 // 7. Resolve sessionAuth from env config
 let sessionAuth: SessionAuthConfig | undefined;
+let onChallengeInjectedFrom: string | undefined;
 {
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
 
@@ -129,6 +130,7 @@ let sessionAuth: SessionAuthConfig | undefined;
 
     if (sessionAuth && projectOnChallenge) {
         sessionAuth.onChallenge = projectOnChallenge;
+        onChallengeInjectedFrom = '.apijack/auth.ts';
     }
 }
 
@@ -150,6 +152,7 @@ const cli = createCli({
     specPath,
     auth: authStrategy,
     sessionAuth,
+    onChallengeInjectedFrom,
     refreshOn: projectSettings.auth?.refreshOn,
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,

--- a/src/auth/refresh-wiring.ts
+++ b/src/auth/refresh-wiring.ts
@@ -5,6 +5,10 @@ import { deepMergeSessionAuth } from './config-merge';
 export interface RefreshWiringOptions {
     sessionAuth?: SessionAuthConfig;
     refreshOn?: number[];
+    /** Set by the shared-binary entry points when they inject a project-level
+     *  `onChallenge` (from `.apijack/auth.ts`) into `sessionAuth`. Used only to
+     *  attribute the injected key in the endpoint-less sessionAuth diagnostic. */
+    onChallengeInjectedFrom?: string;
 }
 
 export interface RefreshWiring {
@@ -44,13 +48,22 @@ export function resolveRefreshWiring(
         // this works without a session.endpoint. Only warn when there's something else
         // in the block, which is the signature of a typo'd handshake key (e.g. `sessions:`
         // instead of `session:`) rather than an intentional refresh-only block.
+        // An explicit `null` (e.g. from a JSON env config) still counts as "present" here
+        // deliberately — the user typed it, and the key is genuinely dead without a
+        // session.endpoint, so it's correct to name it in the warning (#150).
         const foundKeys = Object.keys(rawSessionAuth).filter(
             key => key !== 'refreshOn' && (rawSessionAuth as Record<string, unknown>)[key] !== undefined,
         );
 
         if (foundKeys.length > 0) {
+            const renderedKeys = foundKeys.map(key =>
+                key === 'onChallenge' && options.onChallengeInjectedFrom
+                    ? `onChallenge (injected from ${options.onChallengeInjectedFrom})`
+                    : key,
+            );
+
             console.warn(
-                `[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used. Found: ${foundKeys.join(', ')}.`,
+                `[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used. Found: ${renderedKeys.join(', ')}.`,
             );
         }
     }

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -134,12 +134,14 @@ export async function runRoutine(
     }
 
     let sessionAuth: SessionAuthConfig | undefined;
+    let onChallengeInjectedFrom: string | undefined;
 
     if (envConfig) {
         sessionAuth = (envConfig as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
 
         if (sessionAuth && projectOnChallenge) {
             sessionAuth.onChallenge = projectOnChallenge;
+            onChallengeInjectedFrom = '.apijack/auth.ts';
         }
     }
 
@@ -156,6 +158,7 @@ export async function runRoutine(
         specPath,
         auth: authStrategy,
         sessionAuth,
+        onChallengeInjectedFrom,
         generatedDir,
         allowedCidrs: projectConfig?.allowedCidrs,
         configPath: join(configDir, 'config.json'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export interface CliOptions {
      *  Takes precedence over `sessionAuth.refreshOn` when both are set. Lets a
      *  project with a custom AuthStrategy opt in without a `sessionAuth` block. */
     refreshOn?: number[];
+    /** Set by the shared-binary entry points when they inject a project-level
+     *  `onChallenge` (from `.apijack/auth.ts`) into `sessionAuth`. Used only to
+     *  attribute the injected key in the endpoint-less sessionAuth diagnostic. */
+    onChallengeInjectedFrom?: string;
     outputModes?: string[];
     generatedDir?: string;
     knownSites?: Record<string, { url: string; description: string; group?: string }>;

--- a/tests/auth/refresh-wiring.test.ts
+++ b/tests/auth/refresh-wiring.test.ts
@@ -241,5 +241,23 @@ describe('resolveRefreshWiring', () => {
                 warnSpy.mockRestore();
             }
         });
+
+        test('names a key whose explicit null arrives via the envConfig merge path (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            // A JSON env config can carry `"cookies": null`; deepMerge's scalar
+            // branch assigns it, so it must survive the merge and be named.
+            const refreshOnlySessionAuth = { refreshOn: [401] } as unknown as SessionAuthConfig;
+            const envConfigWithNull = { sessionAuth: { cookies: null } } as unknown as
+                Parameters<typeof resolveRefreshWiring>[1];
+
+            try {
+                resolveRefreshWiring({ sessionAuth: refreshOnlySessionAuth }, envConfigWithNull);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('cookies');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
     });
 });

--- a/tests/auth/refresh-wiring.test.ts
+++ b/tests/auth/refresh-wiring.test.ts
@@ -163,5 +163,83 @@ describe('resolveRefreshWiring', () => {
                 warnSpy.mockRestore();
             }
         });
+
+        test('attributes onChallenge to its injection source when onChallengeInjectedFrom is set (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const refreshOnlyWithChallenge = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring(
+                    { sessionAuth: refreshOnlyWithChallenge, onChallengeInjectedFrom: '.apijack/auth.ts' },
+                    undefined,
+                );
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge (injected from .apijack/auth.ts)');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('renders onChallenge plain when onChallengeInjectedFrom is not set (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const refreshOnlyWithChallenge = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring({ sessionAuth: refreshOnlyWithChallenge }, undefined);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge');
+                expect(message).not.toContain('injected from');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('attributes only the injected onChallenge key when mixed with a typo\'d key (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const mixedSessionAuth = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+                sessions: { endpoint: '/session' },
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring(
+                    { sessionAuth: mixedSessionAuth, onChallengeInjectedFrom: '.apijack/auth.ts' },
+                    undefined,
+                );
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge (injected from .apijack/auth.ts)');
+                expect(message).toContain('sessions');
+                expect(message).not.toContain('sessions (injected from');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('names a key whose value is explicit null (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const explicitNullSessionAuth = {
+                refreshOn: [401],
+                cookies: null,
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring({ sessionAuth: explicitNullSessionAuth }, undefined);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('cookies');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
     });
 });


### PR DESCRIPTION
Closes #150

## Summary

Polishes the endpoint-less `sessionAuth` diagnostic in `src/auth/refresh-wiring.ts` (spawned from #149's non-blocking review observations). Two items, neither a behavior change to the #148 decision logic:

1. When the framework injects `onChallenge` from `.apijack/auth.ts` into the `sessionAuth` block (which `bin/apijack.ts` and `src/run-routine.ts` both do), the warning now attributes it — the user never wrote that key in their config, so naming it bare pointed them at a key that appears in neither file they'd check.
2. The `foundKeys` filter's treatment of explicit `null` values is now a deliberate, pinned decision: `null` counts as present (the user typed it, and the key is genuinely dead), documented with a comment and covered by a test.

## What changes

### Attribution plumbing

- `RefreshWiringOptions` (`src/auth/refresh-wiring.ts`) and `CliOptions` (`src/types.ts`) gain an optional `onChallengeInjectedFrom?: string`, documented as framework-set and diagnostic-only.
- Both shared-binary entry points set it to `'.apijack/auth.ts'` in the same block that performs the `sessionAuth.onChallenge = projectOnChallenge` injection — the flag can never be set without the injection having happened. These are the only two production `createCli` call sites.
- No `cli-builder.ts` change: both `resolveRefreshWiring` call sites already pass the whole `options` object, and `CliOptions` is structurally assignable to `RefreshWiringOptions`.

### Warning rendering

When `foundKeys` contains `onChallenge` and the flag is set, the warning renders it with the source; other keys are untouched:

```
[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used. Found: onChallenge (injected from .apijack/auth.ts), sessions.
```

Rendering is applied to an already-computed key list — the `foundKeys` filter predicate, `refreshOn` precedence, and `mergedSessionAuth` narrowing are byte-for-byte unchanged. A programmatic caller who wrote `onChallenge` into their own `sessionAuth` (no injection) still sees plain `onChallenge`.

The attribution cannot lie: the env-config side of `deepMergeSessionAuth` is JSON-loaded and can never carry a function, so whenever the flag is set, the `onChallenge` being named is the injected one.

### Explicit-null pin

No code change to the filter — a comment on it (referencing #150) records that `value !== undefined` deliberately treats explicit `null` as present, plus a test pinning that `{ cookies: null }` warns and names `cookies`. This holds through the JSON env-config merge path too (`deepMerge` assigns `null` via its scalar branch).

### Tests

Four new tests in `tests/auth/refresh-wiring.test.ts` (existing seven unmodified): injected attribution, non-injected plain rendering, mixed injected + typo'd key (suffix only on `onChallenge`), and the explicit-null pin.

## Acceptance criteria

- [ ] The warning distinguishes a framework-injected `onChallenge` from keys the user wrote into the `sessionAuth` block
- [ ] Explicit-`null` handling in `foundKeys` is decided deliberately and covered by a test
- [ ] The #148 behavior is otherwise unchanged: refreshOn-only is silent, the typo'd-handshake-key case still warns

## Test plan

- [x] `bun test` — 1048 pass / 0 fail (2205 assertions, 83 files)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings in untouched files)
- [x] Independent task review + whole-branch review subagents: clean, no Critical/Important findings
- [x] Verified both `resolveRefreshWiring` call sites pass `options` through, so no cli-builder change is needed
