### PR TITLE
fix: forward settings.json auth.refreshOn from runRoutine (#159)

### DIFF
--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -159,6 +159,11 @@ export async function runRoutine(
         auth: authStrategy,
         sessionAuth,
         onChallengeInjectedFrom,
+        // Mirror bin/apijack.ts: `.apijack/settings.json` auth.refreshOn must reach
+        // createCli here too. Routine fixtures (Playwright/Vitest) are exactly the
+        // long-running flows a stale session bites, so the programmatic entry point
+        // needs the same stale-session refresh the CLI gets.
+        refreshOn: projectSettings.auth?.refreshOn,
         generatedDir,
         allowedCidrs: projectConfig?.allowedCidrs,
         configPath: join(configDir, 'config.json'),

--- a/tests/run-routine-refreshon.isolated.ts
+++ b/tests/run-routine-refreshon.isolated.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * #159 — `runRoutine()` must forward `.apijack/settings.json` `auth.refreshOn`
+ * to createCli(), the same way bin/apijack.ts does.
+ *
+ * The refresh *wiring* below createCli is already covered by
+ * cli-builder-refresh-wiring.integration.test.ts. What was missing — and what
+ * let the gap ship — is a test that the programmatic entry point hands the
+ * setting down at all. So this pins the forwarding, not the retry behavior:
+ * createCli is mocked and we assert on the options object it receives.
+ */
+
+interface CapturedOptions {
+    refreshOn?: number[];
+    customCommandDefaults?: unknown;
+}
+
+let captured: CapturedOptions | undefined;
+
+const stubCli = {
+    use: () => {},
+    command: () => {},
+    dispatcher: () => {},
+    resolver: () => {},
+    runRoutine: async () => ({ status: 'ok' }),
+};
+
+// Capture the real module BEFORE mocking, and put it back in afterAll. bun's
+// module registry is process-wide: without the restore, this stub leaks into
+// every later file that imports createCli (it broke 16 tests across
+// run-routine.test.ts and custom-command-auth.test.ts when first written).
+const realCliBuilder = await import('../src/cli-builder');
+
+mock.module('../src/cli-builder', () => ({
+    ...realCliBuilder,
+    createCli: (options: CapturedOptions) => {
+        captured = options;
+
+        return stubCli;
+    },
+}));
+
+const { runRoutine } = await import('../src/run-routine');
+
+afterAll(() => {
+    mock.module('../src/cli-builder', () => realCliBuilder);
+});
+
+describe('#159 runRoutine forwards settings.json auth.refreshOn', () => {
+    let tmpHome: string;
+    let projectDir: string;
+    let originalHome: string | undefined;
+    let originalCwd: string;
+
+    function writeProject(settings: unknown): void {
+        mkdirSync(join(projectDir, '.apijack', 'routines'), { recursive: true });
+        writeFileSync(join(projectDir, '.apijack.json'), JSON.stringify({}));
+        writeFileSync(join(projectDir, '.apijack', 'config.json'), JSON.stringify({
+            active: 'default',
+            environments: {
+                default: { url: 'http://localhost:9999', user: 'u', password: 'p' },
+            },
+        }));
+        writeFileSync(join(projectDir, '.apijack', 'routines', 'noop.yaml'),
+            'name: noop\nsteps: []\n');
+
+        if (settings !== undefined) {
+            writeFileSync(join(projectDir, '.apijack', 'settings.json'), JSON.stringify(settings));
+        }
+    }
+
+    beforeEach(() => {
+        captured = undefined;
+        const id = `run-routine-refreshon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        tmpHome = join(tmpdir(), `${id}-home`);
+        projectDir = join(tmpdir(), `${id}-project`);
+        mkdirSync(join(tmpHome, '.apijack', 'routines'), { recursive: true });
+        mkdirSync(projectDir, { recursive: true });
+
+        originalHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+        originalCwd = process.cwd();
+        process.chdir(projectDir);
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+
+        rmSync(tmpHome, { recursive: true, force: true });
+        rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    test('auth.refreshOn reaches createCli', async () => {
+        writeProject({ auth: { refreshOn: [401, 403] } });
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toEqual([401, 403]);
+    });
+
+    test('absent settings.json leaves refreshOn undefined rather than throwing', async () => {
+        writeProject(undefined);
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toBeUndefined();
+    });
+
+    test('an invalid auth.refreshOn is dropped by validation before it reaches createCli', async () => {
+        writeProject({ auth: { refreshOn: 'nope' } });
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toBeUndefined();
+    });
+});

--- a/tests/run-routine-refreshon.test.ts
+++ b/tests/run-routine-refreshon.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'path';
+
+/**
+ * #159 — `runRoutine()` must forward `.apijack/settings.json` `auth.refreshOn`
+ * to createCli(), the same way bin/apijack.ts does.
+ *
+ * The assertions live in run-routine-refreshon.isolated.ts, which mocks
+ * createCli to capture the options object. That mock cannot run in-process:
+ * bun evaluates every test file's top level before running any test, so a
+ * top-level `mock.module` poisons the shared registry for every later file
+ * that imports createCli (it broke 16 tests across run-routine.test.ts and
+ * custom-command-auth.test.ts). Running it as its own `bun test` process
+ * contains the mock. The filename deliberately omits `.test`, so the default
+ * suite does not discover it directly — only through this wrapper.
+ */
+
+const repoRoot = join(import.meta.dir, '..');
+
+describe('#159 runRoutine forwards settings.json auth.refreshOn (isolated)', () => {
+    test('isolated createCli-forwarding suite passes', async () => {
+        const proc = Bun.spawn(
+            [process.execPath, 'test', './tests/run-routine-refreshon.isolated.ts'],
+            { cwd: repoRoot, stdout: 'pipe', stderr: 'pipe' },
+        );
+        const stderr = await new Response(proc.stderr).text();
+        const exitCode = await proc.exited;
+
+        // bun test reports results on stderr; surface them when the child fails
+        // so the parent failure is diagnosable without re-running by hand.
+        expect(`${exitCode} ${exitCode === 0 ? '' : stderr}`.trim()).toBe('0');
+        expect(stderr).toContain('3 pass');
+        expect(stderr).toContain('0 fail');
+    }, 30_000);
+});


### PR DESCRIPTION
Closes #159
Closes #161

## Summary

`bin/apijack.ts` forwards `projectSettings.auth?.refreshOn` into `createCli()`. `src/run-routine.ts` loads the same `projectSettings` and forwards `customCommandDefaults` from it — but never `refreshOn`.

The effect: `.apijack/settings.json` with `{ "auth": { "refreshOn": [401] } }` is documented in CLAUDE.md and works from the CLI, but silently does nothing for `runRoutine()`. That's the programmatic entry point CLAUDE.md specifically recommends for Playwright/Vitest fixtures — the long-running flows where a stale session is most likely to bite.

#161 is a duplicate of #159 (filed independently by two workers during the fleet run); both are closed here.

## What changes

One line in `src/run-routine.ts`, mirroring `bin/apijack.ts:156`:

```ts
sessionAuth,
onChallengeInjectedFrom,
refreshOn: projectSettings.auth?.refreshOn,   // ← added
generatedDir,
```

### Test isolation note for the reviewer

The refresh *wiring* below `createCli` is already covered by `cli-builder-refresh-wiring.integration.test.ts`. What was missing — and what let this gap ship — is a test that the programmatic entry point hands the setting down at all. That requires intercepting `createCli`.

A top-level `mock.module` cannot be used here: bun evaluates every test file's top level before running any test, so the stub leaks into the shared module registry. Written that way first, it broke 16 tests across `run-routine.test.ts` and `custom-command-auth.test.ts`. An `afterAll` restore does not help, for the same ordering reason.

So the assertions live in `tests/run-routine-refreshon.isolated.ts` — deliberately named without `.test`, so default discovery skips it — and `tests/run-routine-refreshon.test.ts` runs it as its own `bun test` process, asserting the child's exit code and result line.

## Acceptance criteria

- [ ] `runRoutine()` passes `settings.json` `auth.refreshOn` through to `createCli`
- [ ] An absent `settings.json` leaves `refreshOn` undefined rather than throwing
- [ ] An invalid `auth.refreshOn` is dropped by existing validation before reaching `createCli`
- [ ] No regression in the rest of the suite — specifically no module-mock leakage

## Test plan

- [x] `bun test` — 1077 pass / 0 fail (baseline on this branch: 1076)
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] Negative control: with the one-line fix reverted, `auth.refreshOn reaches createCli` fails and the other two still pass — the test is not vacuous
- [x] Leakage check: full suite re-run after isolating the mock into a subprocess returns to 0 fail
