### PR TITLE
fix: fence-aware #N scan, arg validation, pagination rationale in notify-shipped-issues.sh (#140)

### DIFF
--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -81,10 +81,17 @@
 # `gh api repos/.../pulls/N`; collect-closes-refs.sh uses `gh pr view` so it can
 # skip numbers that turn out to be issues rather than PRs).
 #
+# --bare-refs switches the match stage from keyword-prefixed closing
+# references to ANY `#N`, while leaving the code-stripping pre-pass above
+# untouched. Used by scripts/notify-shipped-issues.sh, whose header explains
+# why that breadth — any `#N`, no closing keyword required — is deliberate
+# there; but a `#N` quoted inside code is no more a real reference in bare
+# mode than in keyword mode, so it still goes through the same strip.
+#
 # Usage:
-#   extract-closing-refs.sh --body-file <file>
-#   extract-closing-refs.sh -            # read stdin
-#   cat body.md | extract-closing-refs.sh
+#   extract-closing-refs.sh [--bare-refs] --body-file <file>
+#   extract-closing-refs.sh [--bare-refs] -            # read stdin
+#   cat body.md | extract-closing-refs.sh [--bare-refs]
 #
 # Output: issue numbers, one per line. Empty output and exit 0 when a body has
 # no closing references — that is a normal case (a chore PR opened outside the
@@ -99,6 +106,12 @@
 
 set -euo pipefail
 
+bare_refs=0
+if [ "${1-}" = "--bare-refs" ]; then
+    bare_refs=1
+    shift
+fi
+
 body_file=""
 case "${1-}" in
     --body-file)
@@ -108,7 +121,7 @@ case "${1-}" in
         body_file="/dev/stdin"
         ;;
     *)
-        echo "usage: extract-closing-refs.sh [--body-file <file> | -]" >&2
+        echo "usage: extract-closing-refs.sh [--bare-refs] [--body-file <file> | -]" >&2
         exit 1
         ;;
 esac
