### PR TITLE
v1.17.0: settings.json validation, refreshOn parity for runRoutine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,25 @@ jobs:
             exit 1
           fi
 
+          job_files=(.claude-jobs/**/*.sh)
+          if [ "${#job_files[@]}" -eq 0 ]; then
+            echo "::error::.claude-jobs/**/*.sh matched no files"
+            exit 1
+          fi
+
+          test_files=(tests/**/*.sh)
+          if [ "${#test_files[@]}" -eq 0 ]; then
+            echo "::error::tests/**/*.sh matched no files"
+            exit 1
+          fi
+
           # shellcheck is silent when clean, so without this the log records no
           # evidence of WHAT was checked. It also surfaces a partial-coverage
           # regression that leaves both groups non-empty — the case the guards
           # above cannot see.
-          echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/"
+          echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/, ${#job_files[@]} in .claude-jobs/, ${#test_files[@]} in tests/"
 
-          shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}"
+          shellcheck --severity=warning "${script_files[@]}" "${skill_files[@]}" "${job_files[@]}" "${test_files[@]}"
 
   unit-tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
           # shellcheck is silent when clean, so without this the log records no
           # evidence of WHAT was checked. It also surfaces a partial-coverage
-          # regression that leaves both groups non-empty — the case the guards
+          # regression that leaves all groups non-empty — the case the guards
           # above cannot see.
           echo "shellcheck: ${#script_files[@]} in scripts/, ${#skill_files[@]} in .claude/skills/, ${#job_files[@]} in .claude-jobs/, ${#test_files[@]} in tests/"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ on:
       - '.github/workflows/ci.yml'
       - 'scripts/**'
       - '.claude/skills/**/scripts/**'
+      - '.claude-jobs/**'
 
 jobs:
   lint:

--- a/bin/apijack.ts
+++ b/bin/apijack.ts
@@ -120,6 +120,7 @@ if (!authResolved) {
 
 // 7. Resolve sessionAuth from env config
 let sessionAuth: SessionAuthConfig | undefined;
+let onChallengeInjectedFrom: string | undefined;
 {
     const env = getActiveEnvConfig(CLI_NAME, { configPath: join(configDir, 'config.json') });
 
@@ -129,6 +130,7 @@ let sessionAuth: SessionAuthConfig | undefined;
 
     if (sessionAuth && projectOnChallenge) {
         sessionAuth.onChallenge = projectOnChallenge;
+        onChallengeInjectedFrom = '.apijack/auth.ts';
     }
 }
 
@@ -150,6 +152,7 @@ const cli = createCli({
     specPath,
     auth: authStrategy,
     sessionAuth,
+    onChallengeInjectedFrom,
     refreshOn: projectSettings.auth?.refreshOn,
     generatedDir,
     allowedCidrs: projectConfig?.allowedCidrs,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "api-client",
     "sdk-generator"
   ],
-  "version": "1.16.0",
+  "version": "1.17.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -46,8 +46,8 @@
 #
 # Known and deliberate gaps. Most leave a reference VISIBLE (a possible false
 # positive) rather than hiding a real one, which is the safer direction to err —
-# the two that can hide one, the early-close reopen above and the setext
-# underline below, say so where they are described:
+# the one that can hide one, the early-close reopen above, says so where it is
+# described:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
@@ -62,9 +62,6 @@
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
 #     because the opener is looked for at the line indent, not past the marker
-#   - a setext heading underline (`Title` over a bare `-`) reads as a list item
-#     and pushes a container, since detecting it needs previous-line state; the
-#     container it pushes can open indented code under it as a fence
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -211,7 +208,7 @@ function list_offset(p,   w, n, c, t) {
 
 BEGIN {
     in_fence = 0; fence_char = ""; fence_len = 0; fence_indent = 0; fence_base = 0
-    depth = 0; base = 0
+    depth = 0; base = 0; prev_text = 0
 }
 {
     # Leading spaces, counted with a loop rather than /^ */ because the count is
@@ -242,6 +239,7 @@ BEGIN {
                     fence_indent = 0; fence_base = 0
                 }
             }
+            prev_text = 0
             next
         }
         # Dedented out of the list item holding the fence, so the fence ended
@@ -251,11 +249,13 @@ BEGIN {
         fence_indent = 0; fence_base = 0
     }
 
+    no_para = 0
     if (!blank) {
         # A list item may contain blank lines, so only a non-blank line closes
         # containers. Popping eagerly lowers base, which makes a deep fence
         # LESS likely to be recognized — the false-positive direction.
-        while (depth > 0 && indent < stack[depth]) depth--
+        popped = 0
+        while (depth > 0 && indent < stack[depth]) { depth--; popped = 1 }
         base = 0
         if (depth > 0) base = stack[depth]
 
@@ -267,9 +267,22 @@ BEGIN {
         if (indent <= base + 3) {
             off = list_offset(probe)
             if (off > 0) {
-                depth++
-                stack[depth] = indent + off
-                base = stack[depth]
+                # An empty marker right after open paragraph text never starts
+                # a list item (#142): for `-` it is a setext underline, for the
+                # rest a lazy continuation ("an empty list item cannot
+                # interrupt a paragraph"). The one exception is a marker that
+                # dedented to pop a container on its way in — that is a real
+                # sibling empty item (`- foo` then `-` at column 0), told
+                # apart here by `popped`.
+                empty_marker = (probe ~ /^([-*+]|[0-9]+[.)])[[:space:]]*$/)
+                if (empty_marker && prev_text && !popped) {
+                    no_para = 1
+                } else {
+                    depth++
+                    stack[depth] = indent + off
+                    base = stack[depth]
+                    if (empty_marker) no_para = 1
+                }
             } else if (match(probe, /^(```+|~~~+)/)) {
                 ch = substr(probe, 1, 1)
                 # A backtick info string cannot itself contain a backtick, so
@@ -277,12 +290,14 @@ BEGIN {
                 if (ch != "`" || index(substr(probe, RLENGTH + 1), "`") == 0) {
                     in_fence = 1; fence_char = ch; fence_len = RLENGTH
                     fence_indent = indent; fence_base = base
+                    prev_text = 0
                     next
                 }
             }
         }
     }
     print strip_spans($0)
+    prev_text = (!blank && !no_para)
 }
 
 # A closing fence cannot carry a trailing info string, so one stray character on

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -44,10 +44,18 @@
 # the state machine is there for exactly that reason. Weigh it before touching
 # the escape.
 #
+# An empty list marker right after open paragraph text pushes no container
+# (#142): for `-` that's a setext heading underline, for `*`/`+`/ordered
+# markers a lazy paragraph continuation ("an empty list item cannot interrupt
+# a paragraph"). The one exception is a marker that dedents back to a sibling
+# position — `- foo` then `-` at column 0 — which pops a container on its way
+# in and still pushes; that pop is how the state machine tells a real empty
+# item apart from the underline.
+#
 # Known and deliberate gaps. Most leave a reference VISIBLE (a possible false
 # positive) rather than hiding a real one, which is the safer direction to err —
-# the one that can hide one, the early-close reopen above, says so where it is
-# described:
+# the two that can hide one, the early-close reopen above and the empty-marker
+# suppression below, say so where they are described:
 #   - indented code blocks and blockquotes are not stripped (per #129: a
 #     blockquote can legitimately carry a real reference)
 #   - code spans are scanned per line, so a span that wraps across a newline
@@ -62,6 +70,11 @@
 #     container early, which only lowers the column a fence must beat
 #   - a fence opener sharing a line with its list marker (`- ```) is not seen,
 #     because the opener is looked for at the line indent, not past the marker
+#   - a line that opens no paragraph but reads as one here (an ATX heading, a
+#     thematic break, an HTML block, an indented code line) suppresses the empty
+#     marker under it, so a fence indented into what CommonMark calls that list
+#     item keeps its lower fence_base and does not end at a dedent — the second
+#     rule that can hide a reference, and unlike the reopen above it is silent
 #
 # Network-free by design: it takes text, not a PR number. Callers do their own
 # fetching, which differs between them for good reasons (the label scripts hit
@@ -273,7 +286,10 @@ BEGIN {
                 # interrupt a paragraph"). The one exception is a marker that
                 # dedented to pop a container on its way in — that is a real
                 # sibling empty item (`- foo` then `-` at column 0), told
-                # apart here by `popped`.
+                # apart here by `popped`. The digit run below is unbounded,
+                # unlike the 9-digit cap in list_offset — safe only because
+                # off > 0 already excludes a 10+-digit marker; keep the two
+                # coupled.
                 empty_marker = (probe ~ /^([-*+]|[0-9]+[.)])[[:space:]]*$/)
                 if (empty_marker && prev_text && !popped) {
                     no_para = 1

--- a/scripts/extract-closing-refs.sh
+++ b/scripts/extract-closing-refs.sh
@@ -81,10 +81,17 @@
 # `gh api repos/.../pulls/N`; collect-closes-refs.sh uses `gh pr view` so it can
 # skip numbers that turn out to be issues rather than PRs).
 #
+# --bare-refs switches the match stage from keyword-prefixed closing
+# references to ANY `#N`, while leaving the code-stripping pre-pass above
+# untouched. Used by scripts/notify-shipped-issues.sh, whose header explains
+# why that breadth — any `#N`, no closing keyword required — is deliberate
+# there; but a `#N` quoted inside code is no more a real reference in bare
+# mode than in keyword mode, so it still goes through the same strip.
+#
 # Usage:
-#   extract-closing-refs.sh --body-file <file>
-#   extract-closing-refs.sh -            # read stdin
-#   cat body.md | extract-closing-refs.sh
+#   extract-closing-refs.sh [--bare-refs] --body-file <file>
+#   extract-closing-refs.sh [--bare-refs] -            # read stdin
+#   cat body.md | extract-closing-refs.sh [--bare-refs]
 #
 # Output: issue numbers, one per line. Empty output and exit 0 when a body has
 # no closing references — that is a normal case (a chore PR opened outside the
@@ -99,6 +106,12 @@
 
 set -euo pipefail
 
+bare_refs=0
+if [ "${1-}" = "--bare-refs" ]; then
+    bare_refs=1
+    shift
+fi
+
 body_file=""
 case "${1-}" in
     --body-file)
@@ -108,7 +121,7 @@ case "${1-}" in
         body_file="/dev/stdin"
         ;;
     *)
-        echo "usage: extract-closing-refs.sh [--body-file <file> | -]" >&2
+        echo "usage: extract-closing-refs.sh [--bare-refs] [--body-file <file> | -]" >&2
         exit 1
         ;;
 esac
@@ -328,8 +341,16 @@ END {
 # rather than be swallowed by the no-match tolerance below.
 stripped=$(awk "$AWK_STRIP" "$body_file")
 
-printf '%s\n' "$stripped" \
-    | grep -oiE "$KEYWORD_RE" \
-    | grep -oE '[0-9]+' \
-    | sort -un \
-    || [ $? -eq 1 ]   # grep exit 1 == no closing references. Any other status propagates.
+if [ "$bare_refs" -eq 1 ]; then
+    printf '%s\n' "$stripped" \
+        | grep -oE '#[0-9]+' \
+        | grep -oE '[0-9]+' \
+        | sort -un \
+        || [ $? -eq 1 ]   # grep exit 1 == no bare references. Any other status propagates.
+else
+    printf '%s\n' "$stripped" \
+        | grep -oiE "$KEYWORD_RE" \
+        | grep -oE '[0-9]+' \
+        | sort -un \
+        || [ $? -eq 1 ]   # grep exit 1 == no closing references. Any other status propagates.
+fi

--- a/scripts/notify-shipped-issues.sh
+++ b/scripts/notify-shipped-issues.sh
@@ -17,7 +17,10 @@
 # This script posts a comment based on the *whole* commit range between
 # releases (any `#N` mention, any keyword), which catches issues referenced
 # in individual commit messages that never made it into the curated PR body.
-# They are complementary — running both is expected, not redundant.
+# They are complementary — running both is expected, not redundant. The
+# `#N` breadth is unchanged, but a reference quoted inside a fenced code
+# block or inline code span is now excluded, via
+# extract-closing-refs.sh --bare-refs.
 #
 # Usage:
 #   notify-shipped-issues.sh <tag> <release-url> [--dry-run]
@@ -35,7 +38,8 @@
 
 set -euo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gh-pin-account.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/gh-pin-account.sh"
 
 dry_run=0
 args=()
@@ -53,6 +57,11 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+if [ "${#args[@]}" -gt 2 ]; then
+    echo "usage: notify-shipped-issues.sh <tag> <release-url> [--dry-run]" >&2
+    exit 1
+fi
 
 # The `||` chain short-circuits, so `${args[0]}`/`${args[1]}` are never
 # indexed until the length check already confirmed they exist — required
@@ -83,11 +92,8 @@ echo "Scanning $PREV_TAG..$TAG for closed-issue references"
 # Same reasoning: capture `git log` first so a bad revision range (e.g. TAG
 # not actually present locally) aborts loudly via `set -e` and git's own
 # stderr, rather than reading as "no issue references" and exiting 0.
-COMMIT_LOG=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s %b")
-NUMS=$(printf '%s' "$COMMIT_LOG" \
-    | grep -oE '#[0-9]+' \
-    | tr -d '#' \
-    | sort -u || true)
+COMMIT_LOG=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"%s%n%b")
+NUMS=$(printf '%s' "$COMMIT_LOG" | "$SCRIPT_DIR/extract-closing-refs.sh" --bare-refs -)
 
 if [ -z "$NUMS" ]; then
     echo "No issue references found."
@@ -112,8 +118,14 @@ for N in $NUMS; do
     # — most plausibly a manual/local re-run while diagnosing a release, or
     # a future reordering of publish.yml's steps. A second run must not
     # double-comment, so look for the marker in any existing comment body
-    # first. `per_page=100` because the default page is the oldest 30
-    # comments, and the marker (if present) is more likely to be recent.
+    # first. The comments endpoint sorts ascending by id and supports only
+    # `since`/`per_page`/`page` — no way to ask for "most recent" — so
+    # `per_page=100` just widens the window from the default oldest 30
+    # comments to the oldest 100; it does not bias toward recent ones. Past
+    # 100 comments the guard fails open and double-comments, which is the
+    # intended direction here too (a duplicate beats a missed
+    # notification); `since` or a page walk is the exact fix if this ever
+    # needs to scale past that.
     #
     # Fails open on a transient API error (`|| echo ''`): that reads as "no
     # existing comment" and falls through to commenting again. A duplicate

--- a/scripts/notify-shipped-issues.sh
+++ b/scripts/notify-shipped-issues.sh
@@ -22,6 +22,15 @@
 # block or inline code span is now excluded, via
 # extract-closing-refs.sh --bare-refs.
 #
+# Known and deliberate gap: the entire commit range is piped as a single
+# document to extract-closing-refs.sh. An unterminated code fence in one
+# commit's body leaves the fence open for all subsequent commits in the range.
+# Until closed, extract-closing-refs.sh treats all content as code and strips
+# it from the scan, masking issue references in those commits. Probability is
+# low (requires odd fence count in a release range). Blast radius: missed
+# courtesy notifications, flagged by the "unterminated code fence" warning
+# extract-closing-refs.sh prints to stderr when the script runs.
+#
 # Usage:
 #   notify-shipped-issues.sh <tag> <release-url> [--dry-run]
 #
@@ -32,9 +41,10 @@
 # toplevel), so this can run from a checkout of a different repo — tests
 # exercise it against a throwaway fixture repo.
 #
-# Never aborts the caller: a failure to comment on one issue is logged to
-# stderr and the loop continues. Exits 0 unless the arguments themselves are
-# invalid.
+# Never aborts on per-issue comment failures: a failure to comment on one
+# issue is logged to stderr and the loop continues. Exits non-zero for
+# invalid arguments, broken revision ranges, or internal extractor failures;
+# per-issue failures do not abort the loop.
 
 set -euo pipefail
 

--- a/src/aliases.ts
+++ b/src/aliases.ts
@@ -160,7 +160,8 @@ export interface RewriteResult {
  *   (error emitted, CLI continues without the alias) -- unless
  *   `opts.generatedCommandsPresent` is `false`, in which case they are skipped
  *   silently, since there is nothing meaningful to validate against before
- *   `generate` has run.
+ *   `generate` has run, or if it ran incompletely (generated command
+ *   registration didn't actually complete).
  * - Longest-prefix wins: multi-token aliases are matched before shorter ones.
  * - Trailing args (positional and flags) are appended verbatim.
  */

--- a/src/auth/refresh-wiring.ts
+++ b/src/auth/refresh-wiring.ts
@@ -5,6 +5,10 @@ import { deepMergeSessionAuth } from './config-merge';
 export interface RefreshWiringOptions {
     sessionAuth?: SessionAuthConfig;
     refreshOn?: number[];
+    /** Set by the shared-binary entry points when they inject a project-level
+     *  `onChallenge` (from `.apijack/auth.ts`) into `sessionAuth`. Used only to
+     *  attribute the injected key in the endpoint-less sessionAuth diagnostic. */
+    onChallengeInjectedFrom?: string;
 }
 
 export interface RefreshWiring {
@@ -44,13 +48,22 @@ export function resolveRefreshWiring(
         // this works without a session.endpoint. Only warn when there's something else
         // in the block, which is the signature of a typo'd handshake key (e.g. `sessions:`
         // instead of `session:`) rather than an intentional refresh-only block.
+        // An explicit `null` (e.g. from a JSON env config) still counts as "present" here
+        // deliberately — the user typed it, and the key is genuinely dead without a
+        // session.endpoint, so it's correct to name it in the warning (#150).
         const foundKeys = Object.keys(rawSessionAuth).filter(
             key => key !== 'refreshOn' && (rawSessionAuth as Record<string, unknown>)[key] !== undefined,
         );
 
         if (foundKeys.length > 0) {
+            const renderedKeys = foundKeys.map(key =>
+                key === 'onChallenge' && options.onChallengeInjectedFrom
+                    ? `onChallenge (injected from ${options.onChallengeInjectedFrom})`
+                    : key,
+            );
+
             console.warn(
-                `[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used. Found: ${foundKeys.join(', ')}.`,
+                `[apijack] sessionAuth is set but missing session.endpoint — SessionAuthStrategy will not be used. Found: ${renderedKeys.join(', ')}.`,
             );
         }
     }

--- a/src/cli-builder.ts
+++ b/src/cli-builder.ts
@@ -641,6 +641,8 @@ export function createCli(options: CliOptions): Cli {
             }
 
             // 9. Create ApiClient and register generated commands
+            let generatedCommandsRegistered = false;
+
             if (commandsModule && ApiClientClass) {
                 const registerFn = commandsModule.registerGeneratedCommands as (
                     program: Command, client: unknown, onResult: (result: unknown) => void,
@@ -745,6 +747,7 @@ export function createCli(options: CliOptions): Cli {
                 };
 
                 registerFn(program, client, onResult);
+                generatedCommandsRegistered = true;
             }
 
             // 10. Register consumer commands and attach per-command requiresAuth preAction hooks.
@@ -960,10 +963,9 @@ export function createCli(options: CliOptions): Cli {
                     process.argv.slice(2),
                     aliasMap,
                     realPaths,
-                    // Mirrors the registration condition above — an existing client
-                    // module that doesn't export ApiClient leaves ApiClientClass
-                    // `undefined`, not `null`.
-                    { generatedCommandsPresent: !!commandsModule && !!ApiClientClass },
+                    // Set iff generated-command registration actually ran, so this
+                    // guard cannot diverge from the registration condition above.
+                    { generatedCommandsPresent: generatedCommandsRegistered },
                 );
 
                 for (const w of warnings) {

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -159,6 +159,11 @@ export async function runRoutine(
         auth: authStrategy,
         sessionAuth,
         onChallengeInjectedFrom,
+        // Mirror bin/apijack.ts: `.apijack/settings.json` auth.refreshOn must reach
+        // createCli here too. Routine fixtures (Playwright/Vitest) are exactly the
+        // long-running flows a stale session bites, so the programmatic entry point
+        // needs the same stale-session refresh the CLI gets.
+        refreshOn: projectSettings.auth?.refreshOn,
         generatedDir,
         allowedCidrs: projectConfig?.allowedCidrs,
         configPath: join(configDir, 'config.json'),

--- a/src/run-routine.ts
+++ b/src/run-routine.ts
@@ -134,12 +134,14 @@ export async function runRoutine(
     }
 
     let sessionAuth: SessionAuthConfig | undefined;
+    let onChallengeInjectedFrom: string | undefined;
 
     if (envConfig) {
         sessionAuth = (envConfig as Record<string, unknown>).sessionAuth as SessionAuthConfig | undefined;
 
         if (sessionAuth && projectOnChallenge) {
             sessionAuth.onChallenge = projectOnChallenge;
+            onChallengeInjectedFrom = '.apijack/auth.ts';
         }
     }
 
@@ -156,6 +158,7 @@ export async function runRoutine(
         specPath,
         auth: authStrategy,
         sessionAuth,
+        onChallengeInjectedFrom,
         generatedDir,
         allowedCidrs: projectConfig?.allowedCidrs,
         configPath: join(configDir, 'config.json'),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -36,14 +36,14 @@ function validateProjectSettings(parsed: unknown): ProjectSettings {
             warnAndIgnore('customCommands', 'an object');
             delete settings.customCommands;
         } else {
-            const customCommands = settings.customCommands as Record<string, unknown>;
+            const customCommands = settings.customCommands;
 
             if ('defaults' in customCommands) {
                 if (!isPlainObject(customCommands.defaults)) {
                     warnAndIgnore('customCommands.defaults', 'an object');
                     delete customCommands.defaults;
                 } else {
-                    const defaults = customCommands.defaults as Record<string, unknown>;
+                    const defaults = customCommands.defaults;
 
                     if ('requiresAuth' in defaults && typeof defaults.requiresAuth !== 'boolean') {
                         warnAndIgnore('customCommands.defaults.requiresAuth', 'a boolean');
@@ -59,7 +59,7 @@ function validateProjectSettings(parsed: unknown): ProjectSettings {
             warnAndIgnore('auth', 'an object');
             delete settings.auth;
         } else {
-            const auth = settings.auth as Record<string, unknown>;
+            const auth = settings.auth;
 
             if ('refreshOn' in auth) {
                 const refreshOn = auth.refreshOn;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,13 +14,76 @@ export interface ProjectSettings {
     };
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function warnAndIgnore(key: string, expected: string): void {
+    console.warn(`[apijack] .apijack/settings.json: '${key}' must be ${expected} — ignoring`);
+}
+
+function validateProjectSettings(parsed: unknown): ProjectSettings {
+    if (!isPlainObject(parsed)) {
+        console.warn('[apijack] .apijack/settings.json: settings must be a JSON object — ignoring');
+
+        return {};
+    }
+
+    const settings = parsed as ProjectSettings & Record<string, unknown>;
+
+    if ('customCommands' in settings) {
+        if (!isPlainObject(settings.customCommands)) {
+            warnAndIgnore('customCommands', 'an object');
+            delete settings.customCommands;
+        } else {
+            const customCommands = settings.customCommands as Record<string, unknown>;
+
+            if ('defaults' in customCommands) {
+                if (!isPlainObject(customCommands.defaults)) {
+                    warnAndIgnore('customCommands.defaults', 'an object');
+                    delete customCommands.defaults;
+                } else {
+                    const defaults = customCommands.defaults as Record<string, unknown>;
+
+                    if ('requiresAuth' in defaults && typeof defaults.requiresAuth !== 'boolean') {
+                        warnAndIgnore('customCommands.defaults.requiresAuth', 'a boolean');
+                        delete defaults.requiresAuth;
+                    }
+                }
+            }
+        }
+    }
+
+    if ('auth' in settings) {
+        if (!isPlainObject(settings.auth)) {
+            warnAndIgnore('auth', 'an object');
+            delete settings.auth;
+        } else {
+            const auth = settings.auth as Record<string, unknown>;
+
+            if ('refreshOn' in auth) {
+                const refreshOn = auth.refreshOn;
+
+                if (!Array.isArray(refreshOn) || !refreshOn.every(v => typeof v === 'number')) {
+                    warnAndIgnore('auth.refreshOn', 'an array of numbers');
+                    delete auth.refreshOn;
+                }
+            }
+        }
+    }
+
+    return settings;
+}
+
 export function loadProjectSettings(apijackDir: string): ProjectSettings {
     const settingsPath = join(apijackDir, 'settings.json');
 
     if (!existsSync(settingsPath)) return {};
 
     try {
-        return JSON.parse(readFileSync(settingsPath, 'utf-8')) as ProjectSettings;
+        const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'));
+
+        return validateProjectSettings(parsed);
     } catch {
         return {};
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,10 @@ export interface CliOptions {
      *  Takes precedence over `sessionAuth.refreshOn` when both are set. Lets a
      *  project with a custom AuthStrategy opt in without a `sessionAuth` block. */
     refreshOn?: number[];
+    /** Set by the shared-binary entry points when they inject a project-level
+     *  `onChallenge` (from `.apijack/auth.ts`) into `sessionAuth`. Used only to
+     *  attribute the injected key in the endpoint-less sessionAuth diagnostic. */
+    onChallengeInjectedFrom?: string;
     outputModes?: string[];
     generatedDir?: string;
     knownSites?: Record<string, { url: string; description: string; group?: string }>;

--- a/tests/aliases.test.ts
+++ b/tests/aliases.test.ts
@@ -260,7 +260,7 @@ describe('rewriteArgv()', () => {
         // Pre-codegen, "customers get-customer-order-summary" hasn't been registered
         // yet, so it's absent from realPaths — same situation as an unknown expansion.
         const aliases: AliasMap = { cs: 'customers get-customer-order-summary' };
-        const result = rewriteArgv(['cs', '42'], aliases, new Set(['generate', 'config']), {
+        const result = rewriteArgv(['cs', '42'], aliases, builtinPaths, {
             generatedCommandsPresent: false,
         });
 

--- a/tests/auth/refresh-wiring.test.ts
+++ b/tests/auth/refresh-wiring.test.ts
@@ -241,5 +241,23 @@ describe('resolveRefreshWiring', () => {
                 warnSpy.mockRestore();
             }
         });
+
+        test('names a key whose explicit null arrives via the envConfig merge path (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            // A JSON env config can carry `"cookies": null`; deepMerge's scalar
+            // branch assigns it, so it must survive the merge and be named.
+            const refreshOnlySessionAuth = { refreshOn: [401] } as unknown as SessionAuthConfig;
+            const envConfigWithNull = { sessionAuth: { cookies: null } } as unknown as
+                Parameters<typeof resolveRefreshWiring>[1];
+
+            try {
+                resolveRefreshWiring({ sessionAuth: refreshOnlySessionAuth }, envConfigWithNull);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('cookies');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
     });
 });

--- a/tests/auth/refresh-wiring.test.ts
+++ b/tests/auth/refresh-wiring.test.ts
@@ -163,5 +163,83 @@ describe('resolveRefreshWiring', () => {
                 warnSpy.mockRestore();
             }
         });
+
+        test('attributes onChallenge to its injection source when onChallengeInjectedFrom is set (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const refreshOnlyWithChallenge = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring(
+                    { sessionAuth: refreshOnlyWithChallenge, onChallengeInjectedFrom: '.apijack/auth.ts' },
+                    undefined,
+                );
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge (injected from .apijack/auth.ts)');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('renders onChallenge plain when onChallengeInjectedFrom is not set (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const refreshOnlyWithChallenge = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring({ sessionAuth: refreshOnlyWithChallenge }, undefined);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge');
+                expect(message).not.toContain('injected from');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('attributes only the injected onChallenge key when mixed with a typo\'d key (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const mixedSessionAuth = {
+                refreshOn: [401],
+                onChallenge: async () => {},
+                sessions: { endpoint: '/session' },
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring(
+                    { sessionAuth: mixedSessionAuth, onChallengeInjectedFrom: '.apijack/auth.ts' },
+                    undefined,
+                );
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('onChallenge (injected from .apijack/auth.ts)');
+                expect(message).toContain('sessions');
+                expect(message).not.toContain('sessions (injected from');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+
+        test('names a key whose value is explicit null (#150)', () => {
+            const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            const explicitNullSessionAuth = {
+                refreshOn: [401],
+                cookies: null,
+            } as unknown as SessionAuthConfig;
+
+            try {
+                resolveRefreshWiring({ sessionAuth: explicitNullSessionAuth }, undefined);
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0]![0] as string;
+                expect(message).toContain('cookies');
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
     });
 });

--- a/tests/cli-builder.test.ts
+++ b/tests/cli-builder.test.ts
@@ -860,6 +860,68 @@ describe('alias validation before codegen has run (#136)', () => {
 
         expect(stderrOut).not.toContain('does not resolve to a known command');
     });
+
+    test('does not report unresolved generated-command aliases when codegen is partial (client exports no ApiClient) (#138)', async () => {
+        const workDir = join(tmpdir(), `apijack-alias-partialcodegen-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        const cliConfigDir = join(workDir, '.testcli');
+        const generatedDir = join(workDir, 'src', 'generated');
+        mkdirSync(cliConfigDir, { recursive: true });
+        mkdirSync(generatedDir, { recursive: true });
+        // Points at an operation that would only exist once `generate` has fully run.
+        writeFileSync(
+            join(cliConfigDir, 'aliases.json'),
+            JSON.stringify({ cs: 'customers list-customers' }),
+        );
+        // commandsModule exists (so `commandsModule` is truthy)...
+        writeFileSync(
+            join(generatedDir, 'commands.ts'),
+            'export function registerGeneratedCommands(): void {}\n',
+        );
+        // ...but the client module imports cleanly without exporting `ApiClient`,
+        // leaving `ApiClientClass` undefined and registration skipped.
+        writeFileSync(join(generatedDir, 'client.ts'), 'export const somethingElse = 1;\n');
+
+        const origArgv = process.argv;
+        const origStderr = process.stderr.write.bind(process.stderr);
+        const origStdout = process.stdout.write.bind(process.stdout);
+        const origLog = console.log;
+        const origExit = process.exit;
+        let stderrOut = '';
+
+        try {
+            process.argv = ['node', 'testcli', 'config', 'list'];
+            process.stderr.write = ((c: string | Uint8Array) => {
+                stderrOut += String(c);
+
+                return true;
+            }) as never;
+            process.stdout.write = (() => true) as never;
+            console.log = () => {};
+            process.exit = (() => {
+                throw new Error('__exit__');
+            }) as never;
+
+            const cli = createCli(makeOptions({
+                configPath: join(cliConfigDir, 'config.json'),
+                generatedDir,
+            }));
+
+            try {
+                await cli.run();
+            } catch (e) {
+                if ((e as Error).message !== '__exit__') throw e;
+            }
+        } finally {
+            process.argv = origArgv;
+            process.stderr.write = origStderr as never;
+            process.stdout.write = origStdout as never;
+            console.log = origLog;
+            process.exit = origExit;
+            rmSync(workDir, { recursive: true, force: true });
+        }
+
+        expect(stderrOut).not.toContain('does not resolve to a known command');
+    });
 });
 
 describe('cli.runRoutine', () => {

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -41,6 +41,21 @@ async function extractFile(path: string): Promise<ExtractResult> {
     return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
 }
 
+/** Same as `extract`, but with `--bare-refs` so ANY `#N` matches, not just keyword-prefixed ones. */
+async function extractBare(body: string): Promise<ExtractResult> {
+    const proc = Bun.spawn([scriptPath, '--bare-refs', '-'], {
+        cwd: repoRoot,
+        stdin: new TextEncoder().encode(body),
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return { issues: stdout.split('\n').filter(Boolean), exitCode, stderr };
+}
+
 // `bun test` runs on windows-latest in CI, where Bun can't exec a .sh directly
 // (ENOENT). The scripts under test are release automation — they run from a
 // maintainer's shell and from Linux CI, never on Windows. Invoking them through
@@ -460,6 +475,44 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
             expect(await proc.exited).toBe(0);
             expect(stdout.split('\n').filter(Boolean)).toEqual(['7']);
+        });
+    });
+
+    describe('--bare-refs mode', () => {
+        test('matches a bare #N with no closing keyword', async () => {
+            const { issues } = await extractBare('see #12 and #34');
+            expect(issues).toEqual(['12', '34']);
+        });
+
+        test('still matches keyword-prefixed refs', async () => {
+            const { issues } = await extractBare('Closes #5\nand #7');
+            expect(issues).toEqual(['5', '7']);
+        });
+
+        test('excludes refs inside a fenced block', async () => {
+            const { issues } = await extractBare('```\n#99\n```\nsee #3\n');
+            expect(issues).toEqual(['3']);
+        });
+
+        test('excludes refs inside an inline code span', async () => {
+            const { issues } = await extractBare('`prefixes #14` and `Discloses #15`. refs #16\n');
+            expect(issues).toEqual(['16']);
+        });
+
+        test('dedupes and sorts numerically', async () => {
+            const { issues } = await extractBare('#100 #9 #11 #9');
+            expect(issues).toEqual(['9', '11', '100']);
+        });
+
+        test('exits 0 with no output on a body with no refs', async () => {
+            const { issues, exitCode } = await extractBare('chore: bump deps\n\nNothing to see here.\n');
+            expect(issues).toEqual([]);
+            expect(exitCode).toBe(0);
+        });
+
+        test('keyword mode regression guard: keyword mode still ignores bare refs', async () => {
+            const { issues } = await extract('see #12\nCloses #5\n');
+            expect(issues).toEqual(['5']);
         });
     });
 

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -279,7 +279,7 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
     describe('documented gaps', () => {
         // Most of these leak a reference rather than hide one — the safer
-        // direction. The one that can hide one is pinned last, and says so. All
+        // direction. The two that can hide one are pinned last, and say so. All
         // of them are here so the behavior can't drift silently; see the header
         // comment in scripts/extract-closing-refs.sh.
 
@@ -319,6 +319,23 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual([]);
             expect(stderr).toContain('unterminated code fence');
         });
+
+        test('a line that opens no paragraph still suppresses the empty marker under it — silently', async () => {
+            // HIDES a reference, and this one is silent where the early-close
+            // reopen above at least warns. An ATX heading (like indented code, a
+            // thematic break, or an HTML block) opens no paragraph in CommonMark,
+            // but the state machine has no model of ATX headings, so it sets
+            // prev_text = 1 anyway and suppresses the empty marker below it. The
+            // fence indented into what CommonMark calls that list item keeps a
+            // lower fence_base and never ends at the dedent, so `Closes #7`
+            // is swallowed with no unterminated-fence warning. dev has the
+            // symmetric defect here: it reports #7 AND fires a spurious
+            // unterminated-fence warning, since CommonMark agrees the ref is code.
+            const { issues, stderr, exitCode } = await extract('# Title\n-\n  ```\n  code\nCloses #7\n  ```\n');
+            expect(issues).toEqual([]);
+            expect(stderr).toBe('');
+            expect(exitCode).toBe(0);
+        });
     });
 
     describe('a setext underline is not a list item', () => {
@@ -341,8 +358,14 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
         });
 
         test('an underline at an item content column is a heading inside the item, not a new container', async () => {
-            const { issues } = await extract('- Title\n  -\n\n      Closes #100\n');
-            expect(issues).toEqual(['100']);
+            // Without the fence this doesn't discriminate: indent 6 is within
+            // base + 3 whether base is 2 (no new container, correct) or 4 (dev's
+            // buggy push). The fence makes it load-bearing: at base 2 it sits 4
+            // past the item's content column — indented code, stays visible — but
+            // dev wrongly pushes a second container to base 4, where the same
+            // fence opens and swallows #100.
+            const { issues } = await extract('- Title\n  -\n\n      ```\n      Closes #100\n      ```\nCloses #7\n');
+            expect(issues).toEqual(['7', '100']);
         });
 
         test('a lone `-` that dedents back to sibling position is still a real empty item', async () => {

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -328,9 +328,12 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             // prev_text = 1 anyway and suppresses the empty marker below it. The
             // fence indented into what CommonMark calls that list item keeps a
             // lower fence_base and never ends at the dedent, so `Closes #7`
-            // is swallowed with no unterminated-fence warning. dev has the
-            // symmetric defect here: it reports #7 AND fires a spurious
-            // unterminated-fence warning, since CommonMark agrees the ref is code.
+            // is swallowed with no unterminated-fence warning. On this shape
+            // dev was CommonMark-correct on both counts — the flush-left line
+            // ends the item and its fence, so it printed #7 and warned about
+            // the genuinely unterminated fence the trailing line opens.
+            // Accepted anyway: the shape is contrived, and #157 tracks
+            // narrowing prev_text so the marker reads as a real item again.
             const { issues, stderr, exitCode } = await extract('# Title\n-\n  ```\n  code\nCloses #7\n  ```\n');
             expect(issues).toEqual([]);
             expect(stderr).toBe('');

--- a/tests/extract-closing-refs.test.ts
+++ b/tests/extract-closing-refs.test.ts
@@ -279,7 +279,7 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
 
     describe('documented gaps', () => {
         // Most of these leak a reference rather than hide one — the safer
-        // direction. The two that can hide one are pinned last, and say so. All
+        // direction. The one that can hide one is pinned last, and says so. All
         // of them are here so the behavior can't drift silently; see the header
         // comment in scripts/extract-closing-refs.sh.
 
@@ -308,17 +308,6 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             expect(issues).toEqual(['7']);
         });
 
-        test('a setext underline hides the indented code beneath it — and is silent', async () => {
-            // HIDES a reference. A heading underlined with a bare lone `-` needs
-            // previous-line state to tell from a list item, so it pushes a
-            // container, and the indented code under it opens as a fence instead
-            // of staying visible. Narrow (`--` and `---` both take other paths)
-            // but this is one of the two shapes nothing else flags.
-            const { issues, stderr } = await extract('Title\n-\n\n    ```\n    Closes #1\n    ```\n');
-            expect(issues).toEqual([]);
-            expect(stderr).toBe('');
-        });
-
         test('a fence closed after an early close hides the rest — but warns', async () => {
             // Pins the MECHANISM, not a divergence. Flush-left code under a
             // bullet dedents out of the item, so the fence ends early and its
@@ -329,6 +318,57 @@ describe.skipIf(process.platform === 'win32')('extract-closing-refs.sh', () => {
             const { issues, stderr } = await extract('- Steps:\n  ```bash\nnpm install\n  ```\n\nCloses #7\n');
             expect(issues).toEqual([]);
             expect(stderr).toContain('unterminated code fence');
+        });
+    });
+
+    describe('a setext underline is not a list item', () => {
+        // An empty list marker on the line right after open paragraph text
+        // never starts a list item (#142): for `-` it is a setext underline,
+        // for `*`/`+`/ordered markers it is a lazy paragraph continuation —
+        // "an empty list item cannot interrupt a paragraph". Either way no
+        // container is pushed, so indented code beneath it stays indented
+        // code rather than opening as a fence.
+        test('leaves the indented code beneath it visible', async () => {
+            const { issues, stderr, exitCode } = await extract('Title\n-\n\n    ```\n    Closes #1\n    ```\n');
+            expect(issues).toEqual(['1']);
+            expect(stderr).toBe('');
+            expect(exitCode).toBe(0);
+        });
+
+        test('trailing whitespace on the underline does not change that', async () => {
+            const { issues } = await extract('Title\n-   \n\n    ```\n    Closes #1\n    ```\n');
+            expect(issues).toEqual(['1']);
+        });
+
+        test('an underline at an item content column is a heading inside the item, not a new container', async () => {
+            const { issues } = await extract('- Title\n  -\n\n      Closes #100\n');
+            expect(issues).toEqual(['100']);
+        });
+
+        test('a lone `-` that dedents back to sibling position is still a real empty item', async () => {
+            // The one exception: dedenting to a sibling marker position pops a
+            // container on the way in, which is how this case is told apart
+            // from the underline above.
+            const { issues } = await extract('- foo\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('the underline closes the paragraph, so a second lone `-` is a genuine item', async () => {
+            const { issues } = await extract('Title\n-\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
+        });
+
+        test('other empty markers cannot interrupt a paragraph either', async () => {
+            const star = await extract('Title\n*\n\n    ```\n    Closes #1\n    ```\n');
+            expect(star.issues).toEqual(['1']);
+
+            const ordered = await extract('Title\n1.\n\n    ```\n    Closes #1\n    ```\n');
+            expect(ordered.issues).toEqual(['1']);
+        });
+
+        test('after a closed fence a lone `-` is a genuine empty item', async () => {
+            const { issues } = await extract('```\ncode\n```\n-\n    ```\n    Closes #100\n    ```\nCloses #7\n');
+            expect(issues).toEqual(['7']);
         });
     });
 

--- a/tests/notify-shipped-issues.test.ts
+++ b/tests/notify-shipped-issues.test.ts
@@ -105,6 +105,14 @@ function buildRepo(dir: string): void {
     git(dir, ['config', 'user.name', 'Test']);
 }
 
+/** Commit with a multi-line message, needed for fenced-block/inline-span fixtures. */
+function commitWithMessage(dir: string, message: string): void {
+    const msgFile = join(dir, '.commit-msg-tmp');
+    writeFileSync(msgFile, message);
+    git(dir, ['commit', '--allow-empty', '-F', msgFile]);
+    rmSync(msgFile);
+}
+
 /** Run notify-shipped-issues.sh with a fake `gh` backed by `fixture`. */
 async function runScript(opts: { cwd: string; args: string[]; fixture: Fixture; repo?: string }): Promise<RunResult> {
     const fakeBin = mkdtempSync(join(tmpdir(), 'notify-shipped-fakebin-'));
@@ -148,6 +156,7 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
     let singleTagRepo: string;
     let noRefRepo: string;
     let crossTagRepo: string;
+    let quotedRepo: string;
 
     // mainRepo carries commits between v1.0.0 and v1.1.0 referencing five
     // issue numbers, one per scenario the fixture drives:
@@ -192,10 +201,41 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
         git(crossTagRepo, ['tag', 'v1.1.0']);
         git(crossTagRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #20']);
         git(crossTagRepo, ['tag', 'v1.11.0']);
+
+        // quotedRepo pins the extractor wiring: a fenced code block and an
+        // inline code span each quote a `#N` that must NOT be scanned as a
+        // reference, alongside genuine references (including out-of-order
+        // ones) that must be — and in numeric order.
+        quotedRepo = mkdtempSync(join(tmpdir(), 'notify-shipped-quoted-'));
+        buildRepo(quotedRepo);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'chore: initial commit']);
+        git(quotedRepo, ['tag', 'v1.0.0']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #100']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #11']);
+        git(quotedRepo, ['commit', '--allow-empty', '-m', 'fix: closed issue Fixes #9']);
+        // Fence opener as the first line of the body — only reachable via
+        // `--pretty=format:"%s%n%b"`; the old "%s %b" glued it onto the
+        // subject line, where the stripper's line-start fence check missed
+        // it.
+        commitWithMessage(quotedRepo, [
+            'fix: fenced reference test',
+            '',
+            '```',
+            'Example #77 quoted',
+            '```',
+            '',
+            'Fixes #5',
+        ].join('\n'));
+        commitWithMessage(quotedRepo, [
+            'fix: inline span reference test',
+            '',
+            'See `prefixes #14` for details',
+        ].join('\n'));
+        git(quotedRepo, ['tag', 'v1.1.0']);
     });
 
     afterAll(() => {
-        for (const dir of [mainRepo, singleTagRepo, noRefRepo, crossTagRepo]) {
+        for (const dir of [mainRepo, singleTagRepo, noRefRepo, crossTagRepo, quotedRepo]) {
             rmSync(dir, { recursive: true, force: true });
         }
     });
@@ -213,6 +253,15 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
             14: { pull_request: null, state: 'closed', comments: [] },
         },
         commentFailures: ['14'],
+    };
+
+    const quotedFixture: Fixture = {
+        issues: {
+            5: { pull_request: null, state: 'closed', comments: [] },
+            9: { pull_request: null, state: 'closed', comments: [] },
+            11: { pull_request: null, state: 'closed', comments: [] },
+            100: { pull_request: null, state: 'closed', comments: [] },
+        },
     };
 
     test('no previous stable tag: exits 0, no comments', async () => {
@@ -326,6 +375,41 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
         expect(result.calls).toContain(`comment 20 Shipped in [v1.11.0](${releaseUrl}) 🚀`);
     });
 
+    test('a reference quoted inside a fenced code block is not matched', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('#5: [dry-run] would comment');
+        expect(result.stdout).not.toContain('#77');
+    });
+
+    test('a reference inside an inline code span is not matched', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).not.toContain('#14');
+    });
+
+    test('scan order is numeric, not lexicographic', async () => {
+        const result = await runScript({
+            cwd: quotedRepo,
+            args: ['v1.1.0', releaseUrl, '--dry-run'],
+            fixture: quotedFixture,
+        });
+        expect(result.exitCode).toBe(0);
+        const indexOf = (n: string) => result.stdout.indexOf(`#${n}: [dry-run] would comment`);
+        const [i9, i11, i100] = [indexOf('9'), indexOf('11'), indexOf('100')];
+        expect(i9).toBeGreaterThanOrEqual(0);
+        expect(i11).toBeGreaterThan(i9);
+        expect(i100).toBeGreaterThan(i11);
+    });
+
     test('a broken revision range fails loudly instead of reading as "no issue references"', async () => {
         // v9.9.9 is not an actual tag in mainRepo: PREV_TAG resolves to
         // v1.1.0 (the highest real tag), then `git log v1.1.0..v9.9.9` fails
@@ -382,6 +466,17 @@ describe.skipIf(process.platform === 'win32')('notify-shipped-issues.sh', () => 
             expect(result.exitCode).toBe(1);
             expect(result.stderr).toContain('usage:');
             expect(result.calls.filter(c => c.startsWith('comment '))).toEqual([]);
+        });
+
+        test('errors on a third positional argument instead of silently ignoring it', async () => {
+            const result = await runScript({
+                cwd: mainRepo,
+                args: ['v1.0.0', releaseUrl, 'junk'],
+                fixture: { issues: {} },
+            });
+            expect(result.exitCode).toBe(1);
+            expect(result.stderr).toContain('usage:');
+            expect(result.calls).toEqual([]);
         });
     });
 });

--- a/tests/run-routine-refreshon.isolated.ts
+++ b/tests/run-routine-refreshon.isolated.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * #159 — `runRoutine()` must forward `.apijack/settings.json` `auth.refreshOn`
+ * to createCli(), the same way bin/apijack.ts does.
+ *
+ * The refresh *wiring* below createCli is already covered by
+ * cli-builder-refresh-wiring.integration.test.ts. What was missing — and what
+ * let the gap ship — is a test that the programmatic entry point hands the
+ * setting down at all. So this pins the forwarding, not the retry behavior:
+ * createCli is mocked and we assert on the options object it receives.
+ */
+
+interface CapturedOptions {
+    refreshOn?: number[];
+    customCommandDefaults?: unknown;
+}
+
+let captured: CapturedOptions | undefined;
+
+const stubCli = {
+    use: () => {},
+    command: () => {},
+    dispatcher: () => {},
+    resolver: () => {},
+    runRoutine: async () => ({ status: 'ok' }),
+};
+
+// Capture the real module BEFORE mocking, and put it back in afterAll. bun's
+// module registry is process-wide: without the restore, this stub leaks into
+// every later file that imports createCli (it broke 16 tests across
+// run-routine.test.ts and custom-command-auth.test.ts when first written).
+const realCliBuilder = await import('../src/cli-builder');
+
+mock.module('../src/cli-builder', () => ({
+    ...realCliBuilder,
+    createCli: (options: CapturedOptions) => {
+        captured = options;
+
+        return stubCli;
+    },
+}));
+
+const { runRoutine } = await import('../src/run-routine');
+
+afterAll(() => {
+    mock.module('../src/cli-builder', () => realCliBuilder);
+});
+
+describe('#159 runRoutine forwards settings.json auth.refreshOn', () => {
+    let tmpHome: string;
+    let projectDir: string;
+    let originalHome: string | undefined;
+    let originalCwd: string;
+
+    function writeProject(settings: unknown): void {
+        mkdirSync(join(projectDir, '.apijack', 'routines'), { recursive: true });
+        writeFileSync(join(projectDir, '.apijack.json'), JSON.stringify({}));
+        writeFileSync(join(projectDir, '.apijack', 'config.json'), JSON.stringify({
+            active: 'default',
+            environments: {
+                default: { url: 'http://localhost:9999', user: 'u', password: 'p' },
+            },
+        }));
+        writeFileSync(join(projectDir, '.apijack', 'routines', 'noop.yaml'),
+            'name: noop\nsteps: []\n');
+
+        if (settings !== undefined) {
+            writeFileSync(join(projectDir, '.apijack', 'settings.json'), JSON.stringify(settings));
+        }
+    }
+
+    beforeEach(() => {
+        captured = undefined;
+        const id = `run-routine-refreshon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        tmpHome = join(tmpdir(), `${id}-home`);
+        projectDir = join(tmpdir(), `${id}-project`);
+        mkdirSync(join(tmpHome, '.apijack', 'routines'), { recursive: true });
+        mkdirSync(projectDir, { recursive: true });
+
+        originalHome = process.env.HOME;
+        process.env.HOME = tmpHome;
+        originalCwd = process.cwd();
+        process.chdir(projectDir);
+    });
+
+    afterEach(() => {
+        process.chdir(originalCwd);
+
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+
+        rmSync(tmpHome, { recursive: true, force: true });
+        rmSync(projectDir, { recursive: true, force: true });
+    });
+
+    test('auth.refreshOn reaches createCli', async () => {
+        writeProject({ auth: { refreshOn: [401, 403] } });
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toEqual([401, 403]);
+    });
+
+    test('absent settings.json leaves refreshOn undefined rather than throwing', async () => {
+        writeProject(undefined);
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toBeUndefined();
+    });
+
+    test('an invalid auth.refreshOn is dropped by validation before it reaches createCli', async () => {
+        writeProject({ auth: { refreshOn: 'nope' } });
+
+        await runRoutine('noop');
+
+        expect(captured?.refreshOn).toBeUndefined();
+    });
+});

--- a/tests/run-routine-refreshon.test.ts
+++ b/tests/run-routine-refreshon.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'bun:test';
+import { join } from 'path';
+
+/**
+ * #159 — `runRoutine()` must forward `.apijack/settings.json` `auth.refreshOn`
+ * to createCli(), the same way bin/apijack.ts does.
+ *
+ * The assertions live in run-routine-refreshon.isolated.ts, which mocks
+ * createCli to capture the options object. That mock cannot run in-process:
+ * bun evaluates every test file's top level before running any test, so a
+ * top-level `mock.module` poisons the shared registry for every later file
+ * that imports createCli (it broke 16 tests across run-routine.test.ts and
+ * custom-command-auth.test.ts). Running it as its own `bun test` process
+ * contains the mock. The filename deliberately omits `.test`, so the default
+ * suite does not discover it directly — only through this wrapper.
+ */
+
+const repoRoot = join(import.meta.dir, '..');
+
+describe('#159 runRoutine forwards settings.json auth.refreshOn (isolated)', () => {
+    test('isolated createCli-forwarding suite passes', async () => {
+        const proc = Bun.spawn(
+            [process.execPath, 'test', './tests/run-routine-refreshon.isolated.ts'],
+            { cwd: repoRoot, stdout: 'pipe', stderr: 'pipe' },
+        );
+        const stderr = await new Response(proc.stderr).text();
+        const exitCode = await proc.exited;
+
+        // bun test reports results on stderr; surface them when the child fails
+        // so the parent failure is diagnosable without re-running by hand.
+        expect(`${exitCode} ${exitCode === 0 ? '' : stderr}`.trim()).toBe('0');
+        expect(stderr).toContain('3 pass');
+        expect(stderr).toContain('0 fail');
+    }, 30_000);
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach, spyOn } from 'bun:test';
+import { describe, test, expect, afterEach, beforeEach, spyOn } from 'bun:test';
 import { loadProjectSettings } from '../src/settings';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -47,12 +47,15 @@ describe('loadProjectSettings()', () => {
     describe('validation', () => {
         let warnSpy: ReturnType<typeof spyOn>;
 
-        afterEach(() => {
-            warnSpy?.mockRestore();
+        beforeEach(() => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
         });
 
-        test('strips auth.refreshOn when it is a scalar and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        afterEach(() => {
+            warnSpy.mockRestore();
+        });
+
+        test('strips auth.refreshOn when it is a scalar and warns with the exact message', () => {
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: 401 } }));
 
@@ -60,12 +63,12 @@ describe('loadProjectSettings()', () => {
 
             expect(settings.auth?.refreshOn).toBeUndefined();
             expect(warnSpy).toHaveBeenCalledTimes(1);
-            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
-            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+            expect(warnSpy.mock.calls[0][0]).toBe(
+                "[apijack] .apijack/settings.json: 'auth.refreshOn' must be an array of numbers — ignoring",
+            );
         });
 
         test('strips auth.refreshOn when it contains a non-number and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: [401, 'x'] } }));
 
@@ -77,8 +80,19 @@ describe('loadProjectSettings()', () => {
             expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
         });
 
+        test('strips auth when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: 'nope' }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
         test('strips customCommands.defaults.requiresAuth when not a boolean and warns', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(
                 join(testRoot, 'settings.json'),
@@ -93,12 +107,36 @@ describe('loadProjectSettings()', () => {
             expect(warnSpy.mock.calls[0][0]).toContain('boolean');
         });
 
-        test('leaves a valid settings file unchanged with no warnings', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+        test('strips customCommands when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ customCommands: 'nope' }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
+        test('strips customCommands.defaults when it is not an object and warns', () => {
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ customCommands: { defaults: 'nope' } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands?.defaults).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands.defaults'");
+            expect(warnSpy.mock.calls[0][0]).toContain('an object');
+        });
+
+        test('leaves a valid settings file unchanged with no warnings, including unknown keys', () => {
             mkdirSync(testRoot, { recursive: true });
             const valid = {
                 customCommands: { defaults: { requiresAuth: true } },
                 auth: { refreshOn: [401] },
+                someFutureOption: 'preserved',
             };
             writeFileSync(join(testRoot, 'settings.json'), JSON.stringify(valid));
 
@@ -109,7 +147,6 @@ describe('loadProjectSettings()', () => {
         });
 
         test('returns {} and warns when top-level value is not an object (array)', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), '[1,2,3]');
 
@@ -121,7 +158,6 @@ describe('loadProjectSettings()', () => {
         });
 
         test('returns {} and warns when top-level value is not an object (string)', () => {
-            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
             mkdirSync(testRoot, { recursive: true });
             writeFileSync(join(testRoot, 'settings.json'), '"hello"');
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, afterEach } from 'bun:test';
+import { describe, test, expect, afterEach, spyOn } from 'bun:test';
 import { loadProjectSettings } from '../src/settings';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
@@ -42,5 +42,94 @@ describe('loadProjectSettings()', () => {
         mkdirSync(testRoot, { recursive: true });
         writeFileSync(join(testRoot, 'settings.json'), '{ not json');
         expect(loadProjectSettings(testRoot)).toEqual({});
+    });
+
+    describe('validation', () => {
+        let warnSpy: ReturnType<typeof spyOn>;
+
+        afterEach(() => {
+            warnSpy?.mockRestore();
+        });
+
+        test('strips auth.refreshOn when it is a scalar and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: 401 } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth?.refreshOn).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
+            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+        });
+
+        test('strips auth.refreshOn when it contains a non-number and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify({ auth: { refreshOn: [401, 'x'] } }));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.auth?.refreshOn).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'auth.refreshOn'");
+            expect(warnSpy.mock.calls[0][0]).toContain('array of numbers');
+        });
+
+        test('strips customCommands.defaults.requiresAuth when not a boolean and warns', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(
+                join(testRoot, 'settings.json'),
+                JSON.stringify({ customCommands: { defaults: { requiresAuth: 'yes' } } }),
+            );
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings.customCommands?.defaults?.requiresAuth).toBeUndefined();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain("'customCommands.defaults.requiresAuth'");
+            expect(warnSpy.mock.calls[0][0]).toContain('boolean');
+        });
+
+        test('leaves a valid settings file unchanged with no warnings', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            const valid = {
+                customCommands: { defaults: { requiresAuth: true } },
+                auth: { refreshOn: [401] },
+            };
+            writeFileSync(join(testRoot, 'settings.json'), JSON.stringify(valid));
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual(valid);
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        test('returns {} and warns when top-level value is not an object (array)', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), '[1,2,3]');
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual({});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain('settings must be a JSON object');
+        });
+
+        test('returns {} and warns when top-level value is not an object (string)', () => {
+            warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+            mkdirSync(testRoot, { recursive: true });
+            writeFileSync(join(testRoot, 'settings.json'), '"hello"');
+
+            const settings = loadProjectSettings(testRoot);
+
+            expect(settings).toEqual({});
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toContain('settings must be a JSON object');
+        });
     });
 });


### PR DESCRIPTION
Closes #138
Closes #140
Closes #142
Closes #144
Closes #146
Closes #150
Closes #159
Closes #161

`.apijack/settings.json` is now validated instead of trusted, and its `auth.refreshOn` finally reaches routine runs as well as the CLI. The rest is diagnostics and repo tooling — no breaking changes.

## ✨ Features

- **`--bare-refs` mode for `extract-closing-refs.sh`** (#163) — emits closing refs as plain numbers for callers that don't want the `Closes #N` framing.

## 🐛 Fixes

- **`runRoutine()` honors `settings.json` `auth.refreshOn`** (#165) — the setting was documented and worked from the CLI, but was silently dropped on the programmatic path, so Playwright/Vitest fixtures never got stale-session refresh.
- **`.apijack/settings.json` values are validated, not cast** (#158) — a wrong-typed `auth.refreshOn` or `customCommands.defaults` now warns and is ignored instead of flowing through as a bad value.
- **Alias guard follows actual registration** (#153) — the pre-codegen guard derived its state from a condition that could diverge from whether generated commands really registered, so a partial codegen left aliases mis-validated.
- **Injected `onChallenge` is attributed in the endpoint-less `sessionAuth` warning** (#160) — the diagnostic now names `.apijack/auth.ts` as the source rather than listing a key the user never wrote.
- **Closing-ref scanner reads a setext underline as a heading** (#156) — an underline was pushing a list container and hiding the indented code beneath it.

## 🧹 Internal

- `notify-shipped-issues.sh` hardened before its first real run (fence-aware `#N` scan, arg validation, pagination rationale), and the shellcheck gate widened to `.claude-jobs/` and `tests/` scripts.

---

Shipped via `scripts/ship.sh`.
