### PR TITLE
docs: stop claiming auth is auto-detected from the OpenAPI spec (#170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bun install -g @apijack/core
 ```
 
 ```bash
-apijack setup              # Configure URL + credentials (auth auto-detected)
+apijack setup              # Configure URL + credentials (Basic auth by default)
 apijack generate            # Pull OpenAPI spec, generate types/client/commands
 apijack --help              # See all generated commands
 ```

--- a/skills/setup-api/SKILL.md
+++ b/skills/setup-api/SKILL.md
@@ -10,7 +10,7 @@ Connect apijack to any API with an OpenAPI spec to generate a full CLI.
 ## Quick Setup
 
 ```bash
-apijack setup              # Interactive: URL, credentials, auth detection
+apijack setup              # Interactive: URL + credentials (Basic auth by default)
 apijack generate           # Pull spec, generate types/client/commands
 apijack --help             # See generated commands
 ```
@@ -20,8 +20,9 @@ apijack --help             # See generated commands
 `apijack setup` prompts for:
 - **Environment name** (e.g. "dev", "staging")
 - **API base URL** (e.g. "http://localhost:8080")
-- **Credentials** (username + password, bearer token, or API key)
-- **Auth type** is auto-detected from the OpenAPI security schemes
+- **Credentials** (username + password)
+
+Auth is Basic by default and is **not** read from the OpenAPI spec's `securitySchemes`. To use another strategy, add a `.apijack/auth.ts` exporting an `AuthStrategy`, or set `authType` (`bearer` or `apiKey`, plus `authHeader` / `apiKey` for the latter) on the environment entry in `config.json`.
 
 Credentials are stored in `~/.apijack/config.json` for dev URLs. Production URLs require environment variables:
 


### PR DESCRIPTION
Closes #170

## Summary

`wiki/Authentication-Strategies.md` documented an "Auto-Detection from OpenAPI Spec" feature — `generate` reading `components.securitySchemes` and picking a strategy — that has never been wired up. `src/auth-detector.ts` was only ever imported by its own test, was never exported from `src/index.ts`, and `bin/apijack.ts` sets `BasicAuthStrategy` unconditionally unless `.apijack/auth.ts` or an `authType` in the env config displaces it. `wiki/OpenAPI-Compatibility.md:114` correctly stated the opposite, so the two pages contradicted each other and sent at least one user down a wrong diagnostic path (inspecting the spec's security section for 401s that had nothing to do with it).

Per triage (option A, agreed with the maintainer): make the docs match the code and delete the dead code. Spec-driven / OAuth auth, if wanted, gets designed deliberately rather than inherited from a detector that predates it.

## What changes

### Dead code — already on `dev` (not in this diff)
- `src/auth-detector.ts` (`detectAuthFromSpec` / `fetchSecuritySchemes`) and `tests/auth-detector.test.ts` were deleted in d118990. That commit is the Stripe e2e timeout change from another session in the same checkout; it swept up the staged deletion for this issue and was pushed straight to `dev`. Rather than rewrite shared history, this PR is based on it and carries the remaining docs. Reviewer: verify with `git show --stat d118990` and `grep -rn "auth-detector\|detectAuthFromSpec\|fetchSecuritySchemes" src bin tests` (empty).

### This PR
- `README.md:44` — `apijack setup` comment said "(auth auto-detected)"; now "(Basic auth by default)". `setup` (`src/commands/setup/setup.ts:64-67`) prompts only for env name / URL / username / password and never writes `authType`.
- `skills/setup-api/SKILL.md` — shipped Claude Code skill (in `package.json` `files`) made the same claim twice ("auth detection", "Auth type is auto-detected from the OpenAPI security schemes") and listed bearer/API-key as setup prompts. Now: credentials are username + password; auth is Basic by default, not read from `securitySchemes`; other strategies via `.apijack/auth.ts` or `authType` (`bearer` / `apiKey` + `authHeader` / `apiKey`) in `config.json`.

### Wiki (pushed directly to `apijack.wiki`, not part of this diff)
- `Authentication-Strategies.md` — the "Auto-Detection from OpenAPI Spec" section (mapping table, priority order, `null` case) is replaced by "The OpenAPI Spec Does Not Configure Auth": `securitySchemes` is not read; strategy is `createCli({ auth })` for custom bins, and `.apijack/auth.ts` → env `authType` → `BasicAuthStrategy` for the shared binary (matches `bin/apijack.ts:86-120` and `src/run-routine.ts:107-135`). Cross-links to OpenAPI-Compatibility, Project-Mode, Building-a-CLI. Wiki commit `a20bc7c`.

Historical design docs under `docs/superpowers/specs/` and `docs/superpowers/plans/` still mention the detector; they are dated records and were left alone on purpose.

## Acceptance criteria

- [ ] `src/auth-detector.ts` and `tests/auth-detector.test.ts` are absent on this branch; `grep -rn "auth-detector\|detectAuthFromSpec\|fetchSecuritySchemes" src bin tests` is empty
- [ ] `bun test` and `bun run lint` pass with no new failures/errors
- [ ] `README.md` and `skills/setup-api/SKILL.md` no longer claim auth is auto-detected from the spec, and describe only what `setup` actually prompts for
- [ ] `wiki/Authentication-Strategies.md` no longer claims `securitySchemes` is read and agrees with `wiki/OpenAPI-Compatibility.md:114`
- [ ] No runtime behavior change (nothing imported the deleted module)

## Test plan

- [x] `bun test` — 1072 pass / 0 fail
- [x] `bun run lint` — 0 errors (118 pre-existing warnings)
- [x] `grep -rn "auth-detector\|detectAuthFromSpec\|fetchSecuritySchemes" src bin tests` → no matches
- [x] Wiki/README/skill claims fact-checked by a subagent against `bin/apijack.ts`, `src/run-routine.ts`, `src/types.ts:30`, `src/commands/setup/setup.ts`