@@ -328,8 +341,16 @@ END {
 # rather than be swallowed by the no-match tolerance below.
 stripped=$(awk "$AWK_STRIP" "$body_file")
 
-printf '%s\n' "$stripped" \
-    | grep -oiE "$KEYWORD_RE" \
-    | grep -oE '[0-9]+' \
-    | sort -un \
-    || [ $? -eq 1 ]   # grep exit 1 == no closing references. Any other status propagates.
+if [ "$bare_refs" -eq 1 ]; then
+    printf '%s\n' "$stripped" \
+        | grep -oE '#[0-9]+' \
+        | grep -oE '[0-9]+' \
+        | sort -un \
+        || [ $? -eq 1 ]   # grep exit 1 == no bare references. Any other status propagates.
+else
+    printf '%s\n' "$stripped" \
+        | grep -oiE "$KEYWORD_RE" \
+        | grep -oE '[0-9]+' \
+        | sort -un \
+        || [ $? -eq 1 ]   # grep exit 1 == no closing references. Any other status propagates.
+fi

--- a/scripts/notify-shipped-issues.sh
+++ b/scripts/notify-shipped-issues.sh
@@ -17,7 +17,10 @@
 # This script posts a comment based on the *whole* commit range between
 # releases (any `#N` mention, any keyword), which catches issues referenced
 # in individual commit messages that never made it into the curated PR body.
-# They are complementary — running both is expected, not redundant.
+# They are complementary — running both is expected, not redundant. The
+# `#N` breadth is unchanged, but a reference quoted inside a fenced code
+# block or inline code span is now excluded, via
+# extract-closing-refs.sh --bare-refs.
 #
 # Usage:
 #   notify-shipped-issues.sh <tag> <release-url> [--dry-run]
@@ -35,7 +38,8 @@
 
 set -euo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gh-pin-account.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/gh-pin-account.sh"
 
 dry_run=0
 args=()
@@ -53,6 +57,11 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+if [ "${#args[@]}" -gt 2 ]; then
+    echo "usage: notify-shipped-issues.sh <tag> <release-url> [--dry-run]" >&2
+    exit 1
+fi
 
 # The `||` chain short-circuits, so `${args[0]}`/`${args[1]}` are never
 # indexed until the length check already confirmed they exist — required
@@ -83,11 +92,8 @@ echo "Scanning $PREV_TAG..$TAG for closed-issue references"
 # Same reasoning: capture `git log` first so a bad revision range (e.g. TAG
 # not actually present locally) aborts loudly via `set -e` and git's own
 # stderr, rather than reading as "no issue references" and exiting 0.
-COMMIT_LOG=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s %b")
-NUMS=$(printf '%s' "$COMMIT_LOG" \
-    | grep -oE '#[0-9]+' \
-    | tr -d '#' \
-    | sort -u || true)
+COMMIT_LOG=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s%n%b")
+NUMS=$(printf '%s' "$COMMIT_LOG" | "$SCRIPT_DIR/extract-closing-refs.sh" --bare-refs -)
 
 if [ -z "$NUMS" ]; then
     echo "No issue references found."
@@ -112,8 +118,14 @@ for N in $NUMS; do
     # — most plausibly a manual/local re-run while diagnosing a release, or
     # a future reordering of publish.yml's steps. A second run must not
     # double-comment, so look for the marker in any existing comment body
-    # first. `per_page=100` because the default page is the oldest 30
-    # comments, and the marker (if present) is more likely to be recent.
+    # first. The comments endpoint sorts ascending by id and supports only
+    # `since`/`per_page`/`page` — no way to ask for "most recent" — so
+    # `per_page=100` just widens the window from the default oldest 30
+    # comments to the oldest 100; it does not bias toward recent ones. Past
+    # 100 comments the guard fails open and double-comments, which is the
+    # intended direction here too (a duplicate beats a missed
+    # notification); `since` or a page walk is the exact fix if this ever
+    # needs to scale past that.
     #
     # Fails open on a transient API error (`|| echo ''`): that reads as "no
     # existing comment" and falls through to commenting again. A duplicate

--- a/scripts/notify-shipped-issues.sh
+++ b/scripts/notify-shipped-issues.sh
@@ -22,6 +22,15 @@
 # block or inline code span is now excluded, via
 # extract-closing-refs.sh --bare-refs.
 #
+# Known and deliberate gap: the entire commit range is piped as a single
+# document to extract-closing-refs.sh. An unterminated code fence in one
+# commit's body leaves the fence open for all subsequent commits in the range.
+# Until closed, extract-closing-refs.sh treats all content as code and strips
+# it from the scan, masking issue references in those commits. Probability is
+# low (requires odd fence count in a release range). Blast radius: missed
+# courtesy notifications, flagged by the "unterminated code fence" warning
+# extract-closing-refs.sh prints to stderr when the script runs.
+#
 # Usage:
 #   notify-shipped-issues.sh <tag> <release-url> [--dry-run]
 #
@@ -32,9 +41,10 @@
 # toplevel), so this can run from a checkout of a different repo — tests
 # exercise it against a throwaway fixture repo.
 #
-# Never aborts the caller: a failure to comment on one issue is logged to
-# stderr and the loop continues. Exits 0 unless the arguments themselves are
-# invalid.
+# Never aborts on per-issue comment failures: a failure to comment on one
+# issue is logged to stderr and the loop continues. Exits non-zero for
+# invalid arguments, broken revision ranges, or internal extractor failures;
+# per-issue failures do not abort the loop.
 
 set -euo pipefail
 

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -41,6 +41,21 @@ async function extractFile(path: string): Promise<ExtractResult> {
     return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
 }
 
+/** Same as `extract`, but with `--bare-refs` so ANY `#N` matches, not just keyword-prefixed ones. */
+async function extractBare(body: string): Promise<ExtractResult> {
+    const proc = Bun.spawn([scriptPath, '--bare-refs', '-'], {
+        cwd: repoRoot,
+        stdin: new TextEncoder().encode(body),
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
+}
+
 // `bun test` runs on windows-latest in CI, where Bun can't exec a .sh directly
 // (ENOENT). The scripts under test are release automation — they run from a
 // maintainer's shell and from Linux CI, never on Windows. Invoking them through
@@ -460,6 +475,44 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
             expect(await proc.exited).toBe(0);
             expect(stdout.split('\n').filter(Boolean)).toEqual(['7']);
+        });
+    });
+
+    describe('--bare-refs mode', () => {
+        test('matches a bare #N with no closing keyword', async () => {
+            const { issues } = await extractBare('see #12 and #34');
+            expect(issues).toEqual(['12', '34']);
+        });
+
+        test('still matches keyword-prefixed refs', async () => {
+            const { issues } = await extractBare('Closes #5\nand #7');
+            expect(issues).toEqual(['5', '7']);
+        });
+
+        test('excludes refs inside a fenced block', async () => {
+            const { issues } = await extractBare('```\n#99\n```\nsee #3\n');
+            expect(issues).toEqual(['3']);
+        });
+
+        test('excludes refs inside an inline code span', async () => {
+            const { issues } = await extractBare('`prefixes #14` and `Discloses #15`. refs #16\n');
+            expect(issues).toEqual(['16']);
+        });
+
+        test('dedupes and sorts numerically', async () => {
+            const { issues } = await extractBare('#100 #9 #11 #9');
+            expect(issues).toEqual(['9', '11', '100']);
+        });
+
+        test('exits 0 with no output on a body with no refs', async () => {
+            const { issues, exitCode } = await extractBare('chore: bump deps\n\nNothing to see here.\n');
+            expect(issues).toEqual([]);
+            expect(exitCode).toBe(0);
+        });
+
+        test('keyword mode regression guard: keyword mode still ignores bare refs', async () => {
+            const { issues } = await extract('see #12\nCloses #5\n');
+            expect(issues).toEqual(['5']);
         });
     });
 

--- a/tests/notify-shipped-issues.test.ts
+++ b/tests/notify-shipped-issues.test.ts
@@ -105,6 +105,14 @@ function buildRepo(dir: string): void {
     git(dir, ['config', 'user.name', 'Test']);
 }
 
+/** Commit with a multi-line message, needed for fenced-block/inline-span fixtures. */
+function commitWithMessage(dir: string, message: string): void {
+    const msgFile = join(dir, '.commit-msg-tmp');
+    writeFileSync(msgFile, message);
+    git(dir, ['commit', '--allow-empty', '-F', msgFile]);
+    rmSync(msgFile);
+}
+
 /** Run notify-shipped-issues.sh with a fake `gh` backed by `fixture`. */
 async function runScript(opts: { cwd: string; args: string[]; fixture: Fixture; repo?: string }): Promise<RunResult> {
     const fakeBin = mkdtempSync(join(tmpdir(), 'notify-shipped-fakebin-'));
@@ -148,6 +156,7 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
     let singleTagRepo: string;
     let noRefRepo: string;
     let crossTagRepo: string;
+    let quotedRepo: string;
 
     // mainRepo carries commits between v1.0.0 and v1.1.0 referencing five
     // issue numbers, one per scenario the fixture drives:
@@ -192,10 +201,41 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
         git(crossTagRepo, ['tag', 'v1.1.0']);
         git(crossTagRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #20']);
         git(crossTagRepo, ['tag', 'v1.11.0']);
+
+        // quotedRepo pins the extractor wiring: a fenced code block and an
+        // inline code span each quote a `#N` that must NOT be scanned as a
+        // reference, alongside genuine references (including out-of-order
+        // ones) that must be — and in numeric order.
+        quotedRepo = mkdtempSync(join(tmpdir(), 'notify-shipped-quoted-'));
+        buildRepo(quotedRepo);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'chore: initial commit']);
+        git(quotedRepo, ['tag', 'v1.0.0']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #100']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #11']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #9']);
+        // Fence opener as the first line of the body — only reachable via
+        // `--pretty=format:"%s%n%b"`; the old "%s %b" glued it onto the
+        // subject line, where the stripper's line-start fence check missed
+        // it.
+        commitWithMessage(quotedRepo, [
+            'fix: fenced reference test',
+            '',
+            '```',
+            'Example #77 quoted',
+            '```',
+            '',
+            'Fixes #5',
+        ].join('\n'));
+        commitWithMessage(quotedRepo, [
+            'fix: inline span reference test',
+            '',
+            'See `prefixes #14` for details',
+        ].join('\n'));
+        git(quotedRepo, ['tag', 'v1.1.0']);
     });
 
     afterAll(() => {
-        for (const dir of [mainRepo, singleTagRepo, noRefRepo, crossTagRepo]) {
+        for (const dir of [mainRepo, singleTagRepo, noRefRepo, crossTagRepo, quotedRepo]) {
             rmSync(dir, { recursive: true, force: true });
         }
     });
@@ -213,6 +253,15 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
             14: { pull_request: null, state: 'closed', comments: [] },
         },
         commentFailures: ['14'],
+    };
+
+    const quotedFixture: Fixture = {
+        issues: {
+            5: { pull_request: null, state: 'closed', comments: [] },
+            9: { pull_request: null, state: 'closed', comments: [] },
+            11: { pull_request: null, state: 'closed', comments: [] },
+            100: { pull_request: null, state: 'closed', comments: [] },
+        },
     };
 
     test('no previous stable tag: exits 0, no comments', async () => {
@@ -326,6 +375,41 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
         expect(result.calls).toContain(`comment 20 Shipped in [v1.11.0](${releaseUrl}) 🚀`);
     });
 
+    test('a reference quoted inside a fenced code block is not matched', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('#5: [dry-run] would comment');
+        expect(result.stdout).not.toContain('#77');
+    });
+
+    test('a reference inside an inline code span is not matched', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).not.toContain('#14');
+    });
+
+    test('scan order is numeric, not lexicographic', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        const indexOf = (n: string) => result.stdout.indexOf(`#${n}: [dry-run] would comment`);
+        const [i9, i11, i100] = [indexOf('9'), indexOf('11'), indexOf('100')];
+        expect(i9).toBeGreaterThanOrEqual(0);
+        expect(i11).toBeGreaterThan(i9);
+        expect(i100).toBeGreaterThan(i11);
+    });
+
     test('a broken revision range fails loudly instead of reading as "no issue references"', async () => {
         // v9.9.9 is not an actual tag in mainRepo: PREV_TAG resolves to
         // v1.1.0 (the highest real tag), then `git log v1.1.0..v9.9.9` fails
@@ -382,6 +466,17 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
             expect(result.exitCode).toBe(1);
             expect(result.stderr).toContain('usage:');
             expect(result.calls.filter(c => c.startsWith('comment '))).toEqual([]);
+        });
+
+        test('errors on a third positional argument instead of silently ignoring it', async () => {
+            const result = await runScript({
+                cwd: mainRepo,
+                args: ['v1.0.0', releaseUrl, 'junk'],
+                fixture: { issues: {} },
+            });
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain('usage:');
+            expect(result.calls).toEqual([]);
         });
     });
 });


### PR DESCRIPTION
Closes #140

## Summary

Hardens `scripts/notify-shipped-issues.sh` — the release-notification script whose first real run happened with v1.16.0 — per the four acceptance criteria of #140. The `#N` scan is now fence- and inline-code-span-aware, the idempotence guard's pagination rationale matches what the endpoint actually does, argument handling is symmetric (extra positionals now error like unknown flags), and the scan log reads in numeric order.

The fence-awareness decision (criterion 1) is settled by real-world evidence: the v1.16.0 run matched `#14` and `#15` from inline code spans in commit 477bebd's body (`` `prefixes #14` ``, `` `Discloses #15` ``) — they avoided stray "Shipped in" comments only because both happen to be PRs. Implementation reuses the existing stripping stage rather than duplicating it.

## What changes

### `--bare-refs` mode in `extract-closing-refs.sh`

The shared extractor gains an opt-in flag that keeps the fence/inline-span-stripping pre-pass identical but matches ANY `#[0-9]+` instead of keyword-prefixed closing references. Output stays deduped and numerically ascending. Keyword mode (all three existing callers) is byte-for-byte unchanged — the flag is shifted off before the untouched `case` block, and the keyword pipeline is character-identical.

### `notify-shipped-issues.sh` wiring and fixes

- The scan pipeline `grep -oE '#[0-9]+' | tr -d '#' | sort -u || true` becomes a pipe through `"$SCRIPT_DIR/extract-closing-refs.sh" --bare-refs -`. The breadth (any `#N`, no closing keyword) is unchanged; quoted references inside fenced blocks or inline spans no longer match. Numeric `sort -un` comes with it, fixing the lexicographic log-order nitpick. The old `|| true` is deliberately gone: the extractor exits 0 with empty output for "no refs", so a non-zero exit now means a real internal failure and aborts loudly via `set -e`.
- Log format `"%s %b"` → `"%s%n%b"` so a fence opener on the first body line sits at line start where the stripper can see it.
- Exact-arg-count check: `notify-shipped-issues.sh v1.16.0 <url> junk` now errors with the usage line (exit 1), symmetric with the unknown-flag path.
- The idempotence-guard comment now states what the comments endpoint actually does: ascending-id order, only `since`/`per_page`/`page` supported, so `per_page=100` widens the oldest window rather than biasing toward recent comments; past 100 comments the guard fails open and double-comments (intended direction), with `since`/page-walk named as the exact fix if ever needed.
- Header documents one new known, deliberate gap: the whole range is piped as one document, so an unterminated fence in one commit's body masks references in subsequent commits (stderr warning is the flag). Low probability, missed-courtesy-comment blast radius; per-commit extraction is filed as a follow-up. The stale "Exits 0 unless the arguments themselves are invalid" contract sentence is corrected while touching the header.

### Criterion 4 — first-real-run inspection

Recorded as a comment on #140: the v1.16.0 **Notify shipped issues** step (run 31393124773) was inspected directly — step green, 10 genuinely-shipped closed issues commented, PR references correctly skipped, and 3 prose-cross-reference strays (#84, #91, #98) noted as the documented accepted-breadth tradeoff.

## Acceptance criteria

- [ ] Fence-awareness decided and implemented: `#N` references inside fenced blocks / inline code spans no longer match (decision rationale: real span-sourced false positives observed in the v1.16.0 run)
- [ ] Pagination rationale comment corrected to match the endpoint's actual ascending-id ordering and fail-open-past-100 behavior
- [ ] Nitpicks addressed: extra positional arguments error with usage; scan output numerically sorted
- [ ] Keyword mode of `extract-closing-refs.sh` behaviorally unchanged for its three existing callers
- [ ] First real run inspected directly and recorded on #140 (see issue comment)

## Test plan

- [x] `bun test` — 1076 pass / 0 fail (7 new extractor tests, 4 new notify tests)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] New tests pin: fenced `#N` and inline-span `#N` excluded end-to-end through the notify script (fixture commits with multi-line bodies), fence-opener-as-first-body-line only reachable via `%s%n%b`, numeric scan order (9 → 11 → 100), three-positional usage error, plus extractor-level coverage of bare mode incl. the keyword-mode regression guard
- [x] Independent reviews: per-task spec+quality reviews, whole-branch final review (verdict: ready to merge), scoped re-review of the doc fix wave
